### PR TITLE
Kathirsvn/repo fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,8 @@
-#JSON API URL. 'testks1' is the Namespace name for test. This can be provided either as last part of the URL path or as a connection option called 'keyspaceName'
+#JSON API URL. 'testks1' is the Namespace name for test.
 JSON_API_URI=http://localhost:8080/v1/testks1
-#Stargate coordinator URL for authentication purposes
+#Stargate coordinator URL for authentication purposes.
 STARGATE_AUTH_URL=http://localhost:8081/v1/auth
-#Stargate Authentication username
+#Stargate Authentication username.
 STARGATE_USERNAME=cassandra
-#Stargate Authentication password
+#Stargate Authentication password.
 STARGATE_PASSWORD=cassandra

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -14,8 +14,6 @@ jobs:
       STARGATE_AUTH_URL: http://localhost:8081/v1/auth
       STARGATE_USERNAME: cassandra
       STARGATE_PASSWORD: cassandra
-      SGTAG: v2.0.9
-      JSONTAG: v1.0.0-ALPHA-2
     steps:      
       - name: disable and stop mono-xsp4.service
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,8 +12,6 @@ jobs:
       STARGATE_AUTH_URL: http://localhost:8081/v1/auth
       STARGATE_USERNAME: cassandra
       STARGATE_PASSWORD: cassandra
-      SGTAG: v2.0.9
-      JSONTAG: v1.0.0-ALPHA-2
     steps:      
       - name: disable and stop mono-xsp4.service
         run: |

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ const driver = stargate_mongoose.driver;
 mongoose.setDriver(driver);
 
 //Set up mongoose
-// JSON API URL
-const JSON_API_URI="http://localhost:8080/v1";
+// JSON API URL & inventory is the Name of the Namespace
+const JSON_API_URI="http://localhost:8080/v1/inventory";
 //Stargate Coordinator Authentication URL
 const AUTH_URL="http://localhost:8081/v1/auth";
 // Define Product schema
@@ -45,9 +45,7 @@ mongoose.connect(JSON_API_URI, {
                     "username":"cassandra",
                     //Default password
                     "password":"cassandra",
-                    "authUrl": AUTH_URL,
-                    //Name of the Namespace
-                    "keyspaceName": "inventory",
+                    "authUrl": AUTH_URL                    
                 });
 //Wait for collections to get created
 Object.values(mongoose.connection.models).map(Model => Model.init());
@@ -61,6 +59,7 @@ app.get('/addproduct', (req, res) => {
   const newProduct = new Product(
     { name:"product"+Math.floor(Math.random() * 99 + 1), 
       price: "" + Math.floor(Math.random() * 900 + 100) });
+  newProduct.save();
   res.send('Added a product!');
 });
 //Get products API
@@ -68,11 +67,12 @@ app.get('/getproducts', (req, res) => {
   Product.find()
     .then(products => res.json(products));
 });
+
 //Start server
 app.listen(PORT, HOST, () => {
   console.log(`Running on http://${HOST}:${PORT}` 
               + '\nNavigate to'
-              + '\n\thttp://localhost:'+PORT+'/addproducts'
+              + '\n\thttp://localhost:'+PORT+'/addproduct'
               + '\n\thttp://localhost:'+PORT+'/getproducts');
 });
 ```

--- a/api-compatibility.versions
+++ b/api-compatibility.versions
@@ -1,2 +1,2 @@
-stargate_version=v2.0.8
+stargate_version=v2.0.9
 json_api_version=v1.0.0-ALPHA-2

--- a/bin/start_json_api.sh
+++ b/bin/start_json_api.sh
@@ -29,7 +29,7 @@ while getopts "qr:t:j:" opt; do
   esac
 done
 
-source api-compatibility.versions
+. ./api-compatibility.versions
 SGTAG=$stargate_version
 JSONTAG=$json_api_version
 

--- a/bin/start_json_api.sh
+++ b/bin/start_json_api.sh
@@ -29,6 +29,10 @@ while getopts "qr:t:j:" opt; do
   esac
 done
 
+source api-compatibility.versions
+SGTAG=$stargate_version
+JSONTAG=$json_api_version
+
 if [ -z "$SGTAG" ]
 then
   echo "Missing stargate version (option -t). For example -t v2.0.8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stargate-mongoose",
-  "version": "0.2.0-ALPHA",
+  "version": "0.2.0-ALPHA-1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stargate-mongoose",
-      "version": "0.2.0-ALPHA",
+      "version": "0.2.0-ALPHA-1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stargate-mongoose",
-  "version": "0.2.0-ALPHA",
+  "version": "0.2.0-ALPHA-1",
   "description": "Stargate's NodeJS Mongoose compatability client",
   "contributors": [
     "CRW (http://barnyrubble.tumblr.com/)",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "Aaron Morton (https://github.com/amorton)",
     "Kathiresan Selvaraj (https://github.com/kathirsvn)"
   ],
-  "homepage": "https://github.com/riptano/stargate-mongoose",
+  "homepage": "https://github.com/stargate/stargate-mongoose",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "mocha": {
@@ -30,7 +30,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/riptano/stargate-mongoose.git"
+    "url": "git+https://github.com/stargate/stargate-mongoose.git"
   },
   "scripts": {
     "test": "nyc ts-mocha --paths -p tsconfig.json tests/**/*.test.ts",
@@ -39,7 +39,7 @@
     "build:docs": "jsdoc2md -t APIReference.hbs --files src/**/*.ts --configure ./jsdoc2md.json > APIReference.md"
   },
   "bugs": {
-    "url": "https://github.com/riptano/stargate-mongoose/issues"
+    "url": "https://github.com/stargate/stargate-mongoose/issues"
   },
   "devDependencies": {
     "@babel/cli": "^7.17.10",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,22 @@
     "Aaron Morton (https://github.com/amorton)",
     "Kathiresan Selvaraj (https://github.com/kathirsvn)"
   ],
+  "keywords": [
+    "cassandra",
+    "dse",
+    "document",
+    "model",
+    "schema",
+    "database",
+    "odm",
+    "data",
+    "datastore",
+    "query",
+    "nosql",
+    "orm",
+    "db",
+    "jsonapi"
+  ],
   "homepage": "https://github.com/stargate/stargate-mongoose",
   "license": "Apache-2.0",
   "main": "dist/index.js",

--- a/src/collections/client.ts
+++ b/src/collections/client.ts
@@ -21,7 +21,6 @@ import { logger } from '@/src/logger';
 export interface ClientOptions {
   applicationToken?: string;
   baseApiPath?: string;
-  keyspaceName?: string;
   logLevel?: string;
   authHeaderName?: string;
   createNamespaceOnConnect?: boolean;
@@ -45,8 +44,8 @@ export class Client {
    *            Astra: https://${databaseId}-${region}.apps.astra.datastax.com
    * @param options provide the Astra applicationToken here along with the keyspace name (optional)
    */
-  constructor(baseUrl: string, options: ClientOptions) {
-    this.keyspaceName = options?.keyspaceName;
+  constructor(baseUrl: string, keyspaceName: string, options: ClientOptions) {
+    this.keyspaceName = keyspaceName;
     this.createNamespaceOnConnect = options?.createNamespaceOnConnect ?? true;
 
     this.httpClient = new HTTPClient({
@@ -70,10 +69,9 @@ export class Client {
    */
   static async connect(uri: string, options?: ClientOptions | null): Promise<Client> {
     const parsedUri = parseUri(uri);
-    const client = new Client(parsedUri.baseUrl, {
+    const client = new Client(parsedUri.baseUrl, parsedUri.keyspaceName, {
       applicationToken: options?.applicationToken ? options?.applicationToken : parsedUri.applicationToken,
         baseApiPath: options?.baseApiPath ? options?.baseApiPath : parsedUri.baseApiPath,
-        keyspaceName: options?.keyspaceName ? options?.keyspaceName : parsedUri.keyspaceName,
         logLevel: options?.logLevel,
         authHeaderName: options?.authHeaderName,
         createNamespaceOnConnect: options?.createNamespaceOnConnect ?? true,

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
 export const LIB_NAME = "stargate-mongoose";
-export const LIB_VERSION = "0.2.0-ALPHA";
+export const LIB_VERSION = "0.2.0-ALPHA-1";

--- a/tests/collections/client.test.ts
+++ b/tests/collections/client.test.ts
@@ -51,13 +51,11 @@ describe('StargateMongoose - collections.Client', () => {
 
     it('should initialize a Client connection with a uri using connect with overrides', async () => {
       const AUTH_TOKEN_TO_CHECK = "123";
-      const KEYSPACE_TO_CHECK = "keyspace1";
       const BASE_API_PATH_TO_CHECK = "baseAPIPath1";
       const LOG_LEVEL_TO_CHECK = "info";
       const AUTH_HEADER_NAME_TO_CHECK = "x-token";
       const client = await Client.connect(astraUri, {
           applicationToken: AUTH_TOKEN_TO_CHECK,
-          keyspaceName: KEYSPACE_TO_CHECK,
           baseApiPath: BASE_API_PATH_TO_CHECK,
           logLevel: LOG_LEVEL_TO_CHECK,
           authHeaderName: AUTH_HEADER_NAME_TO_CHECK,
@@ -66,7 +64,7 @@ describe('StargateMongoose - collections.Client', () => {
         assert.ok(client);
         assert.ok(client.httpClient);
         assert.strictEqual(client.httpClient.applicationToken, AUTH_TOKEN_TO_CHECK);
-        assert.strictEqual(client.keyspaceName, KEYSPACE_TO_CHECK);
+        assert.strictEqual(client.keyspaceName, parseUri(astraUri).keyspaceName);
         assert.strictEqual(client.httpClient.baseUrl, parseUri(astraUri).baseUrl + "/" + BASE_API_PATH_TO_CHECK);          
         assert.strictEqual(client.httpClient.authHeaderName, AUTH_HEADER_NAME_TO_CHECK);
         const db = client.db();
@@ -74,13 +72,12 @@ describe('StargateMongoose - collections.Client', () => {
     });
     it('should parse baseApiPath from URL when possible', async () => {
       const AUTH_TOKEN_TO_CHECK = "123";
-      const KEYSPACE_TO_CHECK = "keyspace1";
+      const KEYSPACE_TO_CHECK = "testks1";
       const BASE_API_PATH_TO_CHECK = "baseAPIPath1";
       const LOG_LEVEL_TO_CHECK = "info";
       const AUTH_HEADER_NAME_TO_CHECK = "x-token";
-      const client = await Client.connect(parseUri(astraUri).baseUrl + "/" + BASE_API_PATH_TO_CHECK + "/testks1", {
+      const client = await Client.connect(parseUri(astraUri).baseUrl + "/" + BASE_API_PATH_TO_CHECK + "/" + KEYSPACE_TO_CHECK, {
           applicationToken: AUTH_TOKEN_TO_CHECK,
-          keyspaceName: KEYSPACE_TO_CHECK,
           logLevel: LOG_LEVEL_TO_CHECK,
           authHeaderName: AUTH_HEADER_NAME_TO_CHECK,
           createNamespaceOnConnect: false
@@ -96,13 +93,12 @@ describe('StargateMongoose - collections.Client', () => {
     });
     it('should parse baseApiPath from URL when possible (multiple path elements)', async () => {
       const AUTH_TOKEN_TO_CHECK = "123";
-      const KEYSPACE_TO_CHECK = "keyspace1";
+      const KEYSPACE_TO_CHECK = "testks1";
       const BASE_API_PATH_TO_CHECK = "apis/baseAPIPath1";
       const LOG_LEVEL_TO_CHECK = "info";
       const AUTH_HEADER_NAME_TO_CHECK = "x-token";
-      const client = await Client.connect(parseUri(astraUri).baseUrl + "/" + BASE_API_PATH_TO_CHECK + "/testks1", {
+      const client = await Client.connect(parseUri(astraUri).baseUrl + "/" + BASE_API_PATH_TO_CHECK + "/" + KEYSPACE_TO_CHECK, {
           applicationToken: AUTH_TOKEN_TO_CHECK,
-          keyspaceName: KEYSPACE_TO_CHECK,
           logLevel: LOG_LEVEL_TO_CHECK,
           authHeaderName: AUTH_HEADER_NAME_TO_CHECK,
           createNamespaceOnConnect: false
@@ -120,14 +116,13 @@ describe('StargateMongoose - collections.Client', () => {
       //only the last occurrence of the keyspace name in the url path must be treated as keyspace
       //other parts of it should be simply be treated as baseApiPath
       const AUTH_TOKEN_TO_CHECK = "123";
-      const KEYSPACE_TO_CHECK = "keyspace1";
+      const KEYSPACE_TO_CHECK = "testks1";
       const BASE_API_PATH_TO_CHECK = "baseAPIPath1";
       const LOG_LEVEL_TO_CHECK = "info";
       const AUTH_HEADER_NAME_TO_CHECK = "x-token";
       const baseUrl = 'http://localhost:8080';
-      const client = await Client.connect(baseUrl + "/testks1/" + BASE_API_PATH_TO_CHECK + "/testks1", {
+      const client = await Client.connect(baseUrl + "/testks1/" + BASE_API_PATH_TO_CHECK + "/" + KEYSPACE_TO_CHECK, {
           applicationToken: AUTH_TOKEN_TO_CHECK,
-          keyspaceName: KEYSPACE_TO_CHECK,
           logLevel: LOG_LEVEL_TO_CHECK,
           authHeaderName: AUTH_HEADER_NAME_TO_CHECK,
           createNamespaceOnConnect: false
@@ -143,14 +138,13 @@ describe('StargateMongoose - collections.Client', () => {
     });
     it('should honor the baseApiPath from options when provided', async () => {
       const AUTH_TOKEN_TO_CHECK = "123";
-      const KEYSPACE_TO_CHECK = "keyspace1";
+      const KEYSPACE_TO_CHECK = "testks1";
       const BASE_API_PATH_TO_CHECK = "baseAPIPath1";
       const LOG_LEVEL_TO_CHECK = "info";
       const AUTH_HEADER_NAME_TO_CHECK = "x-token";
       const baseUrl = 'http://localhost:8080';
-      const client = await Client.connect(baseUrl + "/" + BASE_API_PATH_TO_CHECK + "/testks1", {
+      const client = await Client.connect(baseUrl + "/" + BASE_API_PATH_TO_CHECK + "/" + KEYSPACE_TO_CHECK, {
           applicationToken: AUTH_TOKEN_TO_CHECK,
-          keyspaceName: KEYSPACE_TO_CHECK,
           baseApiPath: "baseAPIPath2",
           logLevel: LOG_LEVEL_TO_CHECK,
           authHeaderName: AUTH_HEADER_NAME_TO_CHECK,
@@ -167,14 +161,13 @@ describe('StargateMongoose - collections.Client', () => {
     });
     it('should handle empty baseApiPath', async () => {
       const AUTH_TOKEN_TO_CHECK = "123";
-      const KEYSPACE_TO_CHECK = "keyspace1";
+      const KEYSPACE_TO_CHECK = "testks1";
       const BASE_API_PATH_TO_CHECK = "baseAPIPath1";
       const LOG_LEVEL_TO_CHECK = "info";
       const AUTH_HEADER_NAME_TO_CHECK = "x-token";
       const baseUrl = 'http://localhost:8080';
-      const client = await Client.connect(baseUrl + "/testks1", {
+      const client = await Client.connect(baseUrl + "/" + KEYSPACE_TO_CHECK, {
           applicationToken: AUTH_TOKEN_TO_CHECK,
-          keyspaceName: KEYSPACE_TO_CHECK,
           logLevel: LOG_LEVEL_TO_CHECK,
           authHeaderName: AUTH_HEADER_NAME_TO_CHECK,
           createNamespaceOnConnect: false
@@ -189,35 +182,33 @@ describe('StargateMongoose - collections.Client', () => {
         assert.ok(db);
     });
     it('should initialize a Client connection with a uri using the constructor', () => {
-      const client = new Client(baseUrl  , {      
+      const client = new Client(baseUrl, 'keyspace1'  , {      
         applicationToken: "123"
       });
       assert.ok(client);
     });
     it('should not initialize a Client connection with a uri using the constructor with no options', () => {
       try {
-        const client = new Client(baseUrl);
+        const client = new Client(baseUrl, 'keyspace1');
         assert.ok(client);
       } catch (e) {
         assert.ok(e);
       }
     });
     it('should initialize a Client connection with a uri using the constructor and a keyspace', () => {
-      const client = new Client(baseUrl, {
-        applicationToken: "123",
-        keyspaceName: "keyspace1"
+      const client = new Client(baseUrl, 'keyspace1', {
+        applicationToken: "123"
       });
       assert.ok(client.keyspaceName);
     });
     it('should initialize a Client connection with a uri using the constructor and a blank keyspace', () => {
-      const client = new Client(baseUrl, {
-        applicationToken: '123',
-        keyspaceName: ''
+      const client = new Client(baseUrl, '', {
+        applicationToken: '123'
       });
       assert.strictEqual(client.keyspaceName, '');
     });
     it('should connect after setting up the client with a constructor', async () => {
-      const client = new Client(baseUrl, {
+      const client = new Client(baseUrl, 'keyspace1', {
         applicationToken: '123',
         createNamespaceOnConnect: false
       });
@@ -227,7 +218,7 @@ describe('StargateMongoose - collections.Client', () => {
     });
     it('should set the auth header name as set in the options', async () => {
       const TEST_HEADER_NAME = 'test-header';
-      const client = new Client(baseUrl, {
+      const client = new Client(baseUrl, 'keyspace1', {
         applicationToken: '123',
         authHeaderName: TEST_HEADER_NAME,
         createNamespaceOnConnect: false
@@ -237,7 +228,7 @@ describe('StargateMongoose - collections.Client', () => {
       assert.strictEqual(connectedClient.httpClient.authHeaderName, TEST_HEADER_NAME);      
     });
     it('should create client when token is not present, but auth details are present', async () => {
-      const client = new Client(baseUrl, {        
+      const client = new Client(baseUrl, 'keyspace1', {        
         username: "user1",
         password: "pass1",
       });
@@ -246,7 +237,7 @@ describe('StargateMongoose - collections.Client', () => {
     });
     it('should not create client when token is not present & one/more of auth details are missing', async () => {
       try {
-        const client = new Client(baseUrl, {        
+        const client = new Client(baseUrl, 'keyspace1', {        
           username: "user1"          
         });
         const connectedClient = client.connect();
@@ -257,7 +248,7 @@ describe('StargateMongoose - collections.Client', () => {
     });
     it('should set the auth url based on options when provided', async () => {
       const TEST_AUTH_URL = 'authurl1';
-      const client = new Client(baseUrl, {        
+      const client = new Client(baseUrl, 'keyspace1', {        
         username: "user1",
         password: "pass1",
         authUrl: TEST_AUTH_URL,
@@ -268,7 +259,7 @@ describe('StargateMongoose - collections.Client', () => {
       assert.strictEqual((await connectedClient).httpClient.authUrl, TEST_AUTH_URL);
     });
     it('should construct the auth url with baseUrl when not provided', async () => {
-      const client = new Client(baseUrl, {        
+      const client = new Client(baseUrl, 'keyspace1', {        
         username: "user1",
         password: "pass1",
         createNamespaceOnConnect: false
@@ -280,7 +271,7 @@ describe('StargateMongoose - collections.Client', () => {
   });
   describe('Client Db operations', () => {
     it('should return a db after setting up the client with a constructor', async () => {
-      const client = new Client(baseUrl, {
+      const client = new Client(baseUrl, 'keyspace1', {
         applicationToken: '123',
         createNamespaceOnConnect: false
       });
@@ -289,7 +280,7 @@ describe('StargateMongoose - collections.Client', () => {
       assert.ok(db);
     });
     it('should not return a db if no name is provided', async () => {
-      const client = new Client(baseUrl, {
+      const client = new Client(baseUrl, 'keyspace1', {
         applicationToken: '123',
         createNamespaceOnConnect: false
       });


### PR DESCRIPTION
**What this PR does**:

- Fixed the homepage URL in package.json for the links on the npm registry page to work correctly.
- Changed workflow files to get Stargate and JSON API Versions from api-compatibility.versions file.
- Added keywords in package.json.
- Updated Quick Start code based on end to end test.
- Removed `keyspaceName` option from the `ClientOptions` since its confusing because the `keyspaceName` is also expected at the end of the URL. And so, in this release the keyspace name is always expected on the URL as the last part and gets removed from the options.
- Updated `.env.example` file to reflect the removal of `keyspaceName` option.
- Updated package version to '0.2.0-ALPHA-1' for the next release.

**Which issue(s) this PR fixes**:
Fixes #37 

**Checklist**
- [X] Changes manually tested
- [X] Automated Tests added/updated
- [X] Documentation added/updated
- [] CLA Signed: [DataStax CLA](https://cla.datastax.com/)