### PR TITLE
bring back callback support for `find()` temporarily

### DIFF
--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -43,8 +43,12 @@ export class Collection extends MongooseCollection {
     return this.collection.countDocuments(filter);
   }
 
-  find(filter: Record<string, any>, options?: FindOptions) {
-    return this.collection.find(filter, options);
+  find(filter: Record<string, any>, options?: FindOptions, callback?: Function) {
+    const cursor = this.collection.find(filter, options);
+    if (callback != null) {
+      return callback(null, cursor);
+    }
+    return cursor;
   }
 
   findOne(filter: Record<string, any>, options?: FindOneOptions) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

I ran into an issue the other day where using `cursor()` exits the process immediately. Try replacing [these lines](https://github.com/stargate/stargate-mongoose-sample-apps/blob/ac1fae008d35c39da5c29aabf8e318e5a2ddb11e/netlify-functions-ecommerce/seed.js#L41-L42) in the netlify ecommerce app seed script with the following:

```
  const cursor = await Product.find().cursor();
  await cursor.eachAsync(p => console.log(p));
  console.log('done');
```

The process silently exits between `find().cursor()` and `await cursor.eachAsync()`, with no error and no 'done' log. That is because [Mongoose still uses the callback-based form of `find()` internally for query cursors](https://github.com/Automattic/mongoose/blob/723f04087fac90702b34e6fb335ceab6d3a6b8f8/lib/cursor/QueryCursor.js#L87). With this change, `eachAsync()` works correctly.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)