### PR TITLE
implement dropDatabase() and createDatabase() (dropNamespace, createNamespace)

### DIFF
--- a/src/collections/client.ts
+++ b/src/collections/client.ts
@@ -69,14 +69,14 @@ export class Client {
     const parsedUri = parseUri(uri);
     const client = new Client(parsedUri.baseUrl, parsedUri.keyspaceName, {
       applicationToken: options?.applicationToken ? options?.applicationToken : parsedUri.applicationToken,
-        baseApiPath: options?.baseApiPath ? options?.baseApiPath : parsedUri.baseApiPath,
-        logLevel: options?.logLevel,
-        authHeaderName: options?.authHeaderName,
-        createNamespaceOnConnect: options?.createNamespaceOnConnect ?? true,
-        username: options?.username,
-        password: options?.password,
-        authUrl: options?.authUrl
-      });
+      baseApiPath: options?.baseApiPath ? options?.baseApiPath : parsedUri.baseApiPath,
+      logLevel: options?.logLevel,
+      authHeaderName: options?.authHeaderName,
+      createNamespaceOnConnect: options?.createNamespaceOnConnect ?? true,
+      username: options?.username,
+      password: options?.password,
+      authUrl: options?.authUrl
+    });
     await client.connect();
     return client;
   }
@@ -88,7 +88,7 @@ export class Client {
   async connect(): Promise<Client> {
     if (this.createNamespaceOnConnect && this.keyspaceName) {
       logger.debug('Creating Namespace ' + this.keyspaceName);
-      await createNamespace(this, this.keyspaceName);
+      await createNamespace(this.httpClient, this.keyspaceName);
     } else {
       logger.debug('Not creating Namespace on connection!');
     }

--- a/src/collections/db.ts
+++ b/src/collections/db.ts
@@ -14,10 +14,11 @@
 
 import { HTTPClient } from '@/src/client';
 import { Collection } from './collection';
-import { executeOperation, dropNamespace } from './utils';
+import { executeOperation, createNamespace, dropNamespace } from './utils';
 import _ from 'lodash';
 
 export class Db {
+  rootHttpClient: HTTPClient;
   httpClient: HTTPClient;
   name: string;
 
@@ -30,6 +31,7 @@ export class Db {
     if (!name) {
       throw new Error('Db: name is required');
     }
+    this.rootHttpClient = httpClient;
     // use a clone of the underlying http client to support multiple db's from a single connection
     this.httpClient = _.cloneDeep(httpClient);
     this.httpClient.baseUrl = `${this.httpClient.baseUrl}/${name}`;
@@ -85,6 +87,14 @@ export class Db {
    * @returns Promise
    */
   async dropDatabase() {
-    return await dropNamespace(this.httpClient, this.name);
+    return await dropNamespace(this.rootHttpClient, this.name);
+  }
+
+  /**
+   *
+   * @returns Promise
+   */
+   async createDatabase() {
+    return await createNamespace(this.rootHttpClient, this.name);
   }
 }

--- a/src/collections/db.ts
+++ b/src/collections/db.ts
@@ -14,7 +14,7 @@
 
 import { HTTPClient } from '@/src/client';
 import { Collection } from './collection';
-import { executeOperation } from './utils';
+import { executeOperation, dropNamespace } from './utils';
 import _ from 'lodash';
 
 export class Db {
@@ -80,12 +80,11 @@ export class Db {
     return await this.httpClient.executeCommand(command);
   }
 
-  // NOOPS and unimplemented
   /**
    *
    * @returns Promise
    */
-  dropDatabase() {
-    throw new Error('dropDatabase not implemented');
+  async dropDatabase() {
+    return await dropNamespace(this.httpClient, this.name);
   }
 }

--- a/src/collections/utils.ts
+++ b/src/collections/utils.ts
@@ -19,7 +19,7 @@ import { logger } from '@/src/logger';
 import axios from 'axios';
 import { type } from 'os';
 import { Client } from '@/src/collections/client';
-import { handleIfErrorResponse } from '@/src/client/httpClient'
+import { HTTPClient, handleIfErrorResponse } from '@/src/client/httpClient'
 
 interface ParsedUri {
   baseUrl: string;
@@ -208,4 +208,21 @@ export async function createNamespace(client:Client, name: string) {
     data
   });
   handleIfErrorResponse(response, data);
+  return response;
+}
+
+export async function dropNamespace(httpClient: HTTPClient, name: string) {
+  const data = {
+    dropNamespace: {
+      name
+    }
+  };
+  const parsedUri = parseUri(httpClient.baseUrl);
+  const response = await httpClient._request({
+    url: `${parsedUri.baseUrl}/${parsedUri.baseApiPath}`,
+    method: 'POST',
+    data
+  });
+  handleIfErrorResponse(response, data);
+  return response;
 }

--- a/src/collections/utils.ts
+++ b/src/collections/utils.ts
@@ -196,14 +196,15 @@ export type QueryOptions = {
   projection?: any
 }
 
-export async function createNamespace(client:Client, name: string) {  
+export async function createNamespace(httpClient: HTTPClient, name: string) {  
   const data = {
     createNamespace: {
       name
     }
   };
-  const response = await client.httpClient._request({
-    url: client.httpClient.baseUrl,
+  const parsedUri = parseUri(httpClient.baseUrl);
+  const response = await httpClient._request({
+    url: httpClient.baseUrl,
     method: 'POST',
     data
   });
@@ -217,9 +218,8 @@ export async function dropNamespace(httpClient: HTTPClient, name: string) {
       name
     }
   };
-  const parsedUri = parseUri(httpClient.baseUrl);
   const response = await httpClient._request({
-    url: `${parsedUri.baseUrl}/${parsedUri.baseApiPath}`,
+    url: httpClient.baseUrl,
     method: 'POST',
     data
   });

--- a/tests/collections/db.test.ts
+++ b/tests/collections/db.test.ts
@@ -105,7 +105,7 @@ for (const testClient in testClients) {
           assert.equal(err.errors.length, 1);
           assert.equal(
             err.errors[0].message,
-            'INVALID_ARGUMENT: Keyspace \'cycling\' doesn\'t exist'
+            'INVALID_ARGUMENT: Keyspace \'' + keyspaceName + '\' doesn\'t exist'
           );
         }
         
@@ -138,7 +138,7 @@ for (const testClient in testClients) {
           assert.equal(err.errors.length, 1);
           assert.equal(
             err.errors[0].message,
-            'INVALID_ARGUMENT: Keyspace \'cycling\' doesn\'t exist'
+            'INVALID_ARGUMENT: Keyspace \'' + keyspaceName + '\' doesn\'t exist'
           );
         }
         

--- a/tests/collections/db.test.ts
+++ b/tests/collections/db.test.ts
@@ -15,7 +15,7 @@
 import assert from 'assert';
 import { Db } from '@/src/collections/db';
 import { Client } from '@/src/collections/client';
-import { parseUri, createNamespace } from '@/src/collections/utils';
+import { parseUri, createNamespace, dropNamespace } from '@/src/collections/utils';
 import { testClients, TEST_COLLECTION_NAME } from '@/tests/fixtures';
 import { randAlphaNumeric } from '@ngneat/falso';
 
@@ -87,7 +87,7 @@ for (const testClient in testClients) {
     describe('dropDatabase', () => {
       after(async () => {
         const keyspaceName = parseUri(process.env.JSON_API_URI).keyspaceName;
-        await createNamespace(astraClient, keyspaceName);
+        await createNamespace(astraClient.httpClient, keyspaceName);
       });
 
       it('should drop the underlying database (AKA namespace)', async () => {
@@ -109,6 +109,43 @@ for (const testClient in testClients) {
           );
         }
         
+      });
+    });
+
+    describe('createDatabase', () => {
+      after(async () => {
+        const keyspaceName = parseUri(process.env.JSON_API_URI).keyspaceName;
+        await createNamespace(astraClient.httpClient, keyspaceName);
+      });
+
+      it('should create the underlying database (AKA namespace)', async () => {
+        const keyspaceName = parseUri(process.env.JSON_API_URI).keyspaceName;
+        const db = new Db(astraClient.httpClient, keyspaceName);
+        const suffix = randAlphaNumeric({ length: 4 }).join('');
+
+        await db.dropDatabase().catch(err => {
+          if (err.errors[0].exceptionClass === 'NotFoundException') {
+            return;
+          }
+
+          throw err;
+        });
+
+        try {
+          await db.createCollection(`test_db_collection_${suffix}`);
+          assert.ok(false);
+        } catch (err) {
+          assert.equal(err.errors.length, 1);
+          assert.equal(
+            err.errors[0].message,
+            'INVALID_ARGUMENT: Keyspace \'cycling\' doesn\'t exist'
+          );
+        }
+        
+        const res = await db.createDatabase();
+        assert.strictEqual(res.status?.ok, 1);
+
+        await db.createCollection(`test_db_collection_${suffix}`);
       });
     });
   });

--- a/tests/collections/db.test.ts
+++ b/tests/collections/db.test.ts
@@ -15,7 +15,7 @@
 import assert from 'assert';
 import { Db } from '@/src/collections/db';
 import { Client } from '@/src/collections/client';
-import { parseUri } from '@/src/collections/utils';
+import { parseUri, createNamespace } from '@/src/collections/utils';
 import { testClients, TEST_COLLECTION_NAME } from '@/tests/fixtures';
 import { randAlphaNumeric } from '@ngneat/falso';
 
@@ -81,6 +81,34 @@ for (const testClient in testClients) {
         const res = await db.dropCollection(`test_db_collection_${suffix}`);
         assert.strictEqual(res.status?.ok, 1);
         assert.strictEqual(res.errors, undefined);
+      });
+    });
+
+    describe('dropDatabase', () => {
+      after(async () => {
+        const keyspaceName = parseUri(process.env.JSON_API_URI).keyspaceName;
+        await createNamespace(astraClient, keyspaceName);
+      });
+
+      it('should drop the underlying database (AKA namespace)', async () => {
+        const keyspaceName = parseUri(process.env.JSON_API_URI).keyspaceName;
+        const db = new Db(astraClient.httpClient, keyspaceName);
+        const suffix = randAlphaNumeric({ length: 4 }).join('');
+        await db.createCollection(`test_db_collection_${suffix}`);
+        const res = await db.dropDatabase();
+        assert.strictEqual(res.status?.ok, 1);
+  
+        try {
+          await db.createCollection(`test_db_collection_${suffix}`);
+          assert.ok(false);
+        } catch (err) {
+          assert.equal(err.errors.length, 1);
+          assert.equal(
+            err.errors[0].message,
+            'INVALID_ARGUMENT: Keyspace \'cycling\' doesn\'t exist'
+          );
+        }
+        
       });
     });
   });

--- a/tests/driver/index.test.ts
+++ b/tests/driver/index.test.ts
@@ -38,7 +38,7 @@ const Cart = mongoose.model('Cart', cartSchema);
 const Product = mongoose.model('Product', productSchema);
 
 describe('StargateMongoose - index', () => {
-  it('should leverage astradb', async function () {    
+  it('should leverage astradb', async function () {  
     await mongoose.connect(astraUri, {
       username: "cassandra",
       password: "cassandra",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Now that we have `dropNamespace()` in https://github.com/stargate/jsonapi/pull/335, we can use it to implement `db.dropDatabase()`, which is extremely useful for cleaning up after tests.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)