### PR TITLE
DRY up option keys definitions

### DIFF
--- a/src/collections/options.ts
+++ b/src/collections/options.ts
@@ -29,13 +29,17 @@ export interface FindOptions {
     projection?: Record<string, 1 | -1>;
 }
 
-export interface FindOptionsInternal {
-    limit?: number;
-    skip?: number;
-    pagingState?: string;
+class _FindOptionsInternal {
+    limit?: number = undefined;
+    skip?: number = undefined;
+    pagingState?: string = undefined;
 }
 
-export const findInternalOptionsKeys: Set<keyof FindOptionsInternal> = new Set(['limit' as const, 'skip' as const, 'pagingState' as const]);
+export interface FindOptionsInternal extends _FindOptionsInternal {}
+
+export const findInternalOptionsKeys: Set<string> = new Set(
+  Object.keys(new _FindOptionsInternal)
+);
 
 /**
  * findOneOptions
@@ -54,50 +58,75 @@ export interface FindOneAndDeleteOptions {
 /**
  * findOneAndReplaceOptions
  */
-export interface FindOneAndReplaceOptions {
-    upsert?: boolean;
-    returnDocument?: 'before' | 'after';
+
+class _FindOneAndReplaceOptions {
+    upsert?: boolean = undefined;
+    returnDocument?: 'before' | 'after' = undefined;
     sort?: Record<string, 1 | -1>;
 }
 
-export const findOneAndReplaceInternalOptionsKeys: Set<keyof Omit<FindOneAndReplaceOptions, 'sort'>> = new Set(['upsert' as const, 'returnDocument' as const]);
+export interface FindOneAndReplaceOptions extends _FindOneAndReplaceOptions {}
+
+export const findOneAndReplaceInternalOptionsKeys: Set<string> = new Set(
+  Object.keys(new _FindOneAndReplaceOptions)
+);
 
 /**
  * findOneAndUpdateOptions
  */
-export interface FindOneAndUpdateOptions {
-    upsert?: boolean;
-    returnDocument?: 'before' | 'after';
+
+class _FindOneAndUpdateOptions {
+    upsert?: boolean = undefined;
+    returnDocument?: 'before' | 'after' = undefined;
     sort?: Record<string, 1 | -1>;
 }
 
-export const findOneAndUpdateInternalOptionsKeys: Set<keyof Omit<FindOneAndUpdateOptions, 'sort'>> = new Set(['upsert' as const, 'returnDocument' as const]);
+export interface FindOneAndUpdateOptions extends _FindOneAndUpdateOptions {}
+
+export const findOneAndUpdateInternalOptionsKeys: Set<string> = new Set(
+  Object.keys(new _FindOneAndUpdateOptions)
+);
 
 /**
  * insertManyOptions
  */
-export interface InsertManyOptions {
-    ordered?: boolean;
+
+class _InsertManyOptions {
+    ordered?: boolean = undefined;
 }
 
-export const insertManyInternalOptionsKeys: Set<keyof InsertManyOptions> = new Set(['ordered' as const]);
+export interface InsertManyOptions extends _InsertManyOptions {}
+
+export const insertManyInternalOptionsKeys: Set<string> = new Set(
+  Object.keys(_InsertManyOptions)
+);
 
 /**
  * updateManyOptions
  */
-export interface UpdateManyOptions {
-    upsert?: boolean;
+
+class _UpdateManyOptions {
+    upsert?: boolean = undefined;
 }
 
-export const updateManyInternalOptionsKeys: Set<keyof UpdateManyOptions> = new Set(['upsert' as const]);
+export interface UpdateManyOptions extends _UpdateManyOptions {}
+
+export const updateManyInternalOptionsKeys: Set<string> = new Set(
+  Object.keys(_UpdateManyOptions)
+);
 
 /**
  * updateOneOptions
  */
-export interface UpdateOneOptions {
-    upsert?: boolean;
+
+class _UpdateOneOptions {
+    upsert?: boolean = undefined;
     sort?: Record<string, 1 | -1>;
 }
 
-export const updateOneInternalOptionsKeys: Set<keyof Omit<UpdateOneOptions, 'sort'>> = new Set(['upsert' as const]);
+export interface UpdateOneOptions extends _UpdateOneOptions {}
+
+export const updateOneInternalOptionsKeys: Set<string> = new Set(
+  Object.keys(new _UpdateOneOptions)
+);
 

--- a/src/collections/options.ts
+++ b/src/collections/options.ts
@@ -98,7 +98,7 @@ class _InsertManyOptions {
 export interface InsertManyOptions extends _InsertManyOptions {}
 
 export const insertManyInternalOptionsKeys: Set<string> = new Set(
-  Object.keys(_InsertManyOptions)
+  Object.keys(new _InsertManyOptions)
 );
 
 /**
@@ -112,7 +112,7 @@ class _UpdateManyOptions {
 export interface UpdateManyOptions extends _UpdateManyOptions {}
 
 export const updateManyInternalOptionsKeys: Set<string> = new Set(
-  Object.keys(_UpdateManyOptions)
+  Object.keys(new _UpdateManyOptions)
 );
 
 /**


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

I wasn't thrilled with how we needed to define options property names multiple times, so I came up with a way to only list them once. It does require creating a separate class, but I think the syntax of using inline identifiers is more concise than the previous approach. The general idea is that 1) an interface can `extends` a class, which is how you can work around the fact that interfaces don't exist in runtime JavaScript, 2) `limit?: number = undefined;` means that `limit` shows up in `Object.keys()`, but `limit?: number` means `limit` does not show up in `Object.keys()`.

What do you think of this approach @kathirsvn ?

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)