### PR TITLE
Use Mongoose 7.4 and fix TS issues in test files

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "dotenv": "^16.0.1",
     "jsdoc-babel": "^0.5.0",
     "jsdoc-to-markdown": "^7.1.1",
-    "mongoose": "7.x",
+    "mongoose": "^7.4.0",
     "nyc": "^15.1.0",
     "sinon": "15.2.0",
     "ts-mocha": "^10.0.0",
@@ -89,7 +89,7 @@
     "winston": "^3.7.2"
   },
   "peerDependencies": {
-    "mongoose": "7.x"
+    "mongoose": "^7.4.0"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/package.json
+++ b/package.json
@@ -71,11 +71,11 @@
     "@types/expect": "^24.3.0",
     "@types/mocha": "^9.1.1",
     "@types/node": "^17.0.36",
+    "@types/sinon": "10.0.15",
     "dotenv": "^16.0.1",
     "jsdoc-babel": "^0.5.0",
     "jsdoc-to-markdown": "^7.1.1",
     "mongoose": "7.x",
-    "mongodb": "5.x",
     "nyc": "^15.1.0",
     "sinon": "15.2.0",
     "ts-mocha": "^10.0.0",
@@ -89,8 +89,7 @@
     "winston": "^3.7.2"
   },
   "peerDependencies": {
-    "mongoose": "7.x",
-    "mongodb": "5.x"
+    "mongoose": "7.x"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "url": "git+https://github.com/stargate/stargate-mongoose.git"
   },
   "scripts": {
-    "test": "env TEST_DOC_DB=jsonapi nyc ts-mocha --paths -p tsconfig.json tests/**/*.test.ts",
+    "test": "env TEST_DOC_DB=jsonapi ts-mocha --paths -p tsconfig.json tests/**/*.test.ts",
     "test-astra": "env TEST_DOC_DB=astra nyc ts-mocha --paths -p tsconfig.json tests/**/*.test.ts",
     "test-jsonapi": "env TEST_DOC_DB=jsonapi nyc ts-mocha --paths -p tsconfig.json tests/**/*.test.ts",
     "preinstall": "node -p \"'export const LIB_NAME = ' + JSON.stringify(require('./package.json').name) + ';'\" > src/version.ts && node -p \"'export const LIB_VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" >> src/version.ts",
@@ -77,6 +77,7 @@
     "mongoose": "7.x",
     "mongodb": "5.x",
     "nyc": "^15.1.0",
+    "sinon": "15.2.0",
     "ts-mocha": "^10.0.0",
     "ts-node": "^10.8.1",
     "tscpaths": "^0.0.9",

--- a/src/collections/options.ts
+++ b/src/collections/options.ts
@@ -14,6 +14,8 @@
 
 export type SortOption = Record<string, 1 | -1> | { $vector: { $meta: Array<number> } } | { $vector: Array<number> };
 
+export type ProjectionOption = Record<string, 1 | 0 | true | false | { $slice: number }>;
+
 /**
  * deleteOneOptions
  */
@@ -28,7 +30,7 @@ export interface FindOptions {
     limit?: number;
     skip?: number;
     sort?: SortOption;
-    projection?: Record<string, 1 | -1>;
+    projection?: ProjectionOption;
 }
 
 class _FindOptionsInternal {

--- a/src/collections/options.ts
+++ b/src/collections/options.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export type SortOption = Record<string, 1 | -1>;
+export type SortOption = Record<string, 1 | -1> | { $vector: { $meta: Array<number> } } | { $vector: Array<number> };
 
 /**
  * deleteOneOptions
@@ -54,7 +54,7 @@ export interface FindOneOptions {
  * findOneAndDeleteOptions
  */
 export interface FindOneAndDeleteOptions {
-    sort?: Record<string, 1 | -1>;
+    sort?: SortOption;
 }
 
 /**
@@ -64,7 +64,7 @@ export interface FindOneAndDeleteOptions {
 class _FindOneAndReplaceOptions {
     upsert?: boolean = undefined;
     returnDocument?: 'before' | 'after' = undefined;
-    sort?: Record<string, 1 | -1>;
+    sort?: SortOption;
 }
 
 export interface FindOneAndReplaceOptions extends _FindOneAndReplaceOptions {}
@@ -80,7 +80,7 @@ export const findOneAndReplaceInternalOptionsKeys: Set<string> = new Set(
 class _FindOneAndUpdateOptions {
     upsert?: boolean = undefined;
     returnDocument?: 'before' | 'after' = undefined;
-    sort?: Record<string, 1 | -1>;
+    sort?: SortOption;
 }
 
 export interface FindOneAndUpdateOptions extends _FindOneAndUpdateOptions {}
@@ -123,7 +123,7 @@ export const updateManyInternalOptionsKeys: Set<string> = new Set(
 
 class _UpdateOneOptions {
     upsert?: boolean = undefined;
-    sort?: Record<string, 1 | -1>;
+    sort?: SortOption;
 }
 
 export interface UpdateOneOptions extends _UpdateOneOptions {}

--- a/src/collections/options.ts
+++ b/src/collections/options.ts
@@ -27,7 +27,7 @@ export interface DeleteOneOptions {
 export interface FindOptions {
     limit?: number;
     skip?: number;
-    sort?: Record<string, 1 | -1>;
+    sort?: SortOption;
     projection?: Record<string, 1 | -1>;
 }
 

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -26,6 +26,7 @@ import {
   UpdateOneOptions
 } from '@/src/collections/options';
 import { DeleteResult } from 'mongodb';
+import { QueryOptions } from 'mongoose';
 
 type NodeCallback<ResultType = any> = (err: Error | null, res: ResultType | null) => unknown;
 
@@ -60,7 +61,7 @@ export class Collection extends MongooseCollection {
 
   find(filter: Record<string, any>, options?: FindOptions, callback?: NodeCallback<Record<string, any>[]>) {
     if (options != null) {
-      processSortOption(options);
+      processQueryOptions(options);
     }
     const cursor = this.collection.find(filter, options);
     if (callback != null) {
@@ -71,7 +72,7 @@ export class Collection extends MongooseCollection {
 
   findOne(filter: Record<string, any>, options?: FindOneOptions) {
     if (options != null) {
-      processSortOption(options);
+      processQueryOptions(options);
     }
     return this.collection.findOne(filter, options);
   }
@@ -86,21 +87,21 @@ export class Collection extends MongooseCollection {
 
   findOneAndUpdate(filter: Record<string, any>, update: Record<string, any>, options?: FindOneAndUpdateOptions) {
     if (options != null) {
-      processSortOption(options);
+      processQueryOptions(options);
     }
     return this.collection.findOneAndUpdate(filter, update, options);
   }
 
   findOneAndDelete(filter: Record<string, any>, options?: FindOneAndDeleteOptions) {
     if (options != null) {
-      processSortOption(options);
+      processQueryOptions(options);
     }
     return this.collection.findOneAndDelete(filter, options);
   }
 
   findOneAndReplace(filter: Record<string, any>, newDoc: Record<string, any>, options?: FindOneAndReplaceOptions) {
     if (options != null) {
-      processSortOption(options);
+      processQueryOptions(options);
     }
     return this.collection.findOneAndReplace(filter, newDoc, options);
   }
@@ -111,7 +112,7 @@ export class Collection extends MongooseCollection {
 
   deleteOne(filter: Record<string, any>, options?: DeleteOneOptions, callback?: NodeCallback<DeleteResult>) {
     if (options != null) {
-      processSortOption(options);
+      processQueryOptions(options);
     }
     
     const promise = this.collection.deleteOne(filter, options);
@@ -125,7 +126,7 @@ export class Collection extends MongooseCollection {
 
   updateOne(filter: Record<string, any>, update: Record<string, any>, options?: UpdateOneOptions) {
     if (options != null) {
-      processSortOption(options);
+      processQueryOptions(options);
     }
     return this.collection.updateOne(filter, update, options);
   }
@@ -184,14 +185,15 @@ export class Collection extends MongooseCollection {
 
 }
 
-function processSortOption(options: { sort?: SortOption }) {
+function processQueryOptions(options: { vectorSearch?: number[], sort?: SortOption }) {
+  if (options.vectorSearch == null) {
+    return;
+  }
   if (options.sort == null) {
-    return;
+    options.sort = {};
   }
-  if (typeof options.sort.$vector !== 'object' || Array.isArray(options.sort.$vector)) {
-    return;
-  }
-  options.sort.$vector = options.sort.$vector.$meta;
+  options.sort.$vector = options.vectorSearch;
+  delete options.vectorSearch;
 }
 
 export class OperationNotSupportedError extends Error {

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -61,7 +61,7 @@ export class Collection extends MongooseCollection {
 
   find(filter: Record<string, any>, options?: FindOptions, callback?: NodeCallback<Record<string, any>[]>) {
     if (options != null) {
-      processQueryOptions(options);
+      processSortOption(options);
     }
     const cursor = this.collection.find(filter, options);
     if (callback != null) {
@@ -72,7 +72,7 @@ export class Collection extends MongooseCollection {
 
   findOne(filter: Record<string, any>, options?: FindOneOptions) {
     if (options != null) {
-      processQueryOptions(options);
+      processSortOption(options);
     }
     return this.collection.findOne(filter, options);
   }
@@ -87,21 +87,21 @@ export class Collection extends MongooseCollection {
 
   findOneAndUpdate(filter: Record<string, any>, update: Record<string, any>, options?: FindOneAndUpdateOptions) {
     if (options != null) {
-      processQueryOptions(options);
+      processSortOption(options);
     }
     return this.collection.findOneAndUpdate(filter, update, options);
   }
 
   findOneAndDelete(filter: Record<string, any>, options?: FindOneAndDeleteOptions) {
     if (options != null) {
-      processQueryOptions(options);
+      processSortOption(options);
     }
     return this.collection.findOneAndDelete(filter, options);
   }
 
   findOneAndReplace(filter: Record<string, any>, newDoc: Record<string, any>, options?: FindOneAndReplaceOptions) {
     if (options != null) {
-      processQueryOptions(options);
+      processSortOption(options);
     }
     return this.collection.findOneAndReplace(filter, newDoc, options);
   }
@@ -112,7 +112,7 @@ export class Collection extends MongooseCollection {
 
   deleteOne(filter: Record<string, any>, options?: DeleteOneOptions, callback?: NodeCallback<DeleteResult>) {
     if (options != null) {
-      processQueryOptions(options);
+      processSortOption(options);
     }
     
     const promise = this.collection.deleteOne(filter, options);
@@ -126,7 +126,7 @@ export class Collection extends MongooseCollection {
 
   updateOne(filter: Record<string, any>, update: Record<string, any>, options?: UpdateOneOptions) {
     if (options != null) {
-      processQueryOptions(options);
+      processSortOption(options);
     }
     return this.collection.updateOne(filter, update, options);
   }
@@ -185,15 +185,14 @@ export class Collection extends MongooseCollection {
 
 }
 
-function processQueryOptions(options: { vectorSearch?: number[], sort?: SortOption }) {
-  if (options.vectorSearch == null) {
+function processSortOption(options: { sort?: SortOption }) {
+  if (options.sort == null) {
     return;
   }
-  if (options.sort == null) {
-    options.sort = {};
+  if (typeof options.sort.$vector !== 'object' || Array.isArray(options.sort.$vector)) {
+    return;
   }
-  options.sort.$vector = options.vectorSearch;
-  delete options.vectorSearch;
+  options.sort.$vector = options.sort.$vector.$meta;
 }
 
 export class OperationNotSupportedError extends Error {

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -40,7 +40,11 @@ export class Collection extends MongooseCollection {
   }
 
   get collection() {
-    return this.conn.db.collection(this.name);
+    if (this._collection != null) {
+      return this._collection;
+    }
+    this._collection = this.conn.db.collection(this.name);
+    return this._collection;
   }
 
   /**
@@ -123,7 +127,7 @@ export class Collection extends MongooseCollection {
     if (options != null) {
       processSortOption(options);
     }
-    
+    console.log('UpdateOne', this.collection.updateOne.toString())
     return this.collection.updateOne(filter, update, options);
   }
 

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -127,7 +127,6 @@ export class Collection extends MongooseCollection {
     if (options != null) {
       processSortOption(options);
     }
-    console.log('UpdateOne', this.collection.updateOne.toString())
     return this.collection.updateOne(filter, update, options);
   }
 

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -21,6 +21,7 @@ import {
   FindOneOptions,
   FindOptions,
   InsertManyOptions,
+  SortOption,
   UpdateManyOptions,
   UpdateOneOptions
 } from '@/src/collections/options';
@@ -54,6 +55,9 @@ export class Collection extends MongooseCollection {
   }
 
   find(filter: Record<string, any>, options?: FindOptions, callback?: NodeCallback<Record<string, any>[]>) {
+    if (options != null) {
+      processSortOption(options);
+    }
     const cursor = this.collection.find(filter, options);
     if (callback != null) {
       return callback(null, cursor);
@@ -62,6 +66,9 @@ export class Collection extends MongooseCollection {
   }
 
   findOne(filter: Record<string, any>, options?: FindOneOptions) {
+    if (options != null) {
+      processSortOption(options);
+    }
     return this.collection.findOne(filter, options);
   }
 
@@ -74,14 +81,23 @@ export class Collection extends MongooseCollection {
   }
 
   findOneAndUpdate(filter: Record<string, any>, update: Record<string, any>, options?: FindOneAndUpdateOptions) {
+    if (options != null) {
+      processSortOption(options);
+    }
     return this.collection.findOneAndUpdate(filter, update, options);
   }
 
   findOneAndDelete(filter: Record<string, any>, options?: FindOneAndDeleteOptions) {
+    if (options != null) {
+      processSortOption(options);
+    }
     return this.collection.findOneAndDelete(filter, options);
   }
 
   findOneAndReplace(filter: Record<string, any>, newDoc: Record<string, any>, options?: FindOneAndReplaceOptions) {
+    if (options != null) {
+      processSortOption(options);
+    }
     return this.collection.findOneAndReplace(filter, newDoc, options);
   }
 
@@ -90,6 +106,10 @@ export class Collection extends MongooseCollection {
   }
 
   deleteOne(filter: Record<string, any>, options?: DeleteOneOptions, callback?: NodeCallback<DeleteResult>) {
+    if (options != null) {
+      processSortOption(options);
+    }
+    
     const promise = this.collection.deleteOne(filter, options);
 
     if (callback != null) {
@@ -100,6 +120,10 @@ export class Collection extends MongooseCollection {
   }
 
   updateOne(filter: Record<string, any>, update: Record<string, any>, options?: UpdateOneOptions) {
+    if (options != null) {
+      processSortOption(options);
+    }
+    
     return this.collection.updateOne(filter, update, options);
   }
 
@@ -155,6 +179,16 @@ export class Collection extends MongooseCollection {
     throw new OperationNotSupportedError('syncIndexes() Not Implemented');
   }
 
+}
+
+function processSortOption(options: { sort?: SortOption }) {
+  if (options.sort == null) {
+    return;
+  }
+  if (typeof options.sort.$vector !== 'object' || Array.isArray(options.sort.$vector)) {
+    return;
+  }
+  options.sort.$vector = options.sort.$vector.$meta;
 }
 
 export class OperationNotSupportedError extends Error {

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,10 +23,6 @@ declare module 'mongoose' {
     logSkippedOptions?: boolean;
     authUrl?: string;
   }
-
-  interface QueryOptions {
-    vectorSearch?: number[];
-  }
 }
 
 import { createStargateUri, createAstraUri } from './collections';

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,5 +17,17 @@ export * as driver from './driver';
 export * as client from './client';
 export * as logger from './logger';
 
+declare module 'mongoose' {
+  interface ConnectOptions {
+    isAstra?: boolean;
+    logSkippedOptions?: boolean;
+    authUrl?: string;
+  }
+
+  interface QueryOptions {
+    vectorSearch?: number[];
+  }
+}
+
 import { createStargateUri, createAstraUri } from './collections';
 export { createStargateUri, createAstraUri };

--- a/tests/collections/collection.test.ts
+++ b/tests/collections/collection.test.ts
@@ -1259,7 +1259,7 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
       assert.strictEqual(updatedDoc1!.pincode, 620020);      
       assert.strictEqual(updatedDoc1!.country, "India");
     });
-    it('should set a field value to new value when the new vaue is < existing value with $min in updateOne and updateMany', async () => {
+    it('should set a field value to new value when the new value is < existing value with $min in updateOne and updateMany', async () => {
       let docList = Array.from({ length: 20 }, () => ({ _id : "id", departmentName: "dept", minScore: 50, maxScore: 800 }));
       docList.forEach((doc, index) => {
         doc._id += index;
@@ -1281,7 +1281,7 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
       assert.strictEqual(updateOneResp.upsertedCount, undefined);
       assert.strictEqual(updateOneResp.upsertedId, undefined);
       const updatedDoc = await collection.findOne({ "_id": "id4" });
-      //assert that the minScore field is set to 5 in the 4th doc because the $min operator sets the field value to new value when the new vaue is less than existing value
+      //assert that the minScore field is set to 5 in the 4th doc because the $min operator sets the field value to new value when the new value is less than existing value
       assert.strictEqual(updatedDoc!.minScore, 5);
       //update the 4th doc using updateOne API with $min operator to set the minScore to 15
       const updateOneResp1 = await collection.updateOne({ "_id": "id4" }, { "$min": { "minScore": 15 } });
@@ -1291,7 +1291,7 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
       assert.strictEqual(updateOneResp1.upsertedCount, undefined);
       assert.strictEqual(updateOneResp1.upsertedId, undefined);
       const updatedDoc1 = await collection.findOne({ "_id": "id4" });
-      //assert that the minScore field is not set to 15 in the 5th doc because the $min operator does not set the field value to new value when the new vaue is greater than existing value
+      //assert that the minScore field is not set to 15 in the 5th doc because the $min operator does not set the field value to new value when the new value is greater than existing value
       assert.strictEqual(updatedDoc1!.minScore, 5);    
       //update all docs using updateMany API with $min operator to set the minScore to 15
       const updateManyResp = await collection.updateMany({ }, { "$min": { "minScore": 15 } });
@@ -1301,7 +1301,7 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
       assert.strictEqual(updateManyResp.upsertedCount, undefined);
       assert.strictEqual(updateManyResp.upsertedId, undefined);
       const allDocs = await collection.find({ }).toArray();
-      //assert that the minScore field is set to 15 in all docs because the $min operator sets the field value to new value when the new vaue is less than existing value
+      //assert that the minScore field is set to 15 in all docs because the $min operator sets the field value to new value when the new value is less than existing value
       allDocs.forEach(doc => {
         if(doc._id === "id4"){
           assert.strictEqual(doc.minScore, 5);
@@ -1317,7 +1317,7 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
       assert.strictEqual(updateManyResp1.upsertedCount, undefined);
       assert.strictEqual(updateManyResp1.upsertedId, undefined);
       const allDocs1 = await collection.find({ }).toArray();
-      //assert that the minScore field is not set to 50 in all docs because the $min operator does not set the field value to new value when the new vaue is greater than existing value
+      //assert that the minScore field is not set to 50 in all docs because the $min operator does not set the field value to new value when the new value is greater than existing value
       allDocs1.forEach(doc => {
         if(doc._id === "id4"){
           assert.strictEqual(doc.minScore, 5);
@@ -1326,7 +1326,7 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
         }
       });
     });
-    it('should set a field value to new value when the new vaue is > existing value with $max in updateOne and updateMany', async () => {
+    it('should set a field value to new value when the new value is > existing value with $max in updateOne and updateMany', async () => {
       let docList = Array.from({ length: 20 }, () => ({ _id : "id", departmentName: "dept", minScore: 50, maxScore: 800 }));
       docList.forEach((doc, index) => {
         doc._id += index;
@@ -1348,7 +1348,7 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
       assert.strictEqual(updateOneResp.upsertedCount, undefined);
       assert.strictEqual(updateOneResp.upsertedId, undefined);
       const updatedDoc = await collection.findOne({ "_id": "id4" });
-      //assert that the maxScore field is set to 950 in the 4th doc because the $max operator sets the field value to new value when the new vaue is greater than existing value
+      //assert that the maxScore field is set to 950 in the 4th doc because the $max operator sets the field value to new value when the new value is greater than existing value
       assert.strictEqual(updatedDoc!.maxScore, 950);
       //update the 4th doc using updateOne API with $max operator to set the maxScore to 15
       const updateOneResp1 = await collection.updateOne({ "_id": "id4" }, { "$max": { "maxScore": 15 } });
@@ -1358,7 +1358,7 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
       assert.strictEqual(updateOneResp1.upsertedCount, undefined);
       assert.strictEqual(updateOneResp1.upsertedId, undefined);
       const updatedDoc1 = await collection.findOne({ "_id": "id4" });
-      //assert that the maxScore field is not set to 15 in the 5th doc because the $max operator does not set the field value to new value when the new vaue is lesser than existing value
+      //assert that the maxScore field is not set to 15 in the 5th doc because the $max operator does not set the field value to new value when the new value is lesser than existing value
       assert.strictEqual(updatedDoc1!.maxScore, 950);    
       //update all docs using updateMany API with $max operator to set the maxScore to 15
       const updateManyResp = await collection.updateMany({ }, { "$max": { "maxScore": 900 } });
@@ -1368,7 +1368,7 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
       assert.strictEqual(updateManyResp.upsertedCount, undefined);
       assert.strictEqual(updateManyResp.upsertedId, undefined);
       const allDocs = await collection.find({ }).toArray();
-      //assert that the maxScore field is set to 900 in all docs because the $max operator sets the field value to new value when the new vaue is greater than existing value
+      //assert that the maxScore field is set to 900 in all docs because the $max operator sets the field value to new value when the new value is greater than existing value
       allDocs.forEach(doc => {
         if(doc._id === "id4"){
           assert.strictEqual(doc.maxScore, 950);
@@ -1384,7 +1384,7 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
       assert.strictEqual(updateManyResp1.upsertedCount, undefined);
       assert.strictEqual(updateManyResp1.upsertedId, undefined);
       const allDocs1 = await collection.find({ }).toArray();
-      //assert that the maxScore field is not set to 50 in all docs because the $max operator does not set the field value to new value when the new vaue is less than existing value
+      //assert that the maxScore field is not set to 50 in all docs because the $max operator does not set the field value to new value when the new value is less than existing value
       allDocs1.forEach(doc => {
         if(doc._id === "id4"){
           assert.strictEqual(doc.maxScore, 950);

--- a/tests/collections/collection.test.ts
+++ b/tests/collections/collection.test.ts
@@ -538,7 +538,13 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
     });
     it('should find doc - return only selected fields (array slice)', async () => {
       //insert some docs
-      let docList = Array.from({ length: 20 }, () => ({ username: "id", address: { city: "nyc" } }));
+      interface Doc {
+        _id?: string;
+        username: string;
+        address: { city: string },
+        tags?: string[]
+      }
+      let docList: Doc[] = Array.from({ length: 20 }, () => ({ username: "id", address: { city: "nyc" } }));
       docList.forEach((doc, index) => {
         doc._id = 'id' + index;
         doc.username = doc.username + (index + 1);
@@ -573,7 +579,13 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
     });
     it('should find doc - return only selected fields (array slice negative)', async () => {
       //insert some docs
-      let docList = Array.from({ length: 20 }, () => ({ username: "id", address: { city: "nyc" } }));
+      interface Doc {
+        _id?: string;
+        username: string;
+        address: { city: string },
+        tags?: string[]
+      }
+      let docList: Doc[] = Array.from({ length: 20 }, () => ({ username: "id", address: { city: "nyc" } }));
       docList.forEach((doc, index) => {
         doc._id = 'id' + index;
         doc.username = doc.username + (index + 1);
@@ -608,7 +620,13 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
     });
     it('should find doc - return only selected fields (array slice gt elements)', async () => {
       //insert some docs
-      let docList = Array.from({ length: 20 }, () => ({ username: "id", address: { city: "nyc" } }));
+      interface Doc {
+        _id?: string;
+        username: string;
+        address: { city: string },
+        tags?: string[]
+      }
+      let docList: Doc[] = Array.from({ length: 20 }, () => ({ username: "id", address: { city: "nyc" } }));
       docList.forEach((doc, index) => {
         doc._id = 'id' + index;
         doc.username = doc.username + (index + 1);
@@ -641,7 +659,13 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
     });
     it('should find doc - return only selected fields (array slice gt elements negative)', async () => {
       //insert some docs
-      let docList = Array.from({ length: 20 }, () => ({ username: "id", address: { city: "nyc" } }));
+      interface Doc {
+        _id?: string;
+        username: string;
+        address: { city: string },
+        tags?: string[]
+      }
+      let docList: Doc[] = Array.from({ length: 20 }, () => ({ username: "id", address: { city: "nyc" } }));
       docList.forEach((doc, index) => {
         doc._id = 'id' + index;
         doc.username = doc.username + (index + 1);
@@ -675,7 +699,8 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
       });
     });
     it('should find & find doc $in test', async () => {
-      let docList = Array.from({ length: 20 }, () => ({ username: "id", city: "nyc" }));
+      interface Doc { _id?: string; username: string; city: string; tags?: string[] }
+      let docList: Doc[] = Array.from({ length: 20 }, () => ({ username: "id", city: "nyc" }));
       docList.forEach((doc, index) => {
         doc._id = 'id' + index;
         doc.username = doc.username + (index + 1);
@@ -704,7 +729,8 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
       assert.ok(ids.has(findOneRespDoc!._id));
     });
     it('should find & find doc $exists test', async () => {
-      let docList = Array.from({ length: 20 }, () => ({ username: "id", city: "nyc" }));
+      interface Doc { _id?: string; username: string; city: string; tags?: string[] }
+      let docList: Doc[] = Array.from({ length: 20 }, () => ({ username: "id", city: "nyc" }));
       docList.forEach((doc, index) => {
         doc._id = 'id' + index;
         doc.username = doc.username + (index + 1);
@@ -726,7 +752,8 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
       assert.ok(findOneRespDoc!.city);
     });
     it('should find & find doc $all test', async () => {
-      let docList = Array.from({ length: 20 }, () => ({ username: "id", city: "nyc" }));
+      interface Doc { _id?: string; username: string; city: string; tags?: string[] }
+      let docList: Doc[] = Array.from({ length: 20 }, () => ({ username: "id", city: "nyc" }));
       docList.forEach((doc, index) => {
         doc._id = 'id' + index;
         doc.username = doc.username + (index + 1);
@@ -754,7 +781,8 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
       assert.strictEqual(findOneRespDoc!._id, docList[5]._id);
     });
     it('should find & find doc $size test', async () => {
-      let docList = Array.from({ length: 20 }, () => ({ username: "id", city: "nyc" }));
+      interface Doc { _id?: string; username: string; city: string; tags?: string[] }
+      let docList: Doc[] = Array.from({ length: 20 }, () => ({ username: "id", city: "nyc" }));
       docList.forEach((doc, index) => {
         doc._id = 'id' + index;
         doc.username = doc.username + (index + 1);
@@ -785,7 +813,8 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
       assert.strictEqual(findOneRespDoc!._id, docList[5]._id);
     });
     it('should find & find doc $size 0 test', async () => {
-      let docList = Array.from({ length: 20 }, () => ({ username: "id", city: "nyc" }));
+      interface Doc { _id?: string; username: string; city: string; tags?: string[] }
+      let docList: Doc[] = Array.from({ length: 20 }, () => ({ username: "id", city: "nyc" }));
       docList.forEach((doc, index) => {
         doc._id = 'id' + index;
         doc.username = doc.username + (index + 1);
@@ -1902,7 +1931,7 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
           "upsert": true
         }
       );
-      assert.ok(value!._id!.match(/^[a-f\d]{24}$/i), value!._id);
+      assert.ok(value!._id!.toString().match(/^[a-f\d]{24}$/i), value!._id!.toString());
     });
   });
   describe('deleteOne tests', () => {
@@ -2129,7 +2158,7 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
       });
 
       const res = await collection.findOne({ _id: 'bigint-test' });
-      assert.strictEqual(res.answer, 42);
+      assert.strictEqual(res!.answer, 42);
     });
     it('should deleteOne with sort', async () => {
       await collection.deleteMany({});

--- a/tests/driver/api.test.ts
+++ b/tests/driver/api.test.ts
@@ -14,7 +14,6 @@
 
 import assert from 'assert';
 import {Db} from '@/src/collections/db';
-import {Collection} from '@src/driver/collection';
 import {Client} from '@/src/collections/client';
 import {
     testClient,
@@ -184,7 +183,7 @@ describe(`Mongoose Model API level tests`, async () => {
                     employee: mongoose.Schema.Types.ObjectId,
                     friends: [String],
                     salary: mongoose.Schema.Types.Decimal128,
-                    favorites: mongoose.Schema.Types.Map,
+                    favorites: Map,
                     nestedSchema: {
                         address: {
                             street: String,
@@ -356,7 +355,8 @@ describe(`Mongoose Model API level tests`, async () => {
             assert.strictEqual(error!.message, 'createIndex() Not Implemented');
         });
         it('API ops tests Model.db', async () => {
-            assert.strictEqual(Product.db.db.name, db.name);
+            const conn = Product.db as unknown as StargateMongooseDriver.Connection;
+            assert.strictEqual(conn.db.name, db.name);
         });
         it('API ops tests Model.deleteMany()', async () => {
             const product1 = new Product({name: 'Product 1', price: 10, isCertified: true, category: 'cat 1'});
@@ -749,13 +749,13 @@ describe(`Mongoose Model API level tests`, async () => {
     describe('vector search', function() {
       afterEach(() => sinon.restore());
 
-      it('supports sort() with vectorSearch option with find()', async function() {
+      it('supports sort() with $meta with find()', async function() {
         const mockCursor = {
           toArray: async () => ([])
         } as unknown as FindCursor<{}>;
-        const collection: Collection = Product.collection;
+        const collection = Product.collection as unknown as StargateMongooseDriver.Collection;
         const find = sinon.stub(collection.collection, 'find').callsFake(() => mockCursor);
-        const res = await Product.find({}).setOptions({ vectorSearch: [1, 2] });
+        const res = await Product.find({}).sort({ $vector: { $meta: [1, 2] } });
         assert.deepStrictEqual(res, []);
         assert.equal(find.getCalls().length, 1);
         const calledWithOptions = find.getCalls()[0].args[1];
@@ -766,11 +766,11 @@ describe(`Mongoose Model API level tests`, async () => {
         });
       });
 
-      it('supports sort() with vectorSearch option with findOne()', async function() {
-        const collection: Collection = Product.collection;
+      it('supports sort() with $meta with findOne()', async function() {
+        const collection = Product.collection as unknown as StargateMongooseDriver.Collection;
         const findOne = sinon.stub(collection.collection, 'findOne')
           .callsFake(() => Promise.resolve(null));
-        const res = await Product.findOne({}).setOptions({ vectorSearch: [1, 2] });
+        const res = await Product.findOne({}).sort({ $vector: { $meta: [1, 2] } });
         assert.deepStrictEqual(res, null);
         assert.equal(findOne.getCalls().length, 1);
         const calledWithOptions = findOne.getCalls()[0].args[1];
@@ -781,11 +781,11 @@ describe(`Mongoose Model API level tests`, async () => {
         });
       });
 
-      it('supports sort() with vectorSearch option with findOneAndUpdate()', async function() {
-        const collection: Collection = Product.collection;
+      it('supports sort() with $meta with findOneAndUpdate()', async function() {
+        const collection = Product.collection as unknown as StargateMongooseDriver.Collection;
         const findOneAndUpdate = sinon.stub(collection.collection, 'findOneAndUpdate')
           .callsFake(() => Promise.resolve({}));
-        await Product.findOneAndUpdate({}, { name: 'iPhone' }, { vectorSearch: [1, 2] });
+        await Product.findOneAndUpdate({}, { name: 'iPhone' }, { sort: { $vector: { $meta: [1, 2] } } });
         assert.equal(findOneAndUpdate.getCalls().length, 1);
         const calledWithOptions = findOneAndUpdate.getCalls()[0].args[2];
         assert.deepEqual(calledWithOptions, {
@@ -795,11 +795,11 @@ describe(`Mongoose Model API level tests`, async () => {
         });
       });
 
-      it('supports sort() with vectorSearch option with findOneAndReplace()', async function() {
-        const collection: Collection = Product.collection;
+      it('supports sort() with $meta with findOneAndReplace()', async function() {
+        const collection = Product.collection as unknown as StargateMongooseDriver.Collection;
         const findOneAndReplace= sinon.stub(collection.collection, 'findOneAndReplace')
           .callsFake(() => Promise.resolve({}));
-        await Product.findOneAndReplace({}, { name: 'iPhone' }, { vectorSearch: [1, 2] });
+        await Product.findOneAndReplace({}, { name: 'iPhone' }, { sort: { $vector: { $meta: [1, 2] } } });
         assert.equal(findOneAndReplace.getCalls().length, 1);
         const calledWithOptions = findOneAndReplace.getCalls()[0].args[2];
         assert.deepEqual(calledWithOptions, {
@@ -809,11 +809,11 @@ describe(`Mongoose Model API level tests`, async () => {
         });
       });
 
-      it('supports sort() with vectorSearch option with findOneAndDelete()', async function() {
-        const collection: Collection = Product.collection;
+      it('supports sort() with $meta with findOneAndDelete()', async function() {
+        const collection = Product.collection as unknown as StargateMongooseDriver.Collection;
         const findOneAndDelete = sinon.stub(collection.collection, 'findOneAndDelete')
           .callsFake(() => Promise.resolve({}));
-        await Product.findOneAndDelete({}, { vectorSearch: [1, 2] });
+        await Product.findOneAndDelete({}, { sort: { $vector: { $meta: [1, 2] } } });
         assert.equal(findOneAndDelete.getCalls().length, 1);
         const calledWithOptions = findOneAndDelete.getCalls()[0].args[1];
         assert.deepEqual(calledWithOptions, {
@@ -823,11 +823,11 @@ describe(`Mongoose Model API level tests`, async () => {
         });
       });
 
-      it('supports sort() with vectorSearch option with deleteOne()', async function() {
-        const collection: Collection = Product.collection;
+      it('supports sort() with $meta with deleteOne()', async function() {
+        const collection = Product.collection as unknown as StargateMongooseDriver.Collection;
         const deleteOne = sinon.stub(collection.collection, 'deleteOne')
           .callsFake(() => Promise.resolve({}));
-        await Product.deleteOne({}, { vectorSearch: [1, 2] });
+        await Product.deleteOne({}, { sort: { $vector: { $meta: [1, 2] } } });
         assert.equal(deleteOne.getCalls().length, 1);
         const calledWithOptions = deleteOne.getCalls()[0].args[1];
         assert.deepEqual(calledWithOptions, {

--- a/tests/driver/api.test.ts
+++ b/tests/driver/api.test.ts
@@ -749,7 +749,7 @@ describe(`Mongoose Model API level tests`, async () => {
     describe('vector search', function() {
       afterEach(() => sinon.restore());
 
-      it('supports sort() with $meta with find()', async function() {
+      it('supports sort() with vectorSearch option with find()', async function() {
         const mockCursor = {
           toArray: async () => ([])
         } as unknown as FindCursor<{}>;
@@ -766,7 +766,7 @@ describe(`Mongoose Model API level tests`, async () => {
         });
       });
 
-      it('supports sort() with $meta with findOne()', async function() {
+      it('supports sort() with vectorSearch option with findOne()', async function() {
         const collection: Collection = Product.collection;
         const findOne = sinon.stub(collection.collection, 'findOne')
           .callsFake(() => Promise.resolve(null));
@@ -781,7 +781,7 @@ describe(`Mongoose Model API level tests`, async () => {
         });
       });
 
-      it('supports sort() with $meta with findOneAndUpdate()', async function() {
+      it('supports sort() with vectorSearch option with findOneAndUpdate()', async function() {
         const collection: Collection = Product.collection;
         const findOneAndUpdate = sinon.stub(collection.collection, 'findOneAndUpdate')
           .callsFake(() => Promise.resolve({}));
@@ -795,7 +795,7 @@ describe(`Mongoose Model API level tests`, async () => {
         });
       });
 
-      it('supports sort() with $meta with findOneAndReplace()', async function() {
+      it('supports sort() with vectorSearch option with findOneAndReplace()', async function() {
         const collection: Collection = Product.collection;
         const findOneAndReplace= sinon.stub(collection.collection, 'findOneAndReplace')
           .callsFake(() => Promise.resolve({}));
@@ -809,7 +809,7 @@ describe(`Mongoose Model API level tests`, async () => {
         });
       });
 
-      it('supports sort() with $meta with findOneAndDelete()', async function() {
+      it('supports sort() with vectorSearch option with findOneAndDelete()', async function() {
         const collection: Collection = Product.collection;
         const findOneAndDelete = sinon.stub(collection.collection, 'findOneAndDelete')
           .callsFake(() => Promise.resolve({}));
@@ -823,7 +823,7 @@ describe(`Mongoose Model API level tests`, async () => {
         });
       });
 
-      it('supports sort() with $meta with deleteOne()', async function() {
+      it('supports sort() with vectorSearch option with deleteOne()', async function() {
         const collection: Collection = Product.collection;
         const deleteOne = sinon.stub(collection.collection, 'deleteOne')
           .callsFake(() => Promise.resolve({}));

--- a/tests/driver/index.test.ts
+++ b/tests/driver/index.test.ts
@@ -117,7 +117,7 @@ describe(`Driver based tests`, async () => {
 
         let productNames: string[] = [];
         const cursor = await Product.find().cursor();
-        await cursor.eachAsync(p => productNames.push(p.name));
+        await cursor.eachAsync(p => productNames.push(p.name!));
         assert.deepEqual(productNames.sort(), ['Product 1', 'Product 2']);
 
         await cart.deleteOne();

--- a/tests/driver/index.test.ts
+++ b/tests/driver/index.test.ts
@@ -43,7 +43,7 @@ describe(`Driver based tests`, async () => {
       });
 
       const productSchema = new mongoose.Schema({
-        name: String,
+        name: { type: String, required: true },
         price: Number,
         expiryDate: Date,
         isCertified: Boolean
@@ -123,7 +123,7 @@ describe(`Driver based tests`, async () => {
       const mongooseInstance = await createMongooseInstance();
 
       const personSchema = new mongooseInstance.Schema({
-        name: String
+        name: { type: String, required: true }
       });
       const Person = mongooseInstance.model('Person', personSchema);
       await Person.init();
@@ -197,7 +197,7 @@ describe(`Driver based tests`, async () => {
       ]);
       const { _id: cartId } = await Cart.create({ name: 'test', products: [productId] });
 
-      const cart = await Cart.findById(cartId).populate('products').orFail();
+      const cart = await Cart.findById(cartId).populate<{ products: (typeof Product)[] }>('products').orFail();
       assert.deepEqual(cart.products.map(p => p.name), ['iPhone 12']);
     });
 
@@ -354,7 +354,8 @@ describe(`Driver based tests`, async () => {
         }
         assert.strictEqual(error.message, 'Cannot drop database in Astra. Please use the Astra UI to drop the database.');
       } else {
-        const resp = await mongooseInstance.connection.dropDatabase();
+        const connection: StargateMongooseDriver.Connection = mongooseInstance.connection as unknown as StargateMongooseDriver.Connection;
+        const resp = await connection.dropDatabase();
         assert.strictEqual(resp.status?.ok, 1);
       }
     });
@@ -383,7 +384,8 @@ describe(`Driver based tests`, async () => {
         }
         assert.strictEqual(error.errors[0].message, 'INVALID_ARGUMENT: Unknown keyspace ' + newKeyspaceName);
       } else {
-        const resp = await mongooseInstance.connection.createCollection('new_collection');
+        const connection: StargateMongooseDriver.Connection = mongooseInstance.connection as unknown as StargateMongooseDriver.Connection;
+        const resp = await connection.createCollection('new_collection');
         assert.strictEqual(resp.status?.ok, 1);
       }
     });


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

There were a bunch of TS failures and `// @ts-ignore` workarounds in the tests. Among them, Mongoose types specifically disallowed `sort({ $vector: { $meta: [1, 2] } })`. With Mongoose 7.4, `sort({ $vector: { $meta: [1, 2] } })` is now valid.

I also went through and cleaned up remaining TS build failures in tests, so `npm run build` succeeds even if you remove `"exclude": ["tests/**/*"]`. Some of the workarounds currently require an inelegant `as unknown as X` type cast, which I would like to improve in the future. But I'm glad we were able to add additional options like `isAstra` to Mongoose's `ConnectOptions`, that will at least make it easier to connect to JSON API.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)