### PR TITLE
support $vector with $meta in sort()

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "url": "git+https://github.com/stargate/stargate-mongoose.git"
   },
   "scripts": {
-    "test": "env TEST_DOC_DB=jsonapi nyc ts-mocha --paths -p tsconfig.json tests/**/*.test.ts",
+    "test": "env TEST_DOC_DB=jsonapi ts-mocha --paths -p tsconfig.json tests/**/*.test.ts",
     "test-astra": "env TEST_DOC_DB=astra nyc ts-mocha --paths -p tsconfig.json tests/**/*.test.ts",
     "test-jsonapi": "env TEST_DOC_DB=jsonapi nyc ts-mocha --paths -p tsconfig.json tests/**/*.test.ts",
     "preinstall": "node -p \"'export const LIB_NAME = ' + JSON.stringify(require('./package.json').name) + ';'\" > src/version.ts && node -p \"'export const LIB_VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" >> src/version.ts",
@@ -77,6 +77,7 @@
     "mongoose": "7.x",
     "mongodb": "5.x",
     "nyc": "^15.1.0",
+    "sinon": "15.2.0",
     "ts-mocha": "^10.0.0",
     "ts-node": "^10.8.1",
     "tscpaths": "^0.0.9",

--- a/src/collections/options.ts
+++ b/src/collections/options.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export type SortOption = Record<string, 1 | -1>;
+export type SortOption = Record<string, 1 | -1> | { $vector: { $meta: Array<number> } } | { $vector: Array<number> };
 
 /**
  * deleteOneOptions
@@ -54,7 +54,7 @@ export interface FindOneOptions {
  * findOneAndDeleteOptions
  */
 export interface FindOneAndDeleteOptions {
-    sort?: Record<string, 1 | -1>;
+    sort?: SortOption;
 }
 
 /**
@@ -64,7 +64,7 @@ export interface FindOneAndDeleteOptions {
 class _FindOneAndReplaceOptions {
     upsert?: boolean = undefined;
     returnDocument?: 'before' | 'after' = undefined;
-    sort?: Record<string, 1 | -1>;
+    sort?: SortOption;
 }
 
 export interface FindOneAndReplaceOptions extends _FindOneAndReplaceOptions {}
@@ -80,7 +80,7 @@ export const findOneAndReplaceInternalOptionsKeys: Set<string> = new Set(
 class _FindOneAndUpdateOptions {
     upsert?: boolean = undefined;
     returnDocument?: 'before' | 'after' = undefined;
-    sort?: Record<string, 1 | -1>;
+    sort?: SortOption;
 }
 
 export interface FindOneAndUpdateOptions extends _FindOneAndUpdateOptions {}
@@ -123,7 +123,7 @@ export const updateManyInternalOptionsKeys: Set<string> = new Set(
 
 class _UpdateOneOptions {
     upsert?: boolean = undefined;
-    sort?: Record<string, 1 | -1>;
+    sort?: SortOption;
 }
 
 export interface UpdateOneOptions extends _UpdateOneOptions {}

--- a/src/collections/options.ts
+++ b/src/collections/options.ts
@@ -27,7 +27,7 @@ export interface DeleteOneOptions {
 export interface FindOptions {
     limit?: number;
     skip?: number;
-    sort?: Record<string, 1 | -1>;
+    sort?: SortOption;
     projection?: Record<string, 1 | -1>;
 }
 

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -40,7 +40,11 @@ export class Collection extends MongooseCollection {
   }
 
   get collection() {
-    return this.conn.db.collection(this.name);
+    if (this._collection != null) {
+      return this._collection;
+    }
+    this._collection = this.conn.db.collection(this.name);
+    return this._collection;
   }
 
   /**
@@ -123,7 +127,7 @@ export class Collection extends MongooseCollection {
     if (options != null) {
       processSortOption(options);
     }
-    
+    console.log('UpdateOne', this.collection.updateOne.toString())
     return this.collection.updateOne(filter, update, options);
   }
 

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -127,7 +127,6 @@ export class Collection extends MongooseCollection {
     if (options != null) {
       processSortOption(options);
     }
-    console.log('UpdateOne', this.collection.updateOne.toString())
     return this.collection.updateOne(filter, update, options);
   }
 

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -21,6 +21,7 @@ import {
   FindOneOptions,
   FindOptions,
   InsertManyOptions,
+  SortOption,
   UpdateManyOptions,
   UpdateOneOptions
 } from '@/src/collections/options';
@@ -54,6 +55,9 @@ export class Collection extends MongooseCollection {
   }
 
   find(filter: Record<string, any>, options?: FindOptions, callback?: NodeCallback<Record<string, any>[]>) {
+    if (options != null) {
+      processSortOption(options);
+    }
     const cursor = this.collection.find(filter, options);
     if (callback != null) {
       return callback(null, cursor);
@@ -62,6 +66,9 @@ export class Collection extends MongooseCollection {
   }
 
   findOne(filter: Record<string, any>, options?: FindOneOptions) {
+    if (options != null) {
+      processSortOption(options);
+    }
     return this.collection.findOne(filter, options);
   }
 
@@ -74,14 +81,23 @@ export class Collection extends MongooseCollection {
   }
 
   findOneAndUpdate(filter: Record<string, any>, update: Record<string, any>, options?: FindOneAndUpdateOptions) {
+    if (options != null) {
+      processSortOption(options);
+    }
     return this.collection.findOneAndUpdate(filter, update, options);
   }
 
   findOneAndDelete(filter: Record<string, any>, options?: FindOneAndDeleteOptions) {
+    if (options != null) {
+      processSortOption(options);
+    }
     return this.collection.findOneAndDelete(filter, options);
   }
 
   findOneAndReplace(filter: Record<string, any>, newDoc: Record<string, any>, options?: FindOneAndReplaceOptions) {
+    if (options != null) {
+      processSortOption(options);
+    }
     return this.collection.findOneAndReplace(filter, newDoc, options);
   }
 
@@ -90,6 +106,10 @@ export class Collection extends MongooseCollection {
   }
 
   deleteOne(filter: Record<string, any>, options?: DeleteOneOptions, callback?: NodeCallback<DeleteResult>) {
+    if (options != null) {
+      processSortOption(options);
+    }
+    
     const promise = this.collection.deleteOne(filter, options);
 
     if (callback != null) {
@@ -100,6 +120,10 @@ export class Collection extends MongooseCollection {
   }
 
   updateOne(filter: Record<string, any>, update: Record<string, any>, options?: UpdateOneOptions) {
+    if (options != null) {
+      processSortOption(options);
+    }
+    
     return this.collection.updateOne(filter, update, options);
   }
 
@@ -155,6 +179,16 @@ export class Collection extends MongooseCollection {
     throw new OperationNotSupportedError('syncIndexes() Not Implemented');
   }
 
+}
+
+function processSortOption(options: { sort?: SortOption }) {
+  if (options.sort == null) {
+    return;
+  }
+  if (typeof options.sort.$vector !== 'object' || Array.isArray(options.sort.$vector)) {
+    return;
+  }
+  options.sort.$vector = options.sort.$vector.$meta;
 }
 
 export class OperationNotSupportedError extends Error {


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Supports `$vector: { $meta: [1, 2] }` as a valid sort option, and converts it to `$vector: [1, 2]`

**Which issue(s) this PR fixes**:
Fixes #111

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)