### PR TITLE
serialize BigInts as numbers for Mongoose 7.1 support, add `env D=1`  support for tests

### DIFF
--- a/src/client/httpClient.ts
+++ b/src/client/httpClient.ts
@@ -70,6 +70,8 @@ const axiosAgent = axios.create({
 const requestInterceptor = (config: AxiosRequestConfig) => {
   const { method, url } = config;
   logger.http(`--- ${method?.toUpperCase()} ${url}`);
+  logger.http(serializeCommand(config.data, true));
+  config.data = serializeCommand(config.data);
   return config;
 };
 
@@ -151,7 +153,7 @@ export class HTTPClient {
          }
       }
       logger.debug('request url %s', requestInfo.url);
-      logger.debug('request command %s', JSON.stringify(requestInfo.data));
+      logger.debug('request command %s', serializeCommand(requestInfo.data));
       const response = await axiosAgent({
         url: requestInfo.url,
         data: requestInfo.data,
@@ -237,5 +239,22 @@ export const handleIfErrorResponse = (response: any, data: Record<string, any>) 
   if(response.errors && response.errors.length > 0){
     throw new StargateServerError(response, data);
   }
+}
+
+function serializeCommand(data: Record<string, any>, pretty?: boolean): string {
+  if (pretty) {
+    return JSON.stringify(data, function(key, value) {
+      if (typeof value === 'bigint') {
+        return Number(value);
+      }
+      return value;
+    }, '  ');
+  }
+  return JSON.stringify(data, function(key, value) {
+    if (typeof value === 'bigint') {
+      return Number(value);
+    }
+    return value;
+  });
 }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -25,3 +25,6 @@ export const logger = winston.createLogger({
 export const setLevel = (level: string) => {
   consoleTransport.level = level;
 };
+export const getLevel = () => {
+  return consoleTransport.level;
+};

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -25,6 +25,3 @@ export const logger = winston.createLogger({
 export const setLevel = (level: string) => {
   consoleTransport.level = level;
 };
-export const getLevel = () => {
-  return consoleTransport.level;
-};

--- a/tests/collections/client.test.ts
+++ b/tests/collections/client.test.ts
@@ -18,6 +18,7 @@ import { testClient } from '@/tests/fixtures';
 import { parseUri } from '@/src/collections/utils';
 import { AUTH_API_PATH } from '@/src/client/httpClient';
 import _ from 'lodash';
+import { getLevel } from '@/src/logger';
 
 describe('StargateMongoose clients test', () => {
   const baseUrl = `https://db_id-region-1.apps.astra.datastax.com`;
@@ -59,7 +60,7 @@ describe('StargateMongoose clients test', () => {
     it('should initialize a Client connection with a uri using connect with overrides', async () => {
       const AUTH_TOKEN_TO_CHECK = "123";
       const BASE_API_PATH_TO_CHECK = "baseAPIPath1";
-      const LOG_LEVEL_TO_CHECK = "info";
+      const LOG_LEVEL_TO_CHECK = getLevel();
       const AUTH_HEADER_NAME_TO_CHECK = "x-token";
       const client = await Client.connect(clientURI, {
           applicationToken: AUTH_TOKEN_TO_CHECK,
@@ -81,7 +82,7 @@ describe('StargateMongoose clients test', () => {
       const AUTH_TOKEN_TO_CHECK = "123";
       const KEYSPACE_TO_CHECK = "testks1";
       const BASE_API_PATH_TO_CHECK = "baseAPIPath1";
-      const LOG_LEVEL_TO_CHECK = "info";
+      const LOG_LEVEL_TO_CHECK = getLevel();
       const AUTH_HEADER_NAME_TO_CHECK = "x-token";
       const client = await Client.connect(parseUri(clientURI).baseUrl + "/" + BASE_API_PATH_TO_CHECK + "/" + KEYSPACE_TO_CHECK, {
           applicationToken: AUTH_TOKEN_TO_CHECK,
@@ -102,7 +103,7 @@ describe('StargateMongoose clients test', () => {
       const AUTH_TOKEN_TO_CHECK = "123";
       const KEYSPACE_TO_CHECK = "testks1";
       const BASE_API_PATH_TO_CHECK = "apis/baseAPIPath1";
-      const LOG_LEVEL_TO_CHECK = "info";
+      const LOG_LEVEL_TO_CHECK = getLevel();
       const AUTH_HEADER_NAME_TO_CHECK = "x-token";
       const client = await Client.connect(parseUri(clientURI).baseUrl + "/" + BASE_API_PATH_TO_CHECK + "/" + KEYSPACE_TO_CHECK, {
           applicationToken: AUTH_TOKEN_TO_CHECK,
@@ -125,7 +126,7 @@ describe('StargateMongoose clients test', () => {
       const AUTH_TOKEN_TO_CHECK = "123";
       const KEYSPACE_TO_CHECK = "testks1";
       const BASE_API_PATH_TO_CHECK = "baseAPIPath1";
-      const LOG_LEVEL_TO_CHECK = "info";
+      const LOG_LEVEL_TO_CHECK = getLevel();
       const AUTH_HEADER_NAME_TO_CHECK = "x-token";
       const baseUrl = 'http://localhost:8080';
       const client = await Client.connect(baseUrl + "/testks1/" + BASE_API_PATH_TO_CHECK + "/" + KEYSPACE_TO_CHECK, {
@@ -147,7 +148,7 @@ describe('StargateMongoose clients test', () => {
       const AUTH_TOKEN_TO_CHECK = "123";
       const KEYSPACE_TO_CHECK = "testks1";
       const BASE_API_PATH_TO_CHECK = "baseAPIPath1";
-      const LOG_LEVEL_TO_CHECK = "info";
+      const LOG_LEVEL_TO_CHECK = getLevel();
       const AUTH_HEADER_NAME_TO_CHECK = "x-token";
       const baseUrl = 'http://localhost:8080';
       const client = await Client.connect(baseUrl + "/" + BASE_API_PATH_TO_CHECK + "/" + KEYSPACE_TO_CHECK, {
@@ -170,7 +171,7 @@ describe('StargateMongoose clients test', () => {
       const AUTH_TOKEN_TO_CHECK = "123";
       const KEYSPACE_TO_CHECK = "testks1";
       const BASE_API_PATH_TO_CHECK = "baseAPIPath1";
-      const LOG_LEVEL_TO_CHECK = "info";
+      const LOG_LEVEL_TO_CHECK = getLevel();
       const AUTH_HEADER_NAME_TO_CHECK = "x-token";
       const baseUrl = 'http://localhost:8080';
       const client = await Client.connect(baseUrl + "/" + KEYSPACE_TO_CHECK, {

--- a/tests/collections/client.test.ts
+++ b/tests/collections/client.test.ts
@@ -18,7 +18,6 @@ import { testClient } from '@/tests/fixtures';
 import { parseUri } from '@/src/collections/utils';
 import { AUTH_API_PATH } from '@/src/client/httpClient';
 import _ from 'lodash';
-import { getLevel } from '@/src/logger';
 
 describe('StargateMongoose clients test', () => {
   const baseUrl = `https://db_id-region-1.apps.astra.datastax.com`;
@@ -60,12 +59,10 @@ describe('StargateMongoose clients test', () => {
     it('should initialize a Client connection with a uri using connect with overrides', async () => {
       const AUTH_TOKEN_TO_CHECK = "123";
       const BASE_API_PATH_TO_CHECK = "baseAPIPath1";
-      const LOG_LEVEL_TO_CHECK = getLevel();
       const AUTH_HEADER_NAME_TO_CHECK = "x-token";
       const client = await Client.connect(clientURI, {
         applicationToken: AUTH_TOKEN_TO_CHECK,
         baseApiPath: BASE_API_PATH_TO_CHECK,
-        logLevel: LOG_LEVEL_TO_CHECK,
         authHeaderName: AUTH_HEADER_NAME_TO_CHECK,
         createNamespaceOnConnect: false
       });
@@ -82,11 +79,9 @@ describe('StargateMongoose clients test', () => {
       const AUTH_TOKEN_TO_CHECK = "123";
       const KEYSPACE_TO_CHECK = "testks1";
       const BASE_API_PATH_TO_CHECK = "baseAPIPath1";
-      const LOG_LEVEL_TO_CHECK = getLevel();
       const AUTH_HEADER_NAME_TO_CHECK = "x-token";
       const client = await Client.connect(parseUri(clientURI).baseUrl + "/" + BASE_API_PATH_TO_CHECK + "/" + KEYSPACE_TO_CHECK, {
         applicationToken: AUTH_TOKEN_TO_CHECK,
-        logLevel: LOG_LEVEL_TO_CHECK,
         authHeaderName: AUTH_HEADER_NAME_TO_CHECK,
         createNamespaceOnConnect: false
       });
@@ -103,11 +98,9 @@ describe('StargateMongoose clients test', () => {
       const AUTH_TOKEN_TO_CHECK = "123";
       const KEYSPACE_TO_CHECK = "testks1";
       const BASE_API_PATH_TO_CHECK = "apis/baseAPIPath1";
-      const LOG_LEVEL_TO_CHECK = getLevel();
       const AUTH_HEADER_NAME_TO_CHECK = "x-token";
       const client = await Client.connect(parseUri(clientURI).baseUrl + "/" + BASE_API_PATH_TO_CHECK + "/" + KEYSPACE_TO_CHECK, {
         applicationToken: AUTH_TOKEN_TO_CHECK,
-        logLevel: LOG_LEVEL_TO_CHECK,
         authHeaderName: AUTH_HEADER_NAME_TO_CHECK,
         createNamespaceOnConnect: false
       });
@@ -126,12 +119,10 @@ describe('StargateMongoose clients test', () => {
       const AUTH_TOKEN_TO_CHECK = "123";
       const KEYSPACE_TO_CHECK = "testks1";
       const BASE_API_PATH_TO_CHECK = "baseAPIPath1";
-      const LOG_LEVEL_TO_CHECK = getLevel();
       const AUTH_HEADER_NAME_TO_CHECK = "x-token";
       const baseUrl = 'http://localhost:8080';
       const client = await Client.connect(baseUrl + "/testks1/" + BASE_API_PATH_TO_CHECK + "/" + KEYSPACE_TO_CHECK, {
         applicationToken: AUTH_TOKEN_TO_CHECK,
-        logLevel: LOG_LEVEL_TO_CHECK,
         authHeaderName: AUTH_HEADER_NAME_TO_CHECK,
         createNamespaceOnConnect: false
       });
@@ -148,13 +139,11 @@ describe('StargateMongoose clients test', () => {
       const AUTH_TOKEN_TO_CHECK = "123";
       const KEYSPACE_TO_CHECK = "testks1";
       const BASE_API_PATH_TO_CHECK = "baseAPIPath1";
-      const LOG_LEVEL_TO_CHECK = getLevel();
       const AUTH_HEADER_NAME_TO_CHECK = "x-token";
       const baseUrl = 'http://localhost:8080';
       const client = await Client.connect(baseUrl + "/" + BASE_API_PATH_TO_CHECK + "/" + KEYSPACE_TO_CHECK, {
         applicationToken: AUTH_TOKEN_TO_CHECK,
         baseApiPath: "baseAPIPath2",
-        logLevel: LOG_LEVEL_TO_CHECK,
         authHeaderName: AUTH_HEADER_NAME_TO_CHECK,
         createNamespaceOnConnect: false
       });
@@ -171,12 +160,10 @@ describe('StargateMongoose clients test', () => {
       const AUTH_TOKEN_TO_CHECK = "123";
       const KEYSPACE_TO_CHECK = "testks1";
       const BASE_API_PATH_TO_CHECK = "baseAPIPath1";
-      const LOG_LEVEL_TO_CHECK = getLevel();
       const AUTH_HEADER_NAME_TO_CHECK = "x-token";
       const baseUrl = 'http://localhost:8080';
       const client = await Client.connect(baseUrl + "/" + KEYSPACE_TO_CHECK, {
         applicationToken: AUTH_TOKEN_TO_CHECK,
-        logLevel: LOG_LEVEL_TO_CHECK,
         authHeaderName: AUTH_HEADER_NAME_TO_CHECK,
         createNamespaceOnConnect: false
       });

--- a/tests/collections/collection.test.ts
+++ b/tests/collections/collection.test.ts
@@ -755,6 +755,16 @@ describe(`StargateMongoose - ${testClient} Connection - collections.collection`,
       res = await collection.findOneAndDelete({}, { sort: { username: -1 } });
       assert.strictEqual(res.value.username, 'c');
     });
+    it('stores BigInts as numbers', async () => {
+      await collection.deleteMany({});
+      await collection.insertOne({
+        _id: 'bigint-test',
+        answer: 42n
+      });
+
+      const res = await collection.findOne({ _id: 'bigint-test' });
+      assert.strictEqual(res.answer, 42);
+    });
     it.skip('should deleteOne with sort', async () => {
       // deleteOne() with sort currently not supported by jsonapi
       await collection.deleteMany({});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -14,3 +14,8 @@
 
 // setup envars
 require("dotenv").config();
+
+import { setLevel } from '@/src/logger';
+if (process.env.D) {
+  setLevel('http');
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

1. Adds a new `serializeCommand()` function that converts BigInts to numbers for JSON. Otherwise, `JSON.stringify()` throws the following error: `error: Error: Command "insertOne" failed with the following errors: [{"message":"Do not know how to serialize a BigInt"}]`
2. For convenience, `env D=1 npm test` enables debug logging, including logging the request body. Very helpful trick for debugging, Mongoose has used this pattern for a decade now.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)