### PR TITLE
add missing dropDatabase() to driver API re: #68

### DIFF
--- a/src/driver/connection.ts
+++ b/src/driver/connection.ts
@@ -65,6 +65,14 @@ export class Connection extends MongooseConnection {
     });
   }
 
+  async dropDatabase() {
+    return executeOperation(async () => {
+      await this._waitForClient();
+      const db = this.client.db();
+      return db.dropDatabase();
+    });
+  }
+
   async openUri(uri: string, options: any) {
     let resolveInitialConnection: Function;
     let rejectInitialConnection: Function;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Missed a spot in #68: `dropDatabase()` currently still throws `Error: dropDatabase not implemented` when calling `mongoose.connection.dropDatabase()`. Also need to add a `dropDatabase()` function at the driver layer.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)