### PR TITLE
make some types more consistent

### DIFF
--- a/src/collections/collection.ts
+++ b/src/collections/collection.ts
@@ -38,6 +38,7 @@ import {
   updateOneInternalOptionsKeys,
   UpdateOneOptions,
   FindOptions,
+  SortOption,
 } from './options';
 
 // https://github.com/mongodb/node-mongodb-native/pull/3323
@@ -161,8 +162,8 @@ export class Collection {
     return executeOperation(async (): Promise<DeleteResult> => {
       type DeleteOneCommand = {
         deleteOne: {
-          filter?: Object,
-          sort?: Record<string, 1 | -1>
+          filter?: Record<string, any>,
+          sort?: SortOption
         }
       };
       const command: DeleteOneCommand = {
@@ -208,8 +209,8 @@ export class Collection {
       type FindOneCommand = {
         findOne: {
           filter?: Record<string, any>,
-          options?: Record<string, any>,
-          sort?: Record<string, any>
+          options?: FindOneOptions,
+          sort?: SortOption
         }
       };
       const command: FindOneCommand = {
@@ -232,10 +233,10 @@ export class Collection {
     return executeOperation(async (): Promise<ModifyResult> => {
       type FindOneAndReplaceCommand = {
         findOneAndReplace: {
-          filter?: Object,
-          replacement?: Object,
-          options?: Object,
-          sort?: Object
+          filter?: Record<string, any>,
+          replacement?: Record<string, any>,
+          options?: FindOneAndReplaceOptions,
+          sort?: SortOption
         }
       };
       const command: FindOneAndReplaceCommand = {
@@ -278,8 +279,8 @@ export class Collection {
   async findOneAndDelete(filter: Record<string, any>, options?: FindOneAndDeleteOptions): Promise<ModifyResult> {
     type FindOneAndDeleteCommand = {
       findOneAndDelete: {
-        filter?: Object,
-        sort?: Object
+        filter?: Record<string, any>,
+        sort?: SortOption
       }
     };
     const command: FindOneAndDeleteCommand = {
@@ -309,10 +310,10 @@ export class Collection {
     return executeOperation(async (): Promise<ModifyResult> => {
       type FindOneAndUpdateCommand = {
         findOneAndUpdate: {
-          filter?: Object,
-          update?: Object,
-          options?: Object,
-          sort?: Object
+          filter?: Record<string, any>,
+          update?: Record<string, any>,
+          options?: FindOneAndUpdateOptions,
+          sort?: SortOption
         }
       };
       const command: FindOneAndUpdateCommand = {

--- a/src/collections/db.ts
+++ b/src/collections/db.ts
@@ -63,12 +63,11 @@ export class Db {
    * @param options
    * @returns Promise
    */
-  async createCollection(collectionName: string, options?: any) {
+  async createCollection(collectionName: string) {
     return executeOperation(async () => {
       const command = {
         createCollection: {
-          name: collectionName,
-          options: options
+          name: collectionName
         }
       };
       return await this.httpClient.executeCommand(command, null);

--- a/src/collections/options.ts
+++ b/src/collections/options.ts
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+export type SortOption = Record<string, 1 | -1>;
+
 /**
  * deleteOneOptions
  */

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -87,15 +87,15 @@ export class Collection extends MongooseCollection {
     return this.collection.updateMany(filter, update, options);
   }
 
+  // No-ops
   dropIndexes() {
-    return this.collection.dropIndexes();
+    throw new Error('dropIndexes() Not Implemented');
   }
 
   createIndex(index: any, options?: any) {
-    return this.collection.createIndex(index, options);
+    throw new Error('createIndex() Not Implemented');
   }
 
-  // No-ops
   bulkWrite(ops: any[], options?: any) {
     throw new Error('bulkWrite() Not Implemented');
   }

--- a/src/driver/connection.ts
+++ b/src/driver/connection.ts
@@ -48,14 +48,14 @@ export class Connection extends MongooseConnection {
     return super.collection(name, options);
   }
 
-  async createCollection(name: string, options: any) {
+  async createCollection(name: string) {
     return executeOperation(async () => {
       await this._waitForClient();
       const db = this.client.db();
       if (!this.client.httpClient.isAstra) {
         db.createDatabase();
       }
-      return db.createCollection(name, options);
+      return db.createCollection(name);
     });
   }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Mostly because there were a bunch of places where we used different types for sort - `Record<string, any>` in some places, `Record<string, 1 | -1>` in others, `Object` in others. With this change, sort is consistently `Record<string, 1 | -1>`.

Also removed `options` parameter from createCollection(), because createCollection() doesn't support any options currently.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)