### PR TITLE
make insertOne tests pass against local

### DIFF
--- a/src/client/httpClient.ts
+++ b/src/client/httpClient.ts
@@ -16,6 +16,7 @@ import http from 'http';
 import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
 import { logger, setLevel } from '@/src/logger';
 import _ from 'lodash';
+import { inspect } from 'util';
 
 const REQUESTED_WITH = 'astra-mongoose 0.1.0';
 const DEFAULT_AUTH_HEADER = 'X-Cassandra-Token';
@@ -143,7 +144,11 @@ export class HTTPClient {
         errors: response.data.errors
       };
     } catch (e: any) {
-       logger.error(e);
+       logger.error(requestInfo.url + ': ' + e.message);
+       logger.error('Data: ' + inspect(requestInfo.data));
+       if (e?.response?.data) {
+         logger.error('Response Data: ' + inspect(e.response.data));
+       }
        return {
         errors: [
           {

--- a/src/collections/collection.ts
+++ b/src/collections/collection.ts
@@ -65,13 +65,12 @@ export class Collection {
    * @param cb
    * @returns Promise
    */
-  async insertOne(doc: Record<string, any>, options?: any, cb?: DocumentCallback) {
+  async insertOne(document: Record<string, any>, options?: any, cb?: DocumentCallback) {
     ({ options, cb } = setOptionsAndCb(options, cb));
     return executeOperation(async (): Promise<InsertOneResult> => {
       let command = {
         insertOne : {
-            doc : doc,
-            options: options
+            document
         }
       };
       const resp = await this.httpClient.executeCommand(command);

--- a/tests/collections/collection.test.ts
+++ b/tests/collections/collection.test.ts
@@ -31,7 +31,9 @@ for (const testClient in testClients) {
       if (!astraClient) {
         return this.skip();
       }
+
       db = astraClient.db();
+      await db.createCollection(TEST_COLLECTION_NAME);
       collection = db.collection(TEST_COLLECTION_NAME);
     });
 


### PR DESCRIPTION
Couple of changes I needed to make to make `npm test -- -g 'should insertOne document'` pass locally.

1. Auto create collection
2. doc -> document