### PR TITLE
remove lodash dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "@babel/preset-typescript": "^7.17.12",
     "@ngneat/falso": "^5.4.0",
     "@types/expect": "^24.3.0",
-    "@types/lodash": "^4.14.182",
     "@types/mocha": "^9.1.1",
     "@types/node": "^17.0.36",
     "dotenv": "^16.0.1",
@@ -86,7 +85,6 @@
   },
   "dependencies": {
     "axios": "^0.27.2",
-    "lodash": "^4.17.21",
     "winston": "^3.7.2"
   },
   "peerDependencies": {

--- a/src/client/httpClient.ts
+++ b/src/client/httpClient.ts
@@ -15,7 +15,6 @@
 import http from 'http';
 import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
 import { logger, setLevel } from '@/src/logger';
-import _ from 'lodash';
 import { inspect } from 'util';
 import { LIB_NAME, LIB_VERSION } from '../version';
 import { getStargateAccessToken, StargateAuthError } from '../collections/utils';

--- a/src/collections/client.ts
+++ b/src/collections/client.ts
@@ -15,7 +15,6 @@
 import { Db } from './db';
 import { createNamespace, executeOperation, parseUri } from './utils';
 import { HTTPClient } from '@/src/client';
-import _ from 'lodash';
 import { logger } from '@/src/logger';
 
 export interface ClientOptions {

--- a/src/collections/collection.ts
+++ b/src/collections/collection.ts
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import _ from 'lodash';
 import {
   DeleteResult,
   InsertOneResult,
@@ -84,8 +83,15 @@ export class Collection {
       throw new Error('Collection name is required');
     }
     // use a clone of the underlying http client to support multiple collections from a single db
-    this.httpClient = _.cloneDeep(httpClient);
-    this.httpClient.baseUrl += `/${name}`;
+    this.httpClient = new HTTPClient({
+      baseUrl: httpClient.baseUrl + `/${name}`,
+      username: httpClient.username,
+      password: httpClient.password,
+      authUrl: httpClient.authUrl,
+      applicationToken: httpClient.applicationToken,
+      authHeaderName: httpClient.authHeaderName,
+      isAstra: httpClient.isAstra
+    });
     this.name = name;
     this.collectionName = name;
   }

--- a/src/collections/db.ts
+++ b/src/collections/db.ts
@@ -15,7 +15,6 @@
 import { HTTPClient } from '@/src/client';
 import { Collection } from './collection';
 import { executeOperation, createNamespace, dropNamespace } from './utils';
-import _ from 'lodash';
 
 export class Db {
   rootHttpClient: HTTPClient;
@@ -33,8 +32,15 @@ export class Db {
     }
     this.rootHttpClient = httpClient;
     // use a clone of the underlying http client to support multiple db's from a single connection
-    this.httpClient = _.cloneDeep(httpClient);
-    this.httpClient.baseUrl = `${this.httpClient.baseUrl}/${name}`;
+    this.httpClient = new HTTPClient({
+      baseUrl: httpClient.baseUrl + `/${name}`,
+      username: httpClient.username,
+      password: httpClient.password,
+      authUrl: httpClient.authUrl,
+      applicationToken: httpClient.applicationToken,
+      authHeaderName: httpClient.authHeaderName,
+      isAstra: httpClient.isAstra
+    });
     this.name = name;
   }
 

--- a/src/collections/utils.ts
+++ b/src/collections/utils.ts
@@ -12,13 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import _ from 'lodash';
 import url from 'url';
-import { ObjectId } from 'mongodb';
 import { logger } from '@/src/logger';
 import axios from 'axios';
-import { type } from 'os';
-import { Client } from '@/src/collections/client';
 import { HTTPClient, handleIfErrorResponse } from '@/src/client/httpClient'
 
 interface ParsedUri {

--- a/src/driver/connection.ts
+++ b/src/driver/connection.ts
@@ -16,7 +16,6 @@ import { Client } from '@/src/collections/client';
 import { Collection } from './collection';
 import { default as MongooseConnection } from 'mongoose/lib/connection';
 import STATES from 'mongoose/lib/connectionstate';
-import _ from 'lodash';
 import { executeOperation } from '../collections/utils';
 
 export class Connection extends MongooseConnection {

--- a/tests/collections/client.test.ts
+++ b/tests/collections/client.test.ts
@@ -17,7 +17,6 @@ import { Client } from '@/src/collections/client';
 import { testClient } from '@/tests/fixtures';
 import { parseUri } from '@/src/collections/utils';
 import { AUTH_API_PATH } from '@/src/client/httpClient';
-import _ from 'lodash';
 
 const localBaseUrl = 'http://localhost:8181';
 

--- a/tests/collections/collection.test.ts
+++ b/tests/collections/collection.test.ts
@@ -17,8 +17,6 @@ import { Db } from '@/src/collections/db';
 import { Collection } from '@/src/collections/collection';
 import { Client } from '@/src/collections/client';
 import { testClient, testClientName, createSampleDoc, sampleUsersList, createSampleDocWithMultiLevel, createSampleDocWithMultiLevelWithId, getSampleDocs, sleep, TEST_COLLECTION_NAME } from '@/tests/fixtures';
-import _ from 'lodash';
-
 
 describe(`StargateMongoose - ${testClientName} Connection - collections.collection`, async () => {
   let astraClient: Client;
@@ -579,8 +577,8 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
       }
       assert.ok(error);
       assert.strictEqual(error.message, "Command \"updateMany\" failed with the following error: More than 20 records found for update by the server");
-      assert.ok(_.isEqual(error.command.updateMany.filter, filter));
-      assert.ok(_.isEqual(error.command.updateMany.update, update));
+      assert.deepStrictEqual(error.command.updateMany.filter, filter);
+      assert.deepStrictEqual(error.command.updateMany.update, update);
     });
   });
   describe('findOneAndUpdate tests', () => {
@@ -660,7 +658,7 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
       }
       assert.ok(exception);
       assert.strictEqual(exception.message, 'Command "deleteMany" failed with the following error: More records found to be deleted even after deleting 20 records');
-      assert.ok(_.isEqual(exception.command.deleteMany.filter, filter));
+      assert.deepStrictEqual(exception.command.deleteMany.filter, filter);
     });
     it('should find with sort', async () => {
       await collection.deleteMany({});
@@ -888,7 +886,7 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
       const resNextSet = await collection.insertMany(docListNextSet);
       assert.strictEqual(resNextSet.insertedCount, docListNextSet.length);
       assert.strictEqual(resNextSet.acknowledged, true);
-      assert.strictEqual(_.keys(resNextSet.insertedIds).length, docListNextSet.length);
+      assert.strictEqual(Object.keys(resNextSet.insertedIds).length, docListNextSet.length);
       //verify counts
       assert.strictEqual(await collection.countDocuments({ city: "nyc" }), 20);
       assert.strictEqual(await collection.countDocuments({ city: "trichy" }), 20);

--- a/tests/driver/index.test.ts
+++ b/tests/driver/index.test.ts
@@ -15,7 +15,6 @@
 import assert from 'assert';
 import mongoose from 'mongoose';
 import * as StargateMongooseDriver from '@/src/driver';
-import { delay } from 'lodash';
 import { testClient } from '@/tests/fixtures';
 import { logger } from '@/src/logger';
 import { parseUri } from '@/src/collections/utils';


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Removes lodash as a dep - Lodash is a fairly heavy dependency and including all of Lodash as a dependency in an npm package is suboptimal. Plus we don't use most of Lodash, and the vast majority of Lodash functionality can be replaced with a one-liner in modern JS. This PR replaces `_.keys()` -> `Object.keys()`, `assert.ok(_.isEqual())` -> `assert.deepStrictEqual()`, and `_.cloneDeep()` -> creating a new object.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)