### PR TITLE
set _id to ObjectId by default when upserting with updateOne, updateMany, findOneAndUpdate, findOneAndReplace

### DIFF
--- a/APIReference.md
+++ b/APIReference.md
@@ -10,13 +10,17 @@
 <dd></dd>
 <dt><a href="#Db">Db</a></dt>
 <dd></dd>
+<dt><a href="#_FindOptionsInternal">_FindOptionsInternal</a></dt>
+<dd><p>findOptions</p></dd>
+<dt><a href="#_FindOneAndReplaceOptions">_FindOneAndReplaceOptions</a></dt>
+<dd><p>findOneAndReplaceOptions</p></dd>
 </dl>
 
 ## Members
 
 <dl>
 <dt><a href="#findInternalOptionsKeys">findInternalOptionsKeys</a></dt>
-<dd><p>findOneAndReplaceOptions</p></dd>
+<dd><p>findOneAndDeleteOptions</p></dd>
 <dt><a href="#findOneAndReplaceInternalOptionsKeys">findOneAndReplaceInternalOptionsKeys</a></dt>
 <dd><p>findOneAndUpdateOptions</p></dd>
 <dt><a href="#findOneAndUpdateInternalOptionsKeys">findOneAndUpdateInternalOptionsKeys</a></dt>
@@ -32,13 +36,6 @@
 <dt><a href="#StargateAuthError">StargateAuthError</a> ⇒</dt>
 <dd><p>executeOperation handles running functions
 return a promise.</p></dd>
-</dl>
-
-## Constants
-
-<dl>
-<dt><a href="#findInternalOptionsKeys">findInternalOptionsKeys</a></dt>
-<dd><p>findOptions</p></dd>
 </dl>
 
 ## Functions
@@ -301,10 +298,22 @@ return a promise.</p></dd>
 ### db.createDatabase() ⇒
 **Kind**: instance method of [<code>Db</code>](#Db)  
 **Returns**: <p>Promise</p>  
+<a name="_FindOptionsInternal"></a>
+
+## \_FindOptionsInternal
+<p>findOptions</p>
+
+**Kind**: global class  
+<a name="_FindOneAndReplaceOptions"></a>
+
+## \_FindOneAndReplaceOptions
+<p>findOneAndReplaceOptions</p>
+
+**Kind**: global class  
 <a name="findInternalOptionsKeys"></a>
 
 ## findInternalOptionsKeys
-<p>findOneAndReplaceOptions</p>
+<p>findOneAndDeleteOptions</p>
 
 **Kind**: global variable  
 <a name="findOneAndReplaceInternalOptionsKeys"></a>
@@ -372,12 +381,6 @@ return a promise.</p>
 | --- | --- |
 | operation | <p>a function that takes no parameters and returns a response</p> |
 
-<a name="findInternalOptionsKeys"></a>
-
-## findInternalOptionsKeys
-<p>findOptions</p>
-
-**Kind**: global constant  
 <a name="parseUri"></a>
 
 ## parseUri(uri) ⇒

--- a/src/collections/collection.ts
+++ b/src/collections/collection.ts
@@ -244,8 +244,7 @@ export class Collection {
           options
         }
       };
-      // Skip for now pending stargate/jsonapi#435
-      // setDefaultIdForUpsert(command.findOneAndReplace, true);
+      setDefaultIdForUpsert(command.findOneAndReplace, true);
       if (options?.sort) {
         command.findOneAndReplace.sort = options.sort;
         if (options.sort != null) {

--- a/src/collections/collection.ts
+++ b/src/collections/collection.ts
@@ -21,7 +21,7 @@ import {
 } from 'mongodb';
 import {FindCursor} from './cursor';
 import {HTTPClient} from '@/src/client';
-import {executeOperation} from './utils';
+import {executeOperation, setDefaultIdForUpsert} from './utils';
 import {InsertManyResult} from 'mongoose';
 import {
   DeleteOneOptions,
@@ -113,6 +113,7 @@ export class Collection {
           options
         }
       };
+      setDefaultIdForUpsert(command.updateOne);
       const updateOneResp = await this.httpClient.executeCommand(command, updateOneInternalOptionsKeys);
       let resp = {
         modifiedCount: updateOneResp.status.modifiedCount,
@@ -136,6 +137,7 @@ export class Collection {
           options
         }
       };
+      setDefaultIdForUpsert(command.updateMany);
       const updateManyResp = await this.httpClient.executeCommand(command, updateManyInternalOptionsKeys);
       if (updateManyResp.status.moreData) {
         throw new StargateMongooseError(`More than ${updateManyResp.status.modifiedCount} records found for update by the server`, command);
@@ -245,6 +247,8 @@ export class Collection {
           options
         }
       };
+      // Skip for now pending stargate/jsonapi#435
+      // setDefaultIdForUpsert(command.findOneAndReplace, true);
       if (options?.sort) {
         command.findOneAndReplace.sort = options.sort;
         if (options.sort != null) {
@@ -322,6 +326,7 @@ export class Collection {
           options
         }
       };
+      setDefaultIdForUpsert(command.findOneAndUpdate);
       if (options?.sort) {
         command.findOneAndUpdate.sort = options.sort;
         delete options.sort;

--- a/src/collections/utils.ts
+++ b/src/collections/utils.ts
@@ -244,7 +244,9 @@ export function setDefaultIdForUpsert(command: Record<string, any>, replace?: bo
     if (command.update.$setOnInsert == null) {
       command.update.$setOnInsert = {};
     }
-    command.update.$setOnInsert._id = new ObjectId();
+    if (!('_id' in command.update.$setOnInsert)) {
+      command.update.$setOnInsert._id = new ObjectId();
+    }
   }
 }
 

--- a/src/collections/utils.ts
+++ b/src/collections/utils.ts
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { ObjectId } from 'mongodb';
 import url from 'url';
 import { logger } from '@/src/logger';
 import axios from 'axios';
-import { HTTPClient, handleIfErrorResponse } from '@/src/client/httpClient'
+import { HTTPClient, handleIfErrorResponse } from '@/src/client/httpClient';
 
 interface ParsedUri {
   baseUrl: string;
@@ -215,4 +216,43 @@ export async function dropNamespace(httpClient: HTTPClient, name: string) {
   });
   handleIfErrorResponse(response, data);
   return response;
+}
+
+export function setDefaultIdForUpsert(command: Record<string, any>, replace?: boolean) {
+  if (command.filter == null || command.options == null) {
+    return;
+  }
+  if (!command.options.upsert) {
+    return;
+  }
+  if ('_id' in command.filter) {
+    return;
+  }
+
+  if (replace) {
+    if (command.replacement != null && '_id' in command.replacement) {
+      return;
+    }
+    command.replacement._id = new ObjectId();
+  } else {
+    if (command.update != null && _updateHasKey(command.update, '_id')) {
+      return;
+    }
+    if (command.update == null) {
+      command.update = {};
+    }
+    if (command.update.$setOnInsert == null) {
+      command.update.$setOnInsert = {};
+    }
+    command.update.$setOnInsert._id = new ObjectId();
+  }
+}
+
+function _updateHasKey(update: Record<string, any>, key: string) {
+  for (const operator of Object.keys(update)) {
+    if (update[operator] != null && typeof update[operator] === 'object' && key in update[operator]) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/tests/collections/collection.test.ts
+++ b/tests/collections/collection.test.ts
@@ -896,6 +896,24 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
       );
       assert.ok(updateOneResp.upsertedId.match(/^[a-f\d]{24}$/i), updateOneResp.upsertedId);
     });
+    it('should not overwrite user-specified _id in $setOnInsert', async () => {
+      await collection.deleteMany({});
+      const updateOneResp = await collection.updateOne(
+        {},
+        {
+          "$setOnInsert": {
+            "_id": "foo"
+          },
+          "$set": {
+            "username": "aaronm"
+          }
+        },
+        {
+          "upsert": true
+        }
+      );
+      assert.equal(updateOneResp.upsertedId, "foo");
+    });
   });
   describe('updateMany tests', () => {
     it('should updateMany documents with ids', async () => {

--- a/tests/collections/collection.test.ts
+++ b/tests/collections/collection.test.ts
@@ -2045,8 +2045,7 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
       const docs = await collection.find({}, { sort: { username: 1 } }).toArray();
       assert.deepStrictEqual(docs.map(doc => doc.answer), [undefined, 42, undefined]);
     });
-    it.skip('findOneAndReplace should make _id an ObjectId when upserting with no _id', async () => {
-      // Skip for now pending stargate/jsonapi#435
+    it('findOneAndReplace should make _id an ObjectId when upserting with no _id', async () => {
       await collection.deleteMany({});
       const { value } = await collection.findOneAndReplace(
         {},
@@ -2058,6 +2057,7 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
           "upsert": true
         }
       );
+      // @ts-ignore
       assert.ok(value!._id!.match(/^[a-f\d]{24}$/i), value!._id);
     });
     it('should findOneAndUpdate without any updates to apply', async () => {

--- a/tests/collections/collection.test.ts
+++ b/tests/collections/collection.test.ts
@@ -881,6 +881,21 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
       assert.strictEqual(updatedDoc!.address.city, "nyc");
       assert.strictEqual(updatedDoc!.address.state, "ny");
     });
+    it('should make _id an ObjectId when upserting with no _id', async () => {
+      await collection.deleteMany({});
+      const updateOneResp = await collection.updateOne(
+        {},
+        {
+          "$set": {
+            "username": "aaronm"
+          }
+        },
+        {
+          "upsert": true
+        }
+      );
+      assert.ok(updateOneResp.upsertedId.match(/^[a-f\d]{24}$/i), updateOneResp.upsertedId);
+    });
   });
   describe('updateMany tests', () => {
     it('should updateMany documents with ids', async () => {
@@ -1746,6 +1761,21 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
         }
       });
     });
+    it('should make _id an ObjectId when upserting with no _id', async () => {
+      await collection.deleteMany({});
+      const { upsertedId } = await collection.updateMany(
+        {},
+        {
+          "$set": {
+            "username": "aaronm"
+          }
+        },
+        {
+          "upsert": true
+        }
+      );
+      assert.ok(upsertedId.match(/^[a-f\d]{24}$/i), upsertedId);
+    });
   });
   describe('findOneAndUpdate tests', () => {
     it('should findOneAndUpdate', async () => {
@@ -1834,6 +1864,22 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
       );
       assert.strictEqual(findOneAndUpdateResp.ok, 1);
       assert.strictEqual(findOneAndUpdateResp.value, null);
+    });
+    it('should make _id an ObjectId when upserting with no _id', async () => {
+      await collection.deleteMany({});
+      const { value } = await collection.findOneAndUpdate(
+        {},
+        {
+          "$set": {
+            "username": "aaronm"
+          }
+        },
+        {
+          "returnDocument": "after",
+          "upsert": true
+        }
+      );
+      assert.ok(value!._id!.match(/^[a-f\d]{24}$/i), value!._id);
     });
   });
   describe('deleteOne tests', () => {
@@ -1975,6 +2021,21 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
 
       const docs = await collection.find({}, { sort: { username: 1 } }).toArray();
       assert.deepStrictEqual(docs.map(doc => doc.answer), [undefined, 42, undefined]);
+    });
+    it.skip('findOneAndReplace should make _id an ObjectId when upserting with no _id', async () => {
+      // Skip for now pending stargate/jsonapi#435
+      await collection.deleteMany({});
+      const { value } = await collection.findOneAndReplace(
+        {},
+        {
+          "username": "aaronm"
+        },
+        {
+          "returnDocument": "after",
+          "upsert": true
+        }
+      );
+      assert.ok(value!._id!.match(/^[a-f\d]{24}$/i), value!._id);
     });
     it('should findOneAndUpdate without any updates to apply', async () => {
       await collection.deleteMany({});

--- a/tests/collections/options.test.ts
+++ b/tests/collections/options.test.ts
@@ -202,8 +202,7 @@ describe(`Options tests`, async () => {
             const findResp = await Product.find({ }, {}, { rawResult: false, limit : 30 });
             assert.strictEqual(findResp.length, 30);
         });
-        //TODO skipping this until https://github.com/stargate/jsonapi/issues/416 is fixed
-        it.skip('should cleanup findOneAndReplaceOptions', async () => {
+        it('should cleanup findOneAndReplaceOptions', async () => {
             //create 20 products using Array with id suffixed to prduct name
             // @ts-ignore
             let products: Product[] = [];


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Right now JSON API sets `_id` to a uuid by default, which can be problematic for Mongoose applications, because Mongoose expects `_id` to be a MongoDB ObjectId by default.

With this PR, stargate-mongoose will set `_id` to an ObjectId by default on upserts - if `upsert: true` is set on `updateOne`, `updateMany`, `findOneAndUpdate`, or `findOneAndReplace`. I ran into an issue with `findOneAndReplace`: https://github.com/stargate/jsonapi/issues/435, but the rest works.

**Which issue(s) this PR fixes**:
Fixes #96

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)