### PR TITLE
set connection config to allow setting `autoCreate` on connection level

### DIFF
--- a/src/driver/connection.ts
+++ b/src/driver/connection.ts
@@ -81,6 +81,16 @@ export class Connection extends MongooseConnection {
       rejectInitialConnection = reject;
     });
 
+    // Set Mongoose-specific config options. Need to set
+    // this in order to allow connection-level overrides for
+    // these options.
+    this.config = {
+      autoCreate: options?.autoCreate,
+      autoIndex: options?.autoIndex,
+      sanitizeFilter: options?.sanitizeFilter,
+      bufferCommands: options?.bufferCommands
+    };
+
     try {
       this._connectionString = uri;
       this.readyState = STATES.connecting;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

I kept running into issues with setting `autoCreate` on connection level in sample apps, and finally figured out why. `openUri()` is responsible for setting `Connection.prototype.config`, which is where [Mongoose looks for connection-level config options](https://github.com/Automattic/mongoose/blob/717fe244a9de9e1fa0ec7d440574290d947f66ab/lib/model.js#L1306-L1311). With this PR, you can do `mongoose.connect(process.env.STARGATE_JSON_API_URL, { autoCreate: true })`.

As a neat consequence, it turns out that we actually _can_ make `autoCreate` default to true. However, if we do that, I'd like to also make `createCollection()` call `createDatabase()`, so we don't get errors if the database doesn't exist yet. What do you think @kathirsvn ?

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)