### PR TITLE
clean up `openUri()` to better handle `createConnection()`

### DIFF
--- a/tests/driver/index.test.ts
+++ b/tests/driver/index.test.ts
@@ -159,10 +159,13 @@ describe(`Driver based tests`, async () => {
     it('handles updating existing document with save()', async () => {
       const mongooseInstance = await createMongooseInstance();
 
+      let options = isAstra ? { isAstra: true } : { username: process.env.STARGATE_USERNAME, password: process.env.STARGATE_PASSWORD, authUrl: process.env.STARGATE_AUTH_URL };
+      const conn = await mongooseInstance.createConnection(dbUri, options).asPromise();
+
       const personSchema = new mongooseInstance.Schema({
         name: String
       });
-      const Person = mongooseInstance.model('Person', personSchema);
+      const Person = conn.model('Person', personSchema);
       await Person.init();
       await Person.deleteMany({});
       const [person] = await Person.create([{ name: 'John' }]);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

I ran into [this logic](https://github.com/Automattic/mongoose/blob/73a524b6d9bf9ae710f854ba3cb51fbb124e0b2a/lib/connection.js#L723-L727) in Mongoose and took a look at what happens if you get an async error when connecting using `createConnection()`: in current implementation of stargate-mongoose, you end up with an uncatchable error. Looks like we need to handle Mongoose's internal `_fireAndForget` option to handle that.

I worked on some logic in Mongoose to make it so that all drivers have to implement is `createClient()`, not all of `openUri()`, but that's coming in a future version of Mongoose. For current version of Mongoose, this implementation is more correct.

Also noticed that we were missing a [`setClient()` function on connections](https://github.com/Automattic/mongoose/blob/73a524b6d9bf9ae710f854ba3cb51fbb124e0b2a/lib/connection.js#L1348).

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)