### PR TITLE
define TypeScript interfaces for options, use Record instead of any

### DIFF
--- a/src/collections/collection.ts
+++ b/src/collections/collection.ts
@@ -15,14 +15,12 @@
 import _ from 'lodash';
 import {
   DeleteResult,
-  FindOneAndUpdateOptions,
   InsertOneResult,
   ModifyResult,
   ObjectId,
-  UpdateOptions,
   UpdateResult
 } from 'mongodb';
-import { FindCursor } from './cursor';
+import { FindCursor, FindOptions } from './cursor';
 import { HTTPClient } from '@/src/client';
 import { executeOperation } from './utils';
 import { inspect } from 'util';
@@ -33,8 +31,38 @@ import { logger } from '@/src/logger';
 // https://github.com/mongodb/node-mongodb-native/pull/3323
 type JSONAPIUpdateResult = Omit<UpdateResult, 'upsertedId'> & { upsertedId: ObjectId | null };
 
-interface DocumentCallback {
-  (err: Error | undefined, res: any): void;
+export interface FindOneOptions {
+  sort?: Record<string, 1 | -1>;
+}
+
+export interface FindOneAndDeleteOptions {
+  sort?: Record<string, 1 | -1>;
+}
+
+export interface FindOneAndReplaceOptions {
+  upsert?: boolean;
+  returnDocument?: 'before' | 'after';
+  sort?: Record<string, 1 | -1>;
+}
+
+export interface FindOneAndUpdateOptions {
+  upsert?: boolean;
+  returnDocument?: 'before' | 'after';
+  sort?: Record<string, 1 | -1>;
+}
+
+export { FindOptions } from './cursor';
+
+export interface InsertManyOptions {
+  ordered?: boolean;
+}
+
+export interface UpdateOneOptions {
+  upsert?: boolean;
+}
+
+export interface UpdateManyOptions {
+  upsert?: boolean;
 }
 
 export class Collection {
@@ -79,12 +107,12 @@ export class Collection {
     });
   }
 
-  async insertMany(docs: any, options?: any) {
+  async insertMany(documents: Record<string, any>[], options?: InsertManyOptions) {
     return executeOperation(async (): Promise<InsertManyResult<any>> => {
       const command = {
         insertMany : {
-            documents : docs,
-            options: options
+          documents,
+          options
         }
       };
       const resp = await this.httpClient.executeCommand(command);
@@ -96,17 +124,13 @@ export class Collection {
     });
   }
 
-  async updateOne(query: any, update: any, options?: UpdateOptions) {
+  async updateOne(filter: Record<string, any>, update: Record<string, any>, options?: UpdateOneOptions) {
     return executeOperation(async (): Promise<JSONAPIUpdateResult> => {
-      if (options != null && 'session' in options) {
-        options = { ...options };
-        delete options.session;
-      }
       const command = {
         updateOne: {
-          filter: query,
-          update: update,
-          options: options
+          filter,
+          update,
+          options
         }
       };
       const updateOneResp = await this.httpClient.executeCommand(command);
@@ -120,13 +144,13 @@ export class Collection {
     });
   }
 
-  async updateMany(query: any, update: any, options?: UpdateOptions) {
+  async updateMany(filter: Record<string, any>, update: Record<string, any>, options?: UpdateManyOptions) {
     return executeOperation(async (): Promise<JSONAPIUpdateResult> => {
       const command = {
         updateMany: {
-          filter: query,
-          update: update,
-          options: options
+          filter,
+          update,
+          options
         }
       };
       const updateManyResp = await this.httpClient.executeCommand(command);
@@ -147,7 +171,7 @@ export class Collection {
     throw new Error('Not Implemented');
   }
 
-  async deleteOne(query: any) {
+  async deleteOne(filter: Record<string, any>) {
     return executeOperation(async (): Promise<DeleteResult> => {
       type DeleteOneCommand = {
         deleteOne: {
@@ -156,7 +180,7 @@ export class Collection {
       };
       const command: DeleteOneCommand = {
         deleteOne: {
-          filter: query,
+          filter
         }
       };
       const deleteOneResp = await this.httpClient.executeCommand(command);
@@ -167,11 +191,11 @@ export class Collection {
     });
   }
 
-  async deleteMany(query: any) {
+  async deleteMany(filter: Record<string, any>) {
     return executeOperation(async (): Promise<DeleteResult> => {
       const command = {
         deleteMany: {
-          filter: query
+          filter
         }
       };
       const deleteManyResp = await this.httpClient.executeCommand(command);
@@ -185,34 +209,24 @@ export class Collection {
     });
   }
 
-  find(query: any, options?: any) {
-    const cursor = new FindCursor(this, query, options);
+  find(filter: Record<string, any>, options?: FindOptions) {
+    const cursor = new FindCursor(this, filter, options);
     return cursor;
   }
 
-  async findOne(query: any, options?: any) {
+  async findOne(filter: Record<string, any>, options?: FindOneOptions) {
     return executeOperation(async (): Promise<any | null> => {
-      // Workaround for Automattic/mongoose#13052
-      if (options && options.session == null) {
-        delete options.session;
-      }
-      // Workaround because Mongoose `save()` uses `findOne({ _id }, { projection: { _id: 1 } })`
-      // if there's no updates, which causes Stargate server to return an error
-      if (options && 'projection' in options) {
-        delete options.projection;
-      }
-
       type FindOneCommand = {
         findOne: {
-          filter?: Object,
-          options?: Object,
-          sort?: Object
+          filter?: Record<string, any>,
+          options?: Record<string, any>,
+          sort?: Record<string, any>
         }
       };
       const command: FindOneCommand = {
         findOne : {
-          filter : query,
-          options: options
+          filter,
+          options
         }
       };
 
@@ -225,7 +239,7 @@ export class Collection {
     });
   }
 
-  async findOneAndReplace(filter: any, replacement: any, options?: any){
+  async findOneAndReplace(filter: Record<string, any>, replacement: Record<string, any>, options?: FindOneAndReplaceOptions) {
     return executeOperation(async (): Promise<ModifyResult> => {
       type FindOneAndReplaceCommand = {
         findOneAndReplace: {
@@ -258,7 +272,7 @@ export class Collection {
     throw new Error('Not Implemented');
   }
 
-  async countDocuments(filter?: any) {
+  async countDocuments(filter?: Record<string, any>) {
     return executeOperation(async (): Promise<number> => {
       const command = {
         countDocuments: {
@@ -270,7 +284,7 @@ export class Collection {
     });
   }
 
-  async findOneAndDelete(query: any, options?: any) {
+  async findOneAndDelete(filter: Record<string, any>, options?: FindOneAndDeleteOptions) {
     type FindOneAndDeleteCommand = {
       findOneAndDelete: {
         filter?: Object,
@@ -279,15 +293,13 @@ export class Collection {
     };
     const command: FindOneAndDeleteCommand = {
       findOneAndDelete : {
-        filter : query
+        filter
       }
     };
     if (options?.sort) {
       command.findOneAndDelete.sort = options.sort;
     }
-    if (options != null && typeof options === 'object' && Object.keys(options).find(key => key !== 'sort')) {
-      throw new TypeError('findOneAndDelete() doesn\'t support options other than sort()');
-    }
+
     const resp = await this.httpClient.executeCommand(command);
     return {
       value : resp.data?.docs[0],
@@ -298,11 +310,11 @@ export class Collection {
  /** 
   * @deprecated
   */
-  async count(filter?: any) {
+  async count(filter?: Record<string, any>) {
     return this.countDocuments(filter);
   }
 
-  async findOneAndUpdate(query: any, update: any, options?: FindOneAndUpdateOptions) {
+  async findOneAndUpdate(filter: Record<string, any>, update: Record<string, any>, options?: FindOneAndUpdateOptions) {
     return executeOperation(async (): Promise<ModifyResult> => {
       type FindOneAndUpdateCommand = {
         findOneAndUpdate: {
@@ -314,9 +326,9 @@ export class Collection {
       };
       const command: FindOneAndUpdateCommand = {
         findOneAndUpdate : {
-          filter : query,
-          update : update,
-          options: options
+          filter,
+          update,
+          options
         }
       };
       if (options?.sort) {

--- a/src/collections/cursor.ts
+++ b/src/collections/cursor.ts
@@ -17,14 +17,16 @@ import { Collection } from './collection';
 import { logger } from '@/src/logger';
 import { executeOperation, QueryOptions } from './utils';
 
-interface ResultCallback {
-  (err: Error | undefined, res: Array<any>): void;
+export interface FindOptions {
+  limit?: number;
+  skip?: number;
+  sort?: Record<string, 1 | -1>;
 }
 
 export class FindCursor {
   collection: Collection;
-  filter: any;
-  options: any;
+  filter: Record<string, any>;
+  options: FindOptions;
   documents: Record<string, any>[] = [];
   status: string = 'uninitialized';
   nextPageState?: string;
@@ -40,10 +42,10 @@ export class FindCursor {
    * @param filter
    * @param options
    */
-  constructor(collection: Collection, filter: any, options?: any) {
+  constructor(collection: Collection, filter: Record<string, any>, options?: FindOptions) {
     this.collection = collection;
     this.filter = filter;
-    this.options = options;
+    this.options = options ?? {};
     this.limit = options?.limit || Infinity;
     this.status = 'initialized';
     this.exhausted = false;
@@ -109,20 +111,15 @@ export class FindCursor {
   async _getMore() {
     const command: {
       find: {
-        filter?: string | undefined | null,
-        projection?: string | undefined | null,
-        options?: QueryOptions | undefined | null,
-        sort?: Object | null
+        filter?: Record<string, any>,
+        options?: Record<string, any>,
+        sort?: Record<string, any>
       }
     } = {
       find: {
         filter: this.filter
       }
     };
-    // Workaround for Automattic/mongoose#13050
-    if (this.options && this.options.projection && Object.keys(this.options.projection).length > 0) {
-      command.find.projection = this.options.projection;
-    }
     if (this.options && this.options.sort) {
       command.find.sort = this.options.sort;
     }

--- a/src/collections/index.ts
+++ b/src/collections/index.ts
@@ -16,6 +16,17 @@ export { Client } from './client';
 export { Collection } from './collection';
 export { Binary, Decimal128, ObjectId, ReadPreference } from 'mongodb';
 
+export {
+  FindOneAndDeleteOptions,
+  FindOneAndReplaceOptions,
+  FindOneAndUpdateOptions,
+  FindOneOptions,
+  FindOptions,
+  InsertManyOptions,
+  UpdateManyOptions,
+  UpdateOneOptions
+} from './collection';
+
 // alias for MongoClient shimming
 export { Client as MongoClient } from './client';
 

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -13,13 +13,22 @@
 // limitations under the License.
 
 import { default as MongooseCollection } from 'mongoose/lib/collection';
+import {
+  FindOneAndDeleteOptions,
+  FindOneAndReplaceOptions,
+  FindOneAndUpdateOptions,
+  FindOneOptions,
+  FindOptions,
+  InsertManyOptions,
+  UpdateManyOptions,
+  UpdateOneOptions
+} from '@/src/collections/collection';
 
 export class Collection extends MongooseCollection {
   debugType = 'StargateMongooseCollection';
 
   constructor(name: string, conn: any, options: any) {
     super(name, conn, options);
-    this.Promise = options.Promise || Promise;
     this.modelName = options.modelName;
     delete options.modelName;
     this._closed = false;
@@ -29,52 +38,52 @@ export class Collection extends MongooseCollection {
     return this.conn.db.collection(this.name);
   }
 
-  countDocuments(filter: any) {
+  countDocuments(filter: Record<string, any>) {
     return this.collection.countDocuments(filter);
   }
 
-  find(query: any, options?: any) {
-    return this.collection.find(query, options);
+  find(filter: Record<string, any>, options?: FindOptions) {
+    return this.collection.find(filter, options);
   }
 
-  findOne(query: any, options?: any) {
-    return this.collection.findOne(query, options);
+  findOne(filter: Record<string, any>, options?: FindOneOptions) {
+    return this.collection.findOne(filter, options);
   }
 
-  insertOne(doc: any, options?: any) {
-    return this.collection.insertOne(doc, options);
+  insertOne(doc: Record<string, any>) {
+    return this.collection.insertOne(doc);
   }
 
-  insertMany(docs: any, options?: any) {
-    return this.collection.insertMany(docs, options);
+  insertMany(documents: Record<string, any>[], options?: InsertManyOptions) {
+    return this.collection.insertMany(documents, options);
   }
 
-  findOneAndUpdate(query: any, update: any, options?: any) {
-    return this.collection.findOneAndUpdate(query, update, options);
+  findOneAndUpdate(filter: Record<string, any>, update: Record<string, any>, options?: FindOneAndUpdateOptions) {
+    return this.collection.findOneAndUpdate(filter, update, options);
   }
 
-  findOneAndDelete(query: any, options?: any) {
-    return this.collection.findOneAndDelete(query, options);
+  findOneAndDelete(filter: Record<string, any>, options?: FindOneAndDeleteOptions) {
+    return this.collection.findOneAndDelete(filter, options);
   }
 
-  findOneAndReplace(query: any, newDoc: any, options?: any) {
-    return this.collection.findOneAndReplace(query, newDoc, options);
+  findOneAndReplace(filter: Record<string, any>, newDoc: Record<string, any>, options?: FindOneAndReplaceOptions) {
+    return this.collection.findOneAndReplace(filter, newDoc, options);
   }
 
-  deleteMany(query: any, options?: any) {
-    return this.collection.deleteMany(query, options);
+  deleteMany(filter: Record<string, any>) {
+    return this.collection.deleteMany(filter);
   }
 
-  deleteOne(query: any, options?: any) {
-    return this.collection.deleteOne(query, options);
+  deleteOne(filter: Record<string, any>) {
+    return this.collection.deleteOne(filter);
   }
 
-  updateOne(query: any, update: any, options?: any) {
-    return this.collection.updateOne(query, update, options);
+  updateOne(filter: Record<string, any>, update: Record<string, any>, options?: UpdateOneOptions) {
+    return this.collection.updateOne(filter, update, options);
   }
 
-  updateMany(query: any, update: any, options?: any) {
-    return this.collection.updateMany(query, update, options);
+  updateMany(filter: Record<string, any>, update: Record<string, any>, options?: UpdateManyOptions) {
+    return this.collection.updateMany(filter, update, options);
   }
 
   dropIndexes() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

1. Explicit interface for all options, like `FindOneOptions`, etc.
2. Use `Record<string, any>` instead of `any` for query filters, documents, etc. Because (1) `any` allows non-object types, like numbers, and (2) `any` allows objects with symbol keys, which won't end up getting stored.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)