### PR TITLE
avoid hardcoding localhost in tests

### DIFF
--- a/tests/collections/client.test.ts
+++ b/tests/collections/client.test.ts
@@ -78,7 +78,7 @@ describe('StargateMongoose - collections.Client', () => {
       const BASE_API_PATH_TO_CHECK = "baseAPIPath1";
       const LOG_LEVEL_TO_CHECK = "info";
       const AUTH_HEADER_NAME_TO_CHECK = "x-token";
-      const client = await Client.connect("http://localhost:8080/" + BASE_API_PATH_TO_CHECK + "/testks1", {
+      const client = await Client.connect(parseUri(astraUri).baseUrl + "/" + BASE_API_PATH_TO_CHECK + "/testks1", {
           applicationToken: AUTH_TOKEN_TO_CHECK,
           keyspaceName: KEYSPACE_TO_CHECK,
           logLevel: LOG_LEVEL_TO_CHECK,
@@ -100,7 +100,7 @@ describe('StargateMongoose - collections.Client', () => {
       const BASE_API_PATH_TO_CHECK = "apis/baseAPIPath1";
       const LOG_LEVEL_TO_CHECK = "info";
       const AUTH_HEADER_NAME_TO_CHECK = "x-token";
-      const client = await Client.connect("http://localhost:8080/" + BASE_API_PATH_TO_CHECK + "/testks1", {
+      const client = await Client.connect(parseUri(astraUri).baseUrl + "/" + BASE_API_PATH_TO_CHECK + "/testks1", {
           applicationToken: AUTH_TOKEN_TO_CHECK,
           keyspaceName: KEYSPACE_TO_CHECK,
           logLevel: LOG_LEVEL_TO_CHECK,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Tests were failing locally on my machine because my .env uses `127.0.0.1` instead of `localhost`. With this change, either works. The tests now pass on my machine :+1:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)