### PR TITLE
Some DX and testing quick fixes

### DIFF
--- a/src/client/httpClient.ts
+++ b/src/client/httpClient.ts
@@ -210,22 +210,25 @@ export class HTTPClient {
       method: HTTP_METHODS.post,
       data
     });
-    handleIfErrorResponse(response);
+    handleIfErrorResponse(response, data);
     return response;
   }
 }
 
 export class StargateServerError extends Error {
-  errors: any[]
-  constructor(response: any) {
-    super(JSON.stringify(response.errors));
+  errors: any[];
+  command: Record<string, any>;
+  constructor(response: any, command: Record<string, any>) {
+    const commandName = Object.keys(command)[0] || 'unknown';
+    super(`Command "${commandName}" failed with the following errors: ${JSON.stringify(response.errors)}`);
     this.errors = response.errors;
+    this.command = command;
   }
 }
 
-const handleIfErrorResponse = (response: any) => {
+const handleIfErrorResponse = (response: any, data: Record<string, any>) => {
   if(response.errors && response.errors.length > 0){
-    throw new StargateServerError(response);
+    throw new StargateServerError(response, data);
   }
 }
 

--- a/src/collections/collection.ts
+++ b/src/collections/collection.ts
@@ -186,6 +186,10 @@ export class Collection {
           options: options
         }
       };
+      // Avoid empty projections
+      if (projection == null || Object.keys(projection).length === 0) {
+        delete command.findOne.projection;
+      }
       const resp = await this.httpClient.executeCommand(command);
       return resp.data.docs[0];
     }, cb);

--- a/src/collections/collection.ts
+++ b/src/collections/collection.ts
@@ -86,7 +86,7 @@ export class Collection {
     return executeOperation(async (): Promise<InsertManyResult<any>> => {
       const command = {
         insertMany : {
-            docs : docs,
+            documents : docs,
             options: options
         }
       };

--- a/src/collections/cursor.ts
+++ b/src/collections/cursor.ts
@@ -26,7 +26,6 @@ interface ResultCallback {
 export class FindCursor {
   collection: Collection;
   filter: any;
-  projection: any;
   options: any;
   documents: Record<string, any>[] = [];
   status: string = 'uninitialized';
@@ -45,10 +44,9 @@ export class FindCursor {
    * @param filter
    * @param options
    */
-  constructor(collection: Collection, filter: any, projection?: any, options?: any) {
+  constructor(collection: Collection, filter: any, options?: any) {
     this.collection = collection;
     this.filter = filter;
-    this.projection = projection;
     this.options = options;
     this.limit = options?.limit || Infinity;
     this.status = 'initialized';
@@ -149,8 +147,9 @@ export class FindCursor {
         filter: this.filter
       }
     };
-    if (this.projection && Object.keys(this.projection).length > 0) {
-      command.find.projection = this.projection;
+    // Workaround for Automattic/mongoose#13050
+    if (this.options && this.options.projection && Object.keys(this.options.projection).length > 0) {
+      command.find.projection = this.options.projection;
     }
     const options = {} as QueryOptions;
     if (this.pageSize != DEFAULT_PAGE_SIZE) { 

--- a/src/collections/cursor.ts
+++ b/src/collections/cursor.ts
@@ -146,10 +146,12 @@ export class FindCursor {
       }
     } = {
       find: {
-        filter: this.filter,
-        projection: this.projection,
+        filter: this.filter
       }
     };
+    if (this.projection && Object.keys(this.projection).length > 0) {
+      command.find.projection = this.projection;
+    }
     const options = {} as QueryOptions;
     if (this.pageSize != DEFAULT_PAGE_SIZE) { 
       options.pageSize = pageSize;

--- a/src/collections/db.ts
+++ b/src/collections/db.ts
@@ -78,7 +78,12 @@ export class Db {
    * @returns Promise
    */
   async dropCollection(collectionName: string, cb?: CollectionCallback) {
-    throw new Error('Not Implemented');
+    const command = {
+      deleteCollection: {
+        name: collectionName
+      }
+    };
+    return await this.httpClient.executeCommand(command);
   }
 
   // NOOPS and unimplemented

--- a/src/collections/utils.ts
+++ b/src/collections/utils.ts
@@ -208,5 +208,6 @@ export const getNestedPathRawValue = (doc: any, key: string) => {
 export type QueryOptions = {
   pageSize?: number,
   pageState?: string|null,
-  limit?: number
+  limit?: number,
+  projection?: any
 }

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -29,12 +29,12 @@ export class Collection extends MongooseCollection {
     return this.conn.db.collection(this.name);
   }
 
-  find(query: any, projection?: any, options?: any, cb?: any) {
-    return this.collection.find(query, projection, options, cb);
+  find(query: any, options?: any, cb?: any) {
+    return this.collection.find(query, options, cb);
   }
 
-  findOne(query: any, projection?: any, options?: any, cb?: any) {
-    return this.collection.findOne(query, projection, options, cb);
+  findOne(query: any, options?: any, cb?: any) {
+    return this.collection.findOne(query, options, cb);
   }
 
   insertOne(doc: any, options?: any, cb?: any) {

--- a/tests/collections/collection.test.ts
+++ b/tests/collections/collection.test.ts
@@ -33,17 +33,16 @@ for (const testClient in testClients) {
       }
 
       db = astraClient.db();
+      await db.dropCollection(TEST_COLLECTION_NAME);
+    });
+
+    beforeEach(async function() {
       await db.createCollection(TEST_COLLECTION_NAME);
       collection = db.collection(TEST_COLLECTION_NAME);
     });
 
-    beforeEach(async function() {
-      await collection?.deleteMany({});
-    });
-
-    after(() => {
-      // run drop collection async to save time
-      db?.dropCollection(TEST_COLLECTION_NAME);
+    afterEach(async function() {
+      await db.dropCollection(TEST_COLLECTION_NAME);
     });
 
     describe('Collection initialization', () => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

1. Made `StargateServerError` message include the command that failed, and store the command document that was sent
2. Fixed `insertMany()`
3. Implemented `dropCollection()`
4. Used `dropCollection()` to clean data in between tests. I was getting a lot of strange test failures locally because data wasn't being cleared.

Also @kathirsvn , what do you think about making `deleteMany()` throw an unimplemented error for now, until the server side implements it? It is a little error prone that `deleteMany()` is a no-op right now, leads to hard-to-debug test failures.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)