### PR TITLE
Fix to clean up unsupported options

### DIFF
--- a/APIReference.md
+++ b/APIReference.md
@@ -15,6 +15,22 @@
 ## Members
 
 <dl>
+<dt><a href="#deleteOneInternalOptionsKeys">deleteOneInternalOptionsKeys</a></dt>
+<dd><p>findOptions</p></dd>
+<dt><a href="#findInternalOptionsKeys">findInternalOptionsKeys</a></dt>
+<dd><p>findOneOptions</p></dd>
+<dt><a href="#findOneInternalOptionsKeys">findOneInternalOptionsKeys</a></dt>
+<dd><p>findOneAndDeleteOptions</p></dd>
+<dt><a href="#findOneAndDeleteInternalOptionsKeys">findOneAndDeleteInternalOptionsKeys</a></dt>
+<dd><p>findOneAndReplaceOptions</p></dd>
+<dt><a href="#findOneAndReplaceInternalOptionsKeys">findOneAndReplaceInternalOptionsKeys</a></dt>
+<dd><p>findOneAndUpdateOptions</p></dd>
+<dt><a href="#findOneAndUpdateInternalOptionsKeys">findOneAndUpdateInternalOptionsKeys</a></dt>
+<dd><p>insertManyOptions</p></dd>
+<dt><a href="#insertManyInternalOptionsKeys">insertManyInternalOptionsKeys</a></dt>
+<dd><p>updateManyOptions</p></dd>
+<dt><a href="#updateManyInternalOptionsKeys">updateManyInternalOptionsKeys</a></dt>
+<dd><p>updateOneOptions</p></dd>
 <dt><a href="#createAstraUri">createAstraUri</a> ⇒</dt>
 <dd><p>Create a stargate  connection URI</p></dd>
 <dt><a href="#createStargateUri">createStargateUri</a></dt>
@@ -22,6 +38,13 @@
 <dt><a href="#StargateAuthError">StargateAuthError</a> ⇒</dt>
 <dd><p>executeOperation handles running functions
 return a promise.</p></dd>
+</dl>
+
+## Constants
+
+<dl>
+<dt><a href="#deleteOneInternalOptionsKeys">deleteOneInternalOptionsKeys</a></dt>
+<dd><p>deleteOneOptions</p></dd>
 </dl>
 
 ## Functions
@@ -113,7 +136,6 @@ return a promise.</p></dd>
 
 * [Collection](#Collection)
     * [new Collection(httpClient, name)](#new_Collection_new)
-    * [.insertOne(mongooseDoc, options)](#Collection+insertOne) ⇒
     * ~~[.count()](#Collection+count)~~
     * [.createIndex(index, options)](#Collection+createIndex) ⇒
     * [.dropIndexes(index, options)](#Collection+dropIndexes) ⇒
@@ -126,17 +148,6 @@ return a promise.</p></dd>
 | --- |
 | httpClient | 
 | name | 
-
-<a name="Collection+insertOne"></a>
-
-### collection.insertOne(mongooseDoc, options) ⇒
-**Kind**: instance method of [<code>Collection</code>](#Collection)  
-**Returns**: <p>Promise</p>  
-
-| Param |
-| --- |
-| mongooseDoc | 
-| options | 
 
 <a name="Collection+count"></a>
 
@@ -296,6 +307,54 @@ return a promise.</p></dd>
 ### db.createDatabase() ⇒
 **Kind**: instance method of [<code>Db</code>](#Db)  
 **Returns**: <p>Promise</p>  
+<a name="deleteOneInternalOptionsKeys"></a>
+
+## deleteOneInternalOptionsKeys
+<p>findOptions</p>
+
+**Kind**: global variable  
+<a name="findInternalOptionsKeys"></a>
+
+## findInternalOptionsKeys
+<p>findOneOptions</p>
+
+**Kind**: global variable  
+<a name="findOneInternalOptionsKeys"></a>
+
+## findOneInternalOptionsKeys
+<p>findOneAndDeleteOptions</p>
+
+**Kind**: global variable  
+<a name="findOneAndDeleteInternalOptionsKeys"></a>
+
+## findOneAndDeleteInternalOptionsKeys
+<p>findOneAndReplaceOptions</p>
+
+**Kind**: global variable  
+<a name="findOneAndReplaceInternalOptionsKeys"></a>
+
+## findOneAndReplaceInternalOptionsKeys
+<p>findOneAndUpdateOptions</p>
+
+**Kind**: global variable  
+<a name="findOneAndUpdateInternalOptionsKeys"></a>
+
+## findOneAndUpdateInternalOptionsKeys
+<p>insertManyOptions</p>
+
+**Kind**: global variable  
+<a name="insertManyInternalOptionsKeys"></a>
+
+## insertManyInternalOptionsKeys
+<p>updateManyOptions</p>
+
+**Kind**: global variable  
+<a name="updateManyInternalOptionsKeys"></a>
+
+## updateManyInternalOptionsKeys
+<p>updateOneOptions</p>
+
+**Kind**: global variable  
 <a name="createAstraUri"></a>
 
 ## createAstraUri ⇒
@@ -337,6 +396,12 @@ return a promise.</p>
 | --- | --- |
 | operation | <p>a function that takes no parameters and returns a response</p> |
 
+<a name="deleteOneInternalOptionsKeys"></a>
+
+## deleteOneInternalOptionsKeys
+<p>deleteOneOptions</p>
+
+**Kind**: global constant  
 <a name="parseUri"></a>
 
 ## parseUri(uri) ⇒

--- a/src/client/httpClient.ts
+++ b/src/client/httpClient.ts
@@ -44,6 +44,7 @@ interface APIClientOptions {
   password?: string;
   authUrl?: string;
   isAstra?: boolean;
+  logSkippedOptions?: boolean;
 }
 
 export interface APIResponse {
@@ -91,6 +92,7 @@ export class HTTPClient {
   password: string;
   authUrl: string;
   isAstra: boolean;
+  logSkippedOptions: boolean;
 
   constructor(options: APIClientOptions) {
     // do not support usage in browsers
@@ -123,6 +125,7 @@ export class HTTPClient {
     }
     this.authHeaderName = options.authHeaderName || DEFAULT_AUTH_HEADER;
     this.isAstra = options.isAstra || false;
+    this.logSkippedOptions = options.logSkippedOptions || false;
   }
 
   async _request(requestInfo: AxiosRequestConfig): Promise<APIResponse> {

--- a/src/client/httpClient.ts
+++ b/src/client/httpClient.ts
@@ -273,7 +273,7 @@ function cleanupOptions(commandName: string, command: Record<string, any>, optio
     Object.keys(command.options!).forEach((key) => {
       if (optionsToRetain === null || !optionsToRetain.has(key)) {
         if (logSkippedOptions) {
-          logger.warn(`${commandName} does not support ${key} option`);
+          logger.warn(`'${commandName}' does not support option '${key}'`);
         }
         delete command.options[key];
       }

--- a/src/collections/client.ts
+++ b/src/collections/client.ts
@@ -27,6 +27,7 @@ export interface ClientOptions {
   password?: string;
   authUrl?: string;
   isAstra?: boolean;
+  logSkippedOptions?: boolean;
 }
 
 interface ClientCallback {
@@ -59,7 +60,8 @@ export class Client {
       username: options.username,
       password: options.password,
       authUrl: options.authUrl,
-      isAstra: options.isAstra
+      isAstra: options.isAstra,
+      logSkippedOptions: options.logSkippedOptions
     });
   }
 

--- a/src/collections/client.ts
+++ b/src/collections/client.ts
@@ -81,7 +81,8 @@ export class Client {
       username: options?.username,
       password: options?.password,
       authUrl: options?.authUrl,
-      isAstra: options?.isAstra
+      isAstra: options?.isAstra,
+      logSkippedOptions: options?.logSkippedOptions
     });
     await client.connect();
     return client;

--- a/src/collections/collection.ts
+++ b/src/collections/collection.ts
@@ -42,7 +42,7 @@ export interface FindOneAndDeleteOptions {
   sort?: Record<string, 1 | -1>;
 }
 
-export type FindOneAndReplaceOptions = {
+export interface FindOneAndReplaceOptions {
   upsert?: boolean;
   returnDocument?: 'before' | 'after';
   sort?: Record<string, 1 | -1>;

--- a/src/collections/collection.ts
+++ b/src/collections/collection.ts
@@ -42,17 +42,17 @@ export interface FindOneAndDeleteOptions {
   sort?: Record<string, 1 | -1>;
 }
 
-export const FindOneAndReplaceOptionsList = {
-  upsert: false,
-  returnDocument: 'before',
-  sort: {}
-} as {
+export type FindOneAndReplaceOptions = {
   upsert?: boolean;
   returnDocument?: 'before' | 'after';
   sort?: Record<string, 1 | -1>;
 }
-export type FindOneAndReplaceOptions = typeof FindOneAndReplaceOptionsList;
-export const FindOneAndReplaceOptionKeys: Set<string> = new Set(Object.keys(FindOneAndReplaceOptionsList));
+
+export const FindOneAndReplaceOptionKeys: Set<string> = new Set(Object.keys({
+  upsert: false,
+  returnDocument: 'before',
+  sort: {}
+} as FindOneAndReplaceOptions));
 
 
 export interface FindOneAndUpdateOptions {
@@ -97,7 +97,8 @@ export class Collection {
       authUrl: httpClient.authUrl,
       applicationToken: httpClient.applicationToken,
       authHeaderName: httpClient.authHeaderName,
-      isAstra: httpClient.isAstra
+      isAstra: httpClient.isAstra,
+      logSkippedOptions: httpClient.logSkippedOptions
     });
     this.name = name;
     this.collectionName = name;

--- a/src/collections/collection.ts
+++ b/src/collections/collection.ts
@@ -24,15 +24,12 @@ import {HTTPClient} from '@/src/client';
 import {executeOperation} from './utils';
 import {InsertManyResult} from 'mongoose';
 import {
-  deleteOneInternalOptionsKeys,
   DeleteOneOptions,
-  findOneAndDeleteInternalOptionsKeys,
   FindOneAndDeleteOptions,
   findOneAndReplaceInternalOptionsKeys,
   FindOneAndReplaceOptions,
   findOneAndUpdateInternalOptionsKeys,
   FindOneAndUpdateOptions,
-  findOneInternalOptionsKeys,
   FindOneOptions,
   insertManyInternalOptionsKeys,
   InsertManyOptions,
@@ -176,7 +173,7 @@ export class Collection {
       if (options?.sort) {
         command.deleteOne.sort = options.sort;
       }
-      const deleteOneResp = await this.httpClient.executeCommand(command, deleteOneInternalOptionsKeys);
+      const deleteOneResp = await this.httpClient.executeCommand(command, null);
       return {
         acknowledged: true,
         deletedCount: deleteOneResp.status.deletedCount
@@ -226,7 +223,7 @@ export class Collection {
         command.findOne.sort = options.sort;
       }
 
-      const resp = await this.httpClient.executeCommand(command, findOneInternalOptionsKeys);
+      const resp = await this.httpClient.executeCommand(command, null);
       return resp.data.document;
     });
   }
@@ -294,7 +291,7 @@ export class Collection {
       command.findOneAndDelete.sort = options.sort;
     }
 
-    const resp = await this.httpClient.executeCommand(command, findOneAndDeleteInternalOptionsKeys);
+    const resp = await this.httpClient.executeCommand(command, null);
     return {
       value : resp.data?.document,
       ok : 1

--- a/src/collections/db.ts
+++ b/src/collections/db.ts
@@ -71,7 +71,7 @@ export class Db {
           options: options
         }
       };
-      return await this.httpClient.executeCommand(command);
+      return await this.httpClient.executeCommand(command, null);
     });
   }
 
@@ -86,7 +86,7 @@ export class Db {
         name: collectionName
       }
     };
-    return await this.httpClient.executeCommand(command);
+    return await this.httpClient.executeCommand(command, null);
   }
 
   /**

--- a/src/collections/db.ts
+++ b/src/collections/db.ts
@@ -39,7 +39,8 @@ export class Db {
       authUrl: httpClient.authUrl,
       applicationToken: httpClient.applicationToken,
       authHeaderName: httpClient.authHeaderName,
-      isAstra: httpClient.isAstra
+      isAstra: httpClient.isAstra,
+      logSkippedOptions: httpClient.logSkippedOptions,
     });
     this.name = name;
   }

--- a/src/collections/index.ts
+++ b/src/collections/index.ts
@@ -24,8 +24,9 @@ export {
   FindOptions,
   InsertManyOptions,
   UpdateManyOptions,
-  UpdateOneOptions
-} from './collection';
+  UpdateOneOptions,
+  DeleteOneOptions
+} from './options';
 
 // alias for MongoClient shimming
 export { Client as MongoClient } from './client';

--- a/src/collections/options.ts
+++ b/src/collections/options.ts
@@ -19,8 +19,6 @@ export interface DeleteOneOptions {
     sort?: Record<string, 1 | -1>;
 }
 
-export const deleteOneInternalOptionsKeys: Set<string> | null = null;
-
 /**
  * findOptions
  */
@@ -31,20 +29,13 @@ export interface FindOptions {
     projection?: Record<string, 1 | -1>;
 }
 
-class FindOptionsInternalClass {
+export interface FindOptionsInternal {
     limit?: number;
     skip?: number;
     pagingState?: string;
-    constructor(limit?: number, skip?: number, pagingState?: string) {
-        this.limit = limit;
-        this.skip = skip;
-        this.pagingState = pagingState;
-    }
 }
 
-export interface FindOptionsInternal extends FindOptionsInternalClass {
-};
-export const findInternalOptionsKeys: Set<string> = new Set<string>(Object.keys(new FindOptionsInternalClass(-1, -1, "pagestate")) as Array<keyof FindOptionsInternal>);
+export const findInternalOptionsKeys: Set<keyof FindOptionsInternal> = new Set(['limit' as const, 'skip' as const, 'pagingState' as const]);
 
 /**
  * findOneOptions
@@ -53,16 +44,12 @@ export interface FindOneOptions {
     sort?: Record<string, 1 | -1>;
 }
 
-export const findOneInternalOptionsKeys: Set<string> | null = null;
-
 /**
  * findOneAndDeleteOptions
  */
 export interface FindOneAndDeleteOptions {
     sort?: Record<string, 1 | -1>;
 }
-
-export const findOneAndDeleteInternalOptionsKeys: Set<string> | null = null;
 
 /**
  * findOneAndReplaceOptions
@@ -73,17 +60,7 @@ export interface FindOneAndReplaceOptions {
     sort?: Record<string, 1 | -1>;
 }
 
-class FindOneAndReplaceInternalOptionsClass {
-    constructor(
-        readonly upsert?: boolean,
-        readonly returnDocument?: 'before' | 'after',
-    ) {
-    }
-}
-
-export interface FindOneAndReplaceInternalOptions extends FindOneAndReplaceInternalOptionsClass {
-};
-export const findOneAndReplaceInternalOptionsKeys: Set<string> = new Set<string>(Object.keys(new FindOneAndReplaceInternalOptionsClass()) as Array<keyof FindOneAndReplaceInternalOptions>);
+export const findOneAndReplaceInternalOptionsKeys: Set<keyof Omit<FindOneAndReplaceOptions, 'sort'>> = new Set(['upsert' as const, 'returnDocument' as const]);
 
 /**
  * findOneAndUpdateOptions
@@ -94,17 +71,7 @@ export interface FindOneAndUpdateOptions {
     sort?: Record<string, 1 | -1>;
 }
 
-class FindOneAndUpdateInternalOptionsClass {
-    constructor(
-        readonly upsert?: boolean,
-        readonly returnDocument?: 'before' | 'after'
-    ) {
-    }
-}
-
-export interface FindOneAndUpdateInternalOptions extends FindOneAndUpdateInternalOptionsClass {
-};
-export const findOneAndUpdateInternalOptionsKeys: Set<string> = new Set<string>(Object.keys(new FindOneAndUpdateInternalOptionsClass()) as Array<keyof FindOneAndUpdateInternalOptions>);
+export const findOneAndUpdateInternalOptionsKeys: Set<keyof Omit<FindOneAndUpdateOptions, 'sort'>> = new Set(['upsert' as const, 'returnDocument' as const]);
 
 /**
  * insertManyOptions
@@ -113,16 +80,7 @@ export interface InsertManyOptions {
     ordered?: boolean;
 }
 
-class InsertManyInternalOptionsClass {
-    constructor(
-        readonly ordered?: boolean
-    ) {
-    }
-}
-
-export interface InsertManyInternalOptions extends InsertManyInternalOptionsClass {
-};
-export const insertManyInternalOptionsKeys: Set<string> = new Set<string>(Object.keys(new InsertManyInternalOptionsClass()) as Array<keyof InsertManyInternalOptions>);
+export const insertManyInternalOptionsKeys: Set<keyof InsertManyOptions> = new Set(['ordered' as const]);
 
 /**
  * updateManyOptions
@@ -130,30 +88,16 @@ export const insertManyInternalOptionsKeys: Set<string> = new Set<string>(Object
 export interface UpdateManyOptions {
     upsert?: boolean;
 }
-class UpdateManyInternalOptionsClass {
-    constructor(
-        readonly upsert?: boolean
-    ) {
-    }
-}
-export interface UpdateManyInternalOptions extends UpdateManyInternalOptionsClass {};
-export const updateManyInternalOptionsKeys: Set<string> = new Set<string>(Object.keys(new UpdateManyInternalOptionsClass()) as Array<keyof UpdateManyInternalOptions>);
+
+export const updateManyInternalOptionsKeys: Set<keyof UpdateManyOptions> = new Set(['upsert' as const]);
 
 /**
  * updateOneOptions
  */
 export interface UpdateOneOptions {
     upsert?: boolean;
-    returnDocument?: 'before' | 'after';
     sort?: Record<string, 1 | -1>;
 }
-class UpdateOneInternalOptionsClass {
-    constructor(
-        readonly upsert?: boolean,
-        readonly returnDocument?: 'before' | 'after'
-    ) {
-    }
-}
-export interface UpdateOneInternalOptions extends UpdateOneInternalOptionsClass {};
-export const updateOneInternalOptionsKeys: Set<string> = new Set<string>(Object.keys(new UpdateOneInternalOptionsClass()) as Array<keyof UpdateOneInternalOptions>);
+
+export const updateOneInternalOptionsKeys: Set<keyof Omit<UpdateOneOptions, 'sort'>> = new Set(['upsert' as const]);
 

--- a/src/collections/options.ts
+++ b/src/collections/options.ts
@@ -1,0 +1,159 @@
+// Copyright DataStax, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * deleteOneOptions
+ */
+export interface DeleteOneOptions {
+    sort?: Record<string, 1 | -1>;
+}
+
+export const deleteOneInternalOptionsKeys: Set<string> | null = null;
+
+/**
+ * findOptions
+ */
+export interface FindOptions {
+    limit?: number;
+    skip?: number;
+    sort?: Record<string, 1 | -1>;
+    projection?: Record<string, 1 | -1>;
+}
+
+class FindOptionsInternalClass {
+    limit?: number;
+    skip?: number;
+    pagingState?: string;
+    constructor(limit?: number, skip?: number, pagingState?: string) {
+        this.limit = limit;
+        this.skip = skip;
+        this.pagingState = pagingState;
+    }
+}
+
+export interface FindOptionsInternal extends FindOptionsInternalClass {
+};
+export const findInternalOptionsKeys: Set<string> = new Set<string>(Object.keys(new FindOptionsInternalClass(-1, -1, "pagestate")) as Array<keyof FindOptionsInternal>);
+
+/**
+ * findOneOptions
+ */
+export interface FindOneOptions {
+    sort?: Record<string, 1 | -1>;
+}
+
+export const findOneInternalOptionsKeys: Set<string> | null = null;
+
+/**
+ * findOneAndDeleteOptions
+ */
+export interface FindOneAndDeleteOptions {
+    sort?: Record<string, 1 | -1>;
+}
+
+export const findOneAndDeleteInternalOptionsKeys: Set<string> | null = null;
+
+/**
+ * findOneAndReplaceOptions
+ */
+export interface FindOneAndReplaceOptions {
+    upsert?: boolean;
+    returnDocument?: 'before' | 'after';
+    sort?: Record<string, 1 | -1>;
+}
+
+class FindOneAndReplaceInternalOptionsClass {
+    constructor(
+        readonly upsert?: boolean,
+        readonly returnDocument?: 'before' | 'after',
+    ) {
+    }
+}
+
+export interface FindOneAndReplaceInternalOptions extends FindOneAndReplaceInternalOptionsClass {
+};
+export const findOneAndReplaceInternalOptionsKeys: Set<string> = new Set<string>(Object.keys(new FindOneAndReplaceInternalOptionsClass()) as Array<keyof FindOneAndReplaceInternalOptions>);
+
+/**
+ * findOneAndUpdateOptions
+ */
+export interface FindOneAndUpdateOptions {
+    upsert?: boolean;
+    returnDocument?: 'before' | 'after';
+    sort?: Record<string, 1 | -1>;
+}
+
+class FindOneAndUpdateInternalOptionsClass {
+    constructor(
+        readonly upsert?: boolean,
+        readonly returnDocument?: 'before' | 'after'
+    ) {
+    }
+}
+
+export interface FindOneAndUpdateInternalOptions extends FindOneAndUpdateInternalOptionsClass {
+};
+export const findOneAndUpdateInternalOptionsKeys: Set<string> = new Set<string>(Object.keys(new FindOneAndUpdateInternalOptionsClass()) as Array<keyof FindOneAndUpdateInternalOptions>);
+
+/**
+ * insertManyOptions
+ */
+export interface InsertManyOptions {
+    ordered?: boolean;
+}
+
+class InsertManyInternalOptionsClass {
+    constructor(
+        readonly ordered?: boolean
+    ) {
+    }
+}
+
+export interface InsertManyInternalOptions extends InsertManyInternalOptionsClass {
+};
+export const insertManyInternalOptionsKeys: Set<string> = new Set<string>(Object.keys(new InsertManyInternalOptionsClass()) as Array<keyof InsertManyInternalOptions>);
+
+/**
+ * updateManyOptions
+ */
+export interface UpdateManyOptions {
+    upsert?: boolean;
+}
+class UpdateManyInternalOptionsClass {
+    constructor(
+        readonly upsert?: boolean
+    ) {
+    }
+}
+export interface UpdateManyInternalOptions extends UpdateManyInternalOptionsClass {};
+export const updateManyInternalOptionsKeys: Set<string> = new Set<string>(Object.keys(new UpdateManyInternalOptionsClass()) as Array<keyof UpdateManyInternalOptions>);
+
+/**
+ * updateOneOptions
+ */
+export interface UpdateOneOptions {
+    upsert?: boolean;
+    returnDocument?: 'before' | 'after';
+    sort?: Record<string, 1 | -1>;
+}
+class UpdateOneInternalOptionsClass {
+    constructor(
+        readonly upsert?: boolean,
+        readonly returnDocument?: 'before' | 'after'
+    ) {
+    }
+}
+export interface UpdateOneInternalOptions extends UpdateOneInternalOptionsClass {};
+export const updateOneInternalOptionsKeys: Set<string> = new Set<string>(Object.keys(new UpdateOneInternalOptionsClass()) as Array<keyof UpdateOneInternalOptions>);
+

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -23,7 +23,7 @@ import {
   InsertManyOptions,
   UpdateManyOptions,
   UpdateOneOptions
-} from '@/src/collections/collection';
+} from '@/src/collections/options';
 
 export class Collection extends MongooseCollection {
   debugType = 'StargateMongooseCollection';
@@ -76,7 +76,7 @@ export class Collection extends MongooseCollection {
   }
 
   deleteOne(filter: Record<string, any>, options?: DeleteOneOptions) {
-    return this.collection.deleteOne(filter);
+    return this.collection.deleteOne(filter, options);
   }
 
   updateOne(filter: Record<string, any>, update: Record<string, any>, options?: UpdateOneOptions) {

--- a/tests/collections/client.test.ts
+++ b/tests/collections/client.test.ts
@@ -186,6 +186,7 @@ describe('StargateMongoose clients test', () => {
     it('should not initialize a Client connection with a uri using the constructor with no options', () => {
       let error: any;
       try {
+        // @ts-ignore intentionally passing no options
         const client = new Client(baseUrl, 'keyspace1');
         assert.ok(client);
       } catch (e) {

--- a/tests/collections/collection.test.ts
+++ b/tests/collections/collection.test.ts
@@ -19,7 +19,7 @@ import { Client } from '@/src/collections/client';
 import { testClient, testClientName, createSampleDoc, sampleUsersList, createSampleDocWithMultiLevel, createSampleDocWithMultiLevelWithId, getSampleDocs, sleep, TEST_COLLECTION_NAME } from '@/tests/fixtures';
 
 describe(`StargateMongoose - ${testClientName} Connection - collections.collection`, async () => {
-  let astraClient: Client;
+  let astraClient: Client | null;
   let db: Db;
   let collection: Collection;
   const sampleDoc = createSampleDoc();
@@ -28,7 +28,7 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
       return this.skip();
     }
     astraClient = await testClient?.client;
-    if (astraClient == null) {
+    if (astraClient === null) {
       return this.skip();
     }
 
@@ -53,6 +53,7 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
     it('should not initialize a Collection without a name', () => {
       let error: any;
       try {
+        // @ts-ignore: Testing invalid input
         const collection = new Collection(db.httpClient);
         assert.ok(collection);
       } catch (e) {
@@ -191,7 +192,7 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
       assert.strictEqual(error.errors[0].message, "Request invalid, the field postCommand.command.documents not valid: must not be empty.");
     });
     it('should insertMany documents ordered', async () => {
-      let docList = Array.from({ length: 20 }, () => ({ "username": "id" }));
+      let docList:{ _id?: string, username:string }[]  = Array.from({ length: 20 }, () => ({ "username": "id" }));
       docList.forEach((doc, index) => {
         doc._id = "docml" + (index + 1);
         doc.username = doc.username + (index + 1);
@@ -204,7 +205,7 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
       });
     });
     it('should error out when one of the docs in insertMany is invalid with ordered true', async () => {
-      let docList = Array.from({ length: 20 }, () => ({ "username": "id" }));
+      let docList:{ _id?: string, username:string }[] = Array.from({ length: 20 }, () => ({ "username": "id" }));
       docList.forEach((doc, index) => {
         doc._id = "docml" + (index + 1);
         doc.username = doc.username + (index + 1);
@@ -226,7 +227,7 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
       });
     });
     it('should error out when one of the docs in insertMany is invalid with ordered false', async () => {
-      let docList = Array.from({ length: 20 }, () => ({ "username": "id" }));
+      let docList:{ _id?: string, username:string }[] = Array.from({ length: 20 }, () => ({ "username": "id" }));
       docList.forEach((doc, index) => {
         doc._id = "docml" + (index + 1);
         doc.username = doc.username + (index + 1);

--- a/tests/collections/cursor.test.ts
+++ b/tests/collections/cursor.test.ts
@@ -17,10 +17,10 @@ import { Db } from '@/src/collections/db';
 import { FindCursor } from '@/src/collections/cursor';
 import { Collection } from '@/src/collections/collection';
 import { Client } from '@/src/collections/client';
-import { testClient, Employee, sampleUsersList, TEST_COLLECTION_NAME } from '@/tests/fixtures';
+import { testClient, sampleUsersList, TEST_COLLECTION_NAME } from '@/tests/fixtures';
 
 describe(`StargateMongoose - ${testClient} Connection - collections.cursor`, async () => {
-  let astraClient: Client;
+  let astraClient: Client | null;
   let db: Db;
   let collection: Collection;
   const sampleUsers = sampleUsersList;
@@ -29,7 +29,7 @@ describe(`StargateMongoose - ${testClient} Connection - collections.cursor`, asy
       return this.skip();
     }
     astraClient = await testClient.client;
-    if (astraClient == null) {
+    if (astraClient === null) {
       return this.skip();
     }
     db = astraClient.db();
@@ -142,12 +142,12 @@ describe(`StargateMongoose - ${testClient} Connection - collections.cursor`, asy
       await collection.insertMany(sampleUsers);
       const cursor = new FindCursor(collection, {});
       assert.strictEqual(cursor.status, 'initialized');
-      const cursorRes = await cursor.toArray();
+      await cursor.toArray();
       assert.strictEqual(cursor.status, 'executed');
       const count = await cursor.count();
       assert.strictEqual(count, sampleUsers.length);
       //run again
-      const cursorRes2 = await cursor.toArray();
+      await cursor.toArray();
       assert.strictEqual(cursor.status, 'executed');
       const count2 = await cursor.count();
       assert.strictEqual(count2, sampleUsers.length);

--- a/tests/collections/db.test.ts
+++ b/tests/collections/db.test.ts
@@ -15,40 +15,44 @@
 import assert from 'assert';
 import { Db } from '@/src/collections/db';
 import { Client } from '@/src/collections/client';
-import { parseUri, createNamespace, dropNamespace } from '@/src/collections/utils';
+import { parseUri, createNamespace } from '@/src/collections/utils';
 import { testClient, TEST_COLLECTION_NAME } from '@/tests/fixtures';
 import { randAlphaNumeric } from '@ngneat/falso';
+import {HTTPClient} from "@/src/client";
 
 describe('StargateMongoose - collections.Db', async () => {
-  let astraClient: Client;
+  let astraClient: Client | null;
   let dbUri: string;
   let isAstra: boolean;
+  let httpClient: HTTPClient;
   before(async function () {
     if (testClient == null) {
       return this.skip();
     }
     astraClient = await testClient.client;
-    if (astraClient == null) {
+    if (astraClient === null) {
       return this.skip();
     }
     dbUri = testClient.uri;
     isAstra = testClient.isAstra;
+    httpClient = astraClient.httpClient;
   });
   afterEach(async () => {
-    const db = astraClient.db();
+    const db = astraClient?.db();
     // run drop collection async to save time
     await db?.dropCollection(TEST_COLLECTION_NAME);
   });
 
   describe('Db initialization', () => {
     it('should initialize a Db', () => {
-      const db = new Db(astraClient.httpClient, 'test-db');
+      const db = new Db(httpClient, 'test-db');
       assert.ok(db);
     });
     it('should not initialize a Db without a name', () => {
       let error: any;
       try {
-        const db = new Db(astraClient.httpClient);
+        // @ts-ignore - intentionally passing undefined for testing purposes
+        const db = new Db(httpClient);
         assert.ok(db);
       } catch (e) {
         error = e;
@@ -59,14 +63,15 @@ describe('StargateMongoose - collections.Db', async () => {
 
   describe('Db collection operations', () => {
     it('should initialize a Collection', () => {
-      const db = new Db(astraClient.httpClient, 'test-db');
+      const db = new Db(httpClient, 'test-db');
       const collection = db.collection('test-collection');
       assert.ok(collection);
     });
     it('should not initialize a Collection without a name', () => {
       let error: any;
       try {
-        const db = new Db(astraClient.httpClient, 'test-db');
+        const db = new Db(httpClient, 'test-db');
+        // @ts-ignore - intentionally passing undefined for testing purposes
         const collection = db.collection();
         assert.ok(collection);
       } catch (e) {
@@ -76,7 +81,7 @@ describe('StargateMongoose - collections.Db', async () => {
     });
     it('should create a Collection', async () => {
       const collectionName = TEST_COLLECTION_NAME;
-      const db = new Db(astraClient.httpClient, parseUri(dbUri).keyspaceName);
+      const db = new Db(httpClient, parseUri(dbUri).keyspaceName);
       const res = await db.createCollection(collectionName);
       assert.ok(res);
       assert.strictEqual(res.status.ok, 1);
@@ -86,7 +91,7 @@ describe('StargateMongoose - collections.Db', async () => {
     });
 
     it('should drop a Collection', async () => {
-      const db = new Db(astraClient.httpClient, parseUri(dbUri).keyspaceName);
+      const db = new Db(httpClient, parseUri(dbUri).keyspaceName);
       const suffix = randAlphaNumeric({ length: 4 }).join('');
       await db.createCollection(`test_db_collection_${suffix}`);
       const res = await db.dropCollection(`test_db_collection_${suffix}`);
@@ -102,14 +107,14 @@ describe('StargateMongoose - collections.Db', async () => {
         return;
       }
       const keyspaceName = parseUri(dbUri).keyspaceName;
-      await createNamespace(astraClient.httpClient, keyspaceName);
+      await createNamespace(httpClient, keyspaceName);
     });
     it('should drop the underlying database (AKA namespace)', async () => {
       if (isAstra) {
         suite.ctx.skip();
       }
       const keyspaceName = parseUri(dbUri).keyspaceName;
-      const db = new Db(astraClient.httpClient, keyspaceName);
+      const db = new Db(httpClient, keyspaceName);
       const suffix = randAlphaNumeric({ length: 4 }).join('');
       await db.createCollection(`test_db_collection_${suffix}`);
       const res = await db.dropDatabase();
@@ -118,14 +123,13 @@ describe('StargateMongoose - collections.Db', async () => {
       try {
         await db.createCollection(`test_db_collection_${suffix}`);
         assert.ok(false);
-      } catch (err) {
+      } catch (err: any) {
         assert.strictEqual(err.errors.length, 1);
         assert.strictEqual(
           err.errors[0].message,
           'INVALID_ARGUMENT: Keyspace \'' + keyspaceName + '\' doesn\'t exist'
         );
       }
-
     });
   });
 
@@ -136,7 +140,7 @@ describe('StargateMongoose - collections.Db', async () => {
         return;
       }
       const keyspaceName = parseUri(dbUri).keyspaceName;
-      await createNamespace(astraClient.httpClient, keyspaceName);
+      await createNamespace(httpClient, keyspaceName);
     });
 
     it('should create the underlying database (AKA namespace)', async () => {
@@ -144,7 +148,7 @@ describe('StargateMongoose - collections.Db', async () => {
         suite.ctx.skip();
       }
       const keyspaceName = parseUri(dbUri).keyspaceName;
-      const db = new Db(astraClient.httpClient, keyspaceName);
+      const db = new Db(httpClient, keyspaceName);
       const suffix = randAlphaNumeric({ length: 4 }).join('');
 
       await db.dropDatabase().catch(err => {
@@ -158,7 +162,7 @@ describe('StargateMongoose - collections.Db', async () => {
       try {
         await db.createCollection(`test_db_collection_${suffix}`);
         assert.ok(false);
-      } catch (err) {
+      } catch (err: any) {
         assert.strictEqual(err.errors.length, 1);
         assert.strictEqual(
           err.errors[0].message,

--- a/tests/collections/options.test.ts
+++ b/tests/collections/options.test.ts
@@ -1,0 +1,133 @@
+// Copyright DataStax, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import assert from 'assert';
+import { Db } from '@/src/collections/db';
+import { Collection } from '@/src/collections/collection';
+import { Client } from '@/src/collections/client';
+import { testClient, testClientName, createSampleDoc, sampleUsersList, createSampleDocWithMultiLevel, createSampleDocWithMultiLevelWithId, getSampleDocs, sleep, TEST_COLLECTION_NAME } from '@/tests/fixtures';
+import mongoose from "mongoose";
+import * as StargateMongooseDriver from "@/src/driver";
+
+describe(`Options tests`, async () => {
+    let astraClient: Client | null;
+    let db: Db;
+    let collection: Collection;
+    const sampleDoc = createSampleDoc();
+    let dbUri: string;
+    let isAstra: boolean;
+    before(async function () {
+        if (testClient == null) {
+            return this.skip();
+        }
+        astraClient = await testClient?.client;
+        if (astraClient === null) {
+            return this.skip();
+        }
+
+        db = astraClient.db();
+        await db.dropCollection(TEST_COLLECTION_NAME);
+        dbUri = testClient.uri;
+        isAstra = testClient.isAstra;
+    });
+
+    async function createClientsAndModels(isAstra: boolean) {
+        let Product, astraMongoose, jsonAPIMongoose;
+        const productSchema = new mongoose.Schema({
+            name: String,
+            price: Number,
+            expiryDate: Date,
+            isCertified: Boolean
+        });
+        if(isAstra){
+            astraMongoose = new mongoose.Mongoose();
+            astraMongoose.setDriver(StargateMongooseDriver);
+            astraMongoose.set('autoCreate', true);
+            astraMongoose.set('autoIndex', false);
+            Product = astraMongoose.model('Product', productSchema);
+            // @ts-ignore - these are config options supported by stargate-mongoose but not mongoose
+            await astraMongoose.connect(dbUri, { isAstra: true, logSkippedOptions: true });
+            await Promise.all(Object.values(astraMongoose.connection.models).map(Model => Model.init()));
+        } else{
+            // @ts-ignore
+            jsonAPIMongoose = new mongoose.Mongoose();
+            jsonAPIMongoose.setDriver(StargateMongooseDriver);
+            jsonAPIMongoose.set('autoCreate', true);
+            jsonAPIMongoose.set('autoIndex', false);
+            Product = jsonAPIMongoose.model('Product', productSchema);
+            // @ts-ignore - these are config options supported by stargate-mongoose but not mongoose
+            await jsonAPIMongoose.connect(dbUri, {
+                username: process.env.STARGATE_USERNAME,
+                password: process.env.STARGATE_PASSWORD,
+                authUrl: process.env.STARGATE_AUTH_URL,
+                logSkippedOptions: true
+            });
+            await Promise.all(Object.values(jsonAPIMongoose.connection.models).map(Model => Model.init()));
+        }
+        return { Product, astraMongoose, jsonAPIMongoose };
+    }
+
+    async function dropCollections(isAstra: boolean, astraMongoose: mongoose.Mongoose, jsonAPIMongoose: mongoose.Mongoose, collectionName: string) {
+        if (isAstra) {
+            astraMongoose?.connection.dropCollection(collectionName);
+        } else {
+            jsonAPIMongoose?.connection.dropCollection(collectionName);
+        }
+    }
+
+    describe('options cleanup tests', () => {
+        it('should cleanup deleteOneOptions', async () => {
+            let Product, astraMongoose, jsonAPIMongoose;
+            try {
+                ({ Product, astraMongoose, jsonAPIMongoose } = await createClientsAndModels(isAstra));
+                // @ts-ignore
+                const product1 = new Product({
+                    name: 'Product 1',
+                    price: 10,
+                    expiryDate: new Date('2024-04-20T00:00:00.000Z'),
+                    isCertified: true
+                });
+                await product1.save();
+                await Product.deleteOne({ name: 'Product 1' }, { runValidations: true });
+            } finally {
+                // @ts-ignore
+                await dropCollections(isAstra, astraMongoose, jsonAPIMongoose, 'products');
+            }
+        });
+        it('should cleanup insertManyOptions', async () => {
+            let Product, astraMongoose, jsonAPIMongoose;
+            try {
+                ({ Product, astraMongoose, jsonAPIMongoose } = await createClientsAndModels(isAstra));
+                // @ts-ignore
+                const product1 = new Product({
+                    name: 'Product 1',
+                    price: 10,
+                    expiryDate: new Date('2024-04-20T00:00:00.000Z'),
+                    isCertified: true
+                });
+                const product2 = new Product({
+                    name: 'Product 1',
+                    price: 10,
+                    expiryDate: new Date('2024-04-20T00:00:00.000Z'),
+                    isCertified: true
+                });
+                //rawResult options should be cleaned up by stargate-mongoose
+                await Product.insertMany([product1, product2], { ordered: false, rawResult: false });
+            } finally {
+                // @ts-ignore
+                await dropCollections(isAstra, astraMongoose, jsonAPIMongoose, 'products');
+            }
+        });
+    });
+});

--- a/tests/collections/options.test.ts
+++ b/tests/collections/options.test.ts
@@ -48,7 +48,8 @@ describe(`Options tests`, async () => {
             name: String,
             price: Number,
             expiryDate: Date,
-            isCertified: Boolean
+            isCertified: Boolean,
+            category: String
         });
         if(isAstra){
             astraMongoose = new mongoose.Mongoose();
@@ -66,13 +67,14 @@ describe(`Options tests`, async () => {
             jsonAPIMongoose.set('autoCreate', true);
             jsonAPIMongoose.set('autoIndex', false);
             Product = jsonAPIMongoose.model('Product', productSchema);
-            // @ts-ignore - these are config options supported by stargate-mongoose but not mongoose
-            await jsonAPIMongoose.connect(dbUri, {
+            const options = {
                 username: process.env.STARGATE_USERNAME,
                 password: process.env.STARGATE_PASSWORD,
                 authUrl: process.env.STARGATE_AUTH_URL,
                 logSkippedOptions: true
-            });
+            };
+            // @ts-ignore - these are config options supported by stargate-mongoose but not mongoose
+            await jsonAPIMongoose.connect(dbUri, options);
             await Promise.all(Object.values(jsonAPIMongoose.connection.models).map(Model => Model.init()));
         }
         return { Product, astraMongoose, jsonAPIMongoose };
@@ -87,43 +89,235 @@ describe(`Options tests`, async () => {
     }
 
     describe('options cleanup tests', () => {
-        it('should cleanup deleteOneOptions', async () => {
-            let Product, astraMongoose, jsonAPIMongoose;
-            try {
-                ({ Product, astraMongoose, jsonAPIMongoose } = await createClientsAndModels(isAstra));
-                // @ts-ignore
-                const product1 = new Product({
-                    name: 'Product 1',
-                    price: 10,
-                    expiryDate: new Date('2024-04-20T00:00:00.000Z'),
-                    isCertified: true
-                });
-                await product1.save();
-                await Product.deleteOne({ name: 'Product 1' }, { runValidations: true });
-            } finally {
-                // @ts-ignore
-                await dropCollections(isAstra, astraMongoose, jsonAPIMongoose, 'products');
-            }
-        });
         it('should cleanup insertManyOptions', async () => {
             let Product, astraMongoose, jsonAPIMongoose;
             try {
                 ({ Product, astraMongoose, jsonAPIMongoose } = await createClientsAndModels(isAstra));
                 // @ts-ignore
-                const product1 = new Product({
-                    name: 'Product 1',
-                    price: 10,
-                    expiryDate: new Date('2024-04-20T00:00:00.000Z'),
-                    isCertified: true
+                const products: Product[] = [new Product({ name: 'Product 2', price: 10, isCertified: true }), new Product({ name: 'Product 1', price: 10, isCertified: false})];
+                //rawResult options should be cleaned up by stargate-mongoose, but 'ordered' should be preserved
+                const insertManyResp = await Product.insertMany(products, { ordered: true, rawResult: false });
+                assert.strictEqual(insertManyResp.length, 2);
+                assert.strictEqual(insertManyResp[0].name, 'Product 2');
+                assert.strictEqual(insertManyResp[1].name, 'Product 1');
+                //check if products are inserted
+                const productsSaved = await Product.find({});
+                assert.strictEqual(productsSaved.length, 2);
+                //check if product name is one of the inserted products names
+                let productNames:Set<string> = new Set<string>();
+                products.map(product => product.name!).forEach(name => productNames.add(name));
+                assert.ok(productNames.has(productsSaved[0].name!));
+                productNames.delete(productsSaved[0].name!);
+                assert.ok(productNames.has(productsSaved[1].name!));
+                productNames.delete(productsSaved[1].name!);
+                assert.strictEqual(productNames.size, 0);
+            } finally {
+                // @ts-ignore
+                await dropCollections(isAstra, astraMongoose, jsonAPIMongoose, 'products');
+            }
+        });
+        it('should cleanup updateOneOptions', async () => {
+            let Product, astraMongoose, jsonAPIMongoose;
+            try {
+                ({ Product, astraMongoose, jsonAPIMongoose } = await createClientsAndModels(isAstra));
+                // @ts-ignore
+                const products: Product[] = [new Product({ name: 'Product 2', price: 10, isCertified: true }), new Product({ name: 'Product 1', price: 10, isCertified: false }), new Product({ name: 'Product 3', price: 10, isCertified: true })];
+                const insertManyResp = await Product.insertMany(products, { ordered: true, rawResult: false });
+                assert.strictEqual(insertManyResp.length, 3);
+                assert.strictEqual(insertManyResp[0].name, 'Product 2');
+                assert.strictEqual(insertManyResp[1].name, 'Product 1');
+                assert.strictEqual(insertManyResp[2].name, 'Product 3');
+                //rawResult options should be cleaned up by stargate-mongoose, but 'upsert' should be preserved
+                const updateOneResp = await Product.updateOne({ name: 'Product 4' },
+                    { $set : { isCertified : true }, $inc: { price: 5 } },
+                    { upsert: true, rawResult: false, sort: { name : 1 } }
+                );
+                assert.ok(updateOneResp.acknowledged);
+                assert.strictEqual(updateOneResp.matchedCount, 0);
+                assert.strictEqual(updateOneResp.modifiedCount, 0);
+                assert.strictEqual(updateOneResp.upsertedCount, 1);
+                assert.ok(updateOneResp.upsertedId);
+                //find product 4
+                const product4 = await Product.findOne({ name : 'Product 4' });
+                assert.strictEqual(product4?.name, 'Product 4');
+                //TODO check if upserting $inc is intentional
+                assert.strictEqual(product4?.price, 5);
+                assert.strictEqual(product4?.isCertified, true);
+            } finally {
+                // @ts-ignore
+                await dropCollections(isAstra, astraMongoose, jsonAPIMongoose, 'products');
+            }
+        });
+        it('should cleanup updateManyOptions', async () => {
+            let Product, astraMongoose, jsonAPIMongoose;
+            try {
+                ({ Product, astraMongoose, jsonAPIMongoose } = await createClientsAndModels(isAstra));
+                // @ts-ignore
+                const products: Product[] = [new Product({ name: 'Product 2', price: 10, isCertified: true, category: 'cat1' }), new Product({ name: 'Product 1', price: 10, isCertified: false, category: 'cat1' }), new Product({ name: 'Product 3', price: 10, isCertified: false, category: 'cat2' })];
+                const insertManyResp = await Product.insertMany(products, { ordered: true, rawResult: false });
+                assert.strictEqual(insertManyResp.length, 3);
+                assert.strictEqual(insertManyResp[0].name, 'Product 2');
+                assert.strictEqual(insertManyResp[1].name, 'Product 1');
+                assert.strictEqual(insertManyResp[2].name, 'Product 3');
+                //rawResult options should be cleaned up by stargate-mongoose, but 'upsert' should be preserved
+                const updateManyResp = await Product.updateMany({ category: 'cat1' },
+                    { $set : { isCertified : true }, $inc: { price: 5 } },
+                    { upsert: true, rawResult: false, sort: { name : 1 } }
+                );
+                assert.ok(updateManyResp.acknowledged);
+                assert.strictEqual(updateManyResp.matchedCount, 2);
+                assert.strictEqual(updateManyResp.modifiedCount, 2);
+                assert.strictEqual(updateManyResp.upsertedCount, undefined);
+                assert.strictEqual(updateManyResp.upsertedId, undefined);
+                //find product 4
+                const cat1Products = await Product.find({ category : 'cat1' });
+                assert.strictEqual(cat1Products.length, 2);
+                cat1Products.forEach(product => {
+                    assert.strictEqual(product.price, 15);
+                    assert.strictEqual(product.isCertified, true);
                 });
-                const product2 = new Product({
-                    name: 'Product 1',
-                    price: 10,
-                    expiryDate: new Date('2024-04-20T00:00:00.000Z'),
-                    isCertified: true
-                });
-                //rawResult options should be cleaned up by stargate-mongoose
-                await Product.insertMany([product1, product2], { ordered: false, rawResult: false });
+            } finally {
+                // @ts-ignore
+                await dropCollections(isAstra, astraMongoose, jsonAPIMongoose, 'products');
+            }
+        });
+        it('should cleanup deleteOneOptions', async () => {
+            let Product, astraMongoose, jsonAPIMongoose;
+            try {
+                ({ Product, astraMongoose, jsonAPIMongoose } = await createClientsAndModels(isAstra));
+                // @ts-ignore
+                const product1 = new Product({ name: 'Product 1', price: 10, isCertified: true });
+                await product1.save();
+                //runValidations is not a flag supported by JSON API, so it should be removed by stargate-mongoose
+                await Product.deleteOne({ name: 'Product 1' }, { runValidations: true });
+                const product1Deleted = await Product.findOne({ name: 'Product 1' });
+                assert.strictEqual(product1Deleted, null);
+            } finally {
+                // @ts-ignore
+                await dropCollections(isAstra, astraMongoose, jsonAPIMongoose, 'products');
+            }
+        });
+        it('should cleanup findOptions', async () => {
+            let Product, astraMongoose, jsonAPIMongoose;
+            try {
+                ({ Product, astraMongoose, jsonAPIMongoose } = await createClientsAndModels(isAstra));
+                //create 20 products using Array with id suffixed to prduct name
+                // @ts-ignore
+                let products: Product[] = [];
+                for (let i = 0; i < 20; i++) {
+                    // @ts-ignore
+                    products.push(new Product({ name: `Product ${i}`, price: 10, isCertified: true }));
+                }
+                await Product.insertMany(products, { ordered: true, rawResult: false });
+                //insert next 20 products using Array with id suffixed to product name
+                // @ts-ignore
+                products = [];
+                for (let i = 20; i < 40; i++) {
+                    // @ts-ignore
+                    products.push(new Product({ name: `Product ${i}`, price: 10, isCertified: true }));
+                }
+                await Product.insertMany(products, { ordered: true, rawResult: false });
+                //find 30 products with rawResult option
+                //rawResult must be removed and the limit must be preserved by stargate-mongoose
+                const findResp = await Product.find({ }, {}, { rawResult: false, limit : 30 });
+                assert.strictEqual(findResp.length, 30);
+            } finally {
+                // @ts-ignore
+                await dropCollections(isAstra, astraMongoose, jsonAPIMongoose, 'products');
+            }
+        });
+        //TODO skipping this until https://github.com/stargate/jsonapi/issues/416 is fixed
+        it.skip('should cleanup findOneAndReplaceOptions', async () => {
+            let Product, astraMongoose, jsonAPIMongoose;
+            try {
+                ({ Product, astraMongoose, jsonAPIMongoose } = await createClientsAndModels(isAstra));
+                //create 20 products using Array with id suffixed to prduct name
+                // @ts-ignore
+                let products: Product[] = [];
+                for (let i = 0; i < 20; i++) {
+                    // @ts-ignore
+                    products.push(new Product({ name: `Product ${i}`, price: 10, isCertified: true }));
+                }
+                await Product.insertMany(products, { ordered: true, rawResult: false });
+                //findOneAndReplace with rawResult option
+                const findOneAndReplaceResp = await Product.findOneAndReplace({ name: 'Product 25' },
+                    { price: 20, isCertified: false, name: 'Product 25' },
+                    { rawResult: false, upsert: true, returnDocument: 'after' });
+                console.log(findOneAndReplaceResp);
+                assert.strictEqual(findOneAndReplaceResp.isCertified,false);
+                assert.strictEqual(findOneAndReplaceResp.price,20);
+                assert.ok(findOneAndReplaceResp._id);
+                //find product 25
+                const product25 = await Product.findOne({ name: 'Product 25' });
+                console.log('product25',product25);
+                assert.strictEqual(product25?.isCertified,false);
+                assert.strictEqual(product25?.price,20);
+                assert.strictEqual(product25?.name,'Product 25');
+            } finally {
+                // @ts-ignore
+                await dropCollections(isAstra, astraMongoose, jsonAPIMongoose, 'products');
+            }
+        });
+        it('should cleanup findOneAndDeleteOptions', async () => {
+            let Product, astraMongoose, jsonAPIMongoose;
+            try {
+                ({ Product, astraMongoose, jsonAPIMongoose } = await createClientsAndModels(isAstra));
+                //create 20 products using Array with id suffixed to prduct name
+                // @ts-ignore
+                let products: Product[] = [];
+                for (let i = 0; i < 20; i++) {
+                    if(i === 5 || i === 6) {
+                        // @ts-ignore
+                        products.push(new Product({ name: `Product ${i}`, price: 10, isCertified: true, category: `cat 6` }));
+                    } else {
+                        // @ts-ignore
+                        products.push(new Product({ name: `Product ${i}`, price: 10, isCertified: true, category: `cat ${i}` }));
+                    }
+                }
+                await Product.insertMany(products, { ordered: true, rawResult: false });
+                //findOneAndDelete with rawResult option and sort with name in ascending order
+                const findOneAndDeleteResp = await Product.findOneAndDelete({ category: 'cat 6' }, { rawResult: false, sort : { name : 1} });
+                //check if Product 5 is deleted
+                const product5 = await Product.findOne({ name: 'Product 5' });
+                assert.strictEqual(product5, null);
+                //check if Product 6 is not deleted
+                const product6 = await Product.findOne({ name: 'Product 6' });
+                assert.strictEqual(product6?.name, 'Product 6');
+                assert.strictEqual(product6?.price, 10);
+                assert.strictEqual(product6?.isCertified, true);
+                assert.strictEqual(product6?.category, 'cat 6');
+            } finally {
+                // @ts-ignore
+                await dropCollections(isAstra, astraMongoose, jsonAPIMongoose, 'products');
+            }
+        });
+        //TODO skipping until https://github.com/stargate/jsonapi/issues/417 is fixed
+        it.skip('should cleanup findOneAndUpdateOptions', async () => {
+            let Product, astraMongoose, jsonAPIMongoose;
+            try {
+                ({ Product, astraMongoose, jsonAPIMongoose } = await createClientsAndModels(isAstra));
+                //create 20 products using Array with id suffixed to product name
+                // @ts-ignore
+                let products: Product[] = [];
+                for (let i = 0; i < 20; i++) {
+                    // @ts-ignore
+                    products.push(new Product({ name: `Product ${i}`, price: 10, isCertified: true }));
+                }
+                await Product.insertMany(products, { ordered: true, rawResult: false });
+                //findOneAndUpdate with rawResult option
+                const findOneAndUpdateResp = await Product.findOneAndUpdate({ name: 'Product 25' },
+                    { price: 20, isCertified: false, name: 'Product 25' },
+                    { rawResult: false, upsert: true, returnDocument: 'after' });
+                console.log(findOneAndUpdateResp);
+                assert.strictEqual(findOneAndUpdateResp.isCertified,false);
+                assert.strictEqual(findOneAndUpdateResp.price,20);
+                assert.strictEqual(findOneAndUpdateResp.name,'Product 25');
+                assert.ok(findOneAndUpdateResp._id);
+                //find product 25
+                const product25 = await Product.findOne({ name: 'Product 25' });
+                assert.strictEqual(product25?.isCertified,false);
+                assert.strictEqual(product25?.price,20);
+                assert.strictEqual(product25?.name,'Product 25');
             } finally {
                 // @ts-ignore
                 await dropCollections(isAstra, astraMongoose, jsonAPIMongoose, 'products');

--- a/tests/driver/index.test.ts
+++ b/tests/driver/index.test.ts
@@ -70,13 +70,14 @@ describe(`Driver based tests`, async () => {
         Cart = jsonAPIMongoose.model('Cart', cartSchema);
         Product = jsonAPIMongoose.model('Product', productSchema);
 
-        // @ts-ignore - these are config options supported by stargate-mongoose but not mongoose
-        await jsonAPIMongoose.connect(dbUri, {
+        const options = {
           username: process.env.STARGATE_USERNAME,
           password: process.env.STARGATE_PASSWORD,
           authUrl: process.env.STARGATE_AUTH_URL,
           logSkippedOptions: true
-        });
+        };
+        // @ts-ignore - these are config options supported by stargate-mongoose but not mongoose
+        await jsonAPIMongoose.connect(dbUri, options);
         await Promise.all(Object.values(jsonAPIMongoose.connection.models).map(Model => Model.init()));
       }
       const product1 = new Product({ name: 'Product 1', price: 10, expiryDate: new Date('2024-04-20T00:00:00.000Z'), isCertified: true });

--- a/tests/driver/index.test.ts
+++ b/tests/driver/index.test.ts
@@ -27,7 +27,7 @@ describe(`Driver based tests`, async () => {
       return this.skip();
     }
     const astraClient = await testClient.client;
-    if (astraClient == null) {
+    if (astraClient === null) {
       logger.info('Skipping tests for client: %s', testClient);
       return this.skip();
     }
@@ -58,6 +58,7 @@ describe(`Driver based tests`, async () => {
         Cart = astraMongoose.model('Cart', cartSchema);
         Product = astraMongoose.model('Product', productSchema);
 
+        // @ts-ignore - these are config options supported by stargate-mongoose but not mongoose
         await astraMongoose.connect(dbUri, { isAstra: true });
         await Promise.all(Object.values(astraMongoose.connection.models).map(Model => Model.init()));
       } else {
@@ -69,6 +70,7 @@ describe(`Driver based tests`, async () => {
         Cart = jsonAPIMongoose.model('Cart', cartSchema);
         Product = jsonAPIMongoose.model('Product', productSchema);
 
+        // @ts-ignore - these are config options supported by stargate-mongoose but not mongoose
         await jsonAPIMongoose.connect(dbUri, {
           username: process.env.STARGATE_USERNAME,
           password: process.env.STARGATE_PASSWORD,
@@ -113,6 +115,7 @@ describe(`Driver based tests`, async () => {
       mongooseInstance.set('autoCreate', true);
       mongooseInstance.set('autoIndex', false);
       let options = isAstra ? { isAstra: true } : { username: process.env.STARGATE_USERNAME, password: process.env.STARGATE_PASSWORD, authUrl: process.env.STARGATE_AUTH_URL };
+      // @ts-ignore - these are config options supported by stargate-mongoose but not mongoose
       await mongooseInstance.connect(dbUri, options);
       if (isAstra) {
         let error: any;
@@ -141,6 +144,7 @@ describe(`Driver based tests`, async () => {
       let newDbUri = dbUriSplit.join('/');
       //if token is not null, append it to the new dbUri
       newDbUri = token ? newDbUri + '?applicationToken=' + token : newDbUri;
+      // @ts-ignore - these are config options supported by stargate-mongoose but not mongoose
       await mongooseInstance.connect(newDbUri, options);
       if (isAstra) {
         let error: any;

--- a/tests/driver/index.test.ts
+++ b/tests/driver/index.test.ts
@@ -70,7 +70,8 @@ describe(`Driver based tests`, async () => {
         await jsonAPIMongoose.connect(dbUri, {
           username: process.env.STARGATE_USERNAME,
           password: process.env.STARGATE_PASSWORD,
-          authUrl: process.env.STARGATE_AUTH_URL
+          authUrl: process.env.STARGATE_AUTH_URL,
+          logSkippedOptions: true
         });
         await Promise.all(Object.values(jsonAPIMongoose.connection.models).map(Model => Model.init()));
       }

--- a/tests/driver/index.test.ts
+++ b/tests/driver/index.test.ts
@@ -86,6 +86,11 @@ describe(`Driver based tests`, async () => {
         products: [product1._id, product2._id]
       });
       await cart.save();
+
+      const findOneAndReplaceResp = await Cart.findOneAndReplace({ cartName: 'wewson' }, { name: 'My Cart 2', cartName: 'wewson1' }, { returnDocument: 'after'}).exec();
+      assert.strictEqual(findOneAndReplaceResp!.name, 'My Cart 2');
+      assert.strictEqual(findOneAndReplaceResp!.cartName, 'wewson1');
+
       if (isAstra) {
         astraMongoose?.connection.dropCollection('carts');
         astraMongoose?.connection.dropCollection('products');


### PR DESCRIPTION
**What this PR does**:

There are `options` sent by `mongoose` (and not explicitly by the end user), which are not supported by the JSON API. This PR cleans them up by checking if every option in the `options`, is supported by the JSON API or not.

Without this fix, when we try `findOneAndReplace` (from mongoose client and model instance) for example, we get below error (where `overwrite` is not a field end user set in this case).

```log
error: Error: Command "findOneAndReplace" failed with the following errors:
 [{"message":"Unrecognized field \"overwrite\" (class io.stargate.sgv2.jsonapi.api.model.command.impl.FindOneAndReplaceCommand$Options), not marked as ignorable (2 known properties: \"returnDocument\", \"upsert\"])\n at [Source: (ByteArrayInputStream); line: 1, column: 202] 
(through reference chain: io.stargate.sgv2.jsonapi.api.model.command.impl.FindOneAndReplaceCommand[\"options\"]->io.stargate.sgv2.jsonapi.api.model.command.impl.FindOneAndReplaceCommand$Options[\"overwrite\"])","exceptionClass":"UnrecognizedPropertyException"}]
```
Request
```typescript
await Cart.findOneAndReplace({ cartName: 'wewson' },
                             { name: 'My Cart 2', cartName: 'wewson1' }, 
                             { returnDocument: 'after'}
                             ).exec();

```

```json
  "findOneAndReplace": {
    "filter": {
      "cartName": "wewson"
    },
    "replacement": {
      "cartName": "wewson1",
      "name": "My Cart 2"
    },
    "options": {
      "returnDocument": "after",
      "overwrite": true,
      "returnOriginal": false,
      "projection": {}
    }
  }
```

We could see options like `overwrite`, `returnOriginal`, `projection` in the request and cleaning them up one by one is not practical, so created an instance of the options interface to get the keys for validation.

Also, added a connection flag called `logSkippedOptions` to log any option skipped by the driver for debugging purposes, which will be `false` by default.

**Checklist**
- [X] Changes manually tested
- [X] Automated Tests added/updated
- [X] Documentation added/updated
- [X] CLA Signed: [DataStax CLA](https://cla.datastax.com/)