### PR TITLE
typescript improvements using type overrides with `setDriver()`

### DIFF
--- a/src/driver/connection.ts
+++ b/src/driver/connection.ts
@@ -17,10 +17,15 @@ import { Collection } from './collection';
 import { default as MongooseConnection } from 'mongoose/lib/connection';
 import STATES from 'mongoose/lib/connectionstate';
 import { executeOperation } from '../collections/utils';
+import type { Model } from 'mongoose';
 
 export class Connection extends MongooseConnection {
   debugType = 'StargateMongooseConnection';
   initialConnection: Promise<Connection> | null = null;
+  readonly models: Record<
+    string,
+    Model<any>
+  > = {};
 
   constructor(base: any) {
     super(base);

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,13 +17,25 @@ export * as driver from './driver';
 export * as client from './client';
 export * as logger from './logger';
 
+import { Collection, Connection } from './driver';
+import { Model, Mongoose } from 'mongoose';
+
 declare module 'mongoose' {
   interface ConnectOptions {
     isAstra?: boolean;
     logSkippedOptions?: boolean;
     authUrl?: string;
   }
+
+  export function setDriver<TOverrides>(driver: any): Omit<Mongoose, keyof TOverrides> & TOverrides;
 }
+
+export interface StargateMongooseDriverOverrides {
+  mongo: never;
+  connection: Connection;
+  connections: Connection[];
+}
+export type StargateMongoose = Omit<Mongoose, keyof StargateMongooseDriverOverrides> & StargateMongooseDriverOverrides;
 
 import { createStargateUri, createAstraUri } from './collections';
 export { createStargateUri, createAstraUri };

--- a/tests/driver/api.test.ts
+++ b/tests/driver/api.test.ts
@@ -25,6 +25,7 @@ import {randomUUID} from "crypto";
 import sinon from "sinon";
 import {OperationNotSupportedError} from "@/src/driver";
 import { FindCursor } from 'mongodb';
+import type { StargateMongoose, StargateMongooseDriverOverrides } from '@/src/index';
 
 const productSchema = new mongoose.Schema({
   name: String,
@@ -55,8 +56,12 @@ describe(`Mongoose Model API level tests`, async () => {
         dbUri = testClient.uri;
         isAstra = testClient.isAstra;
     });
-    let mongooseInstance: Mongoose | null = null;
-    let Product: Model<any>, Cart: Model<any>, astraMongoose: Mongoose | null, jsonAPIMongoose: Mongoose | null;
+
+    let mongooseInstance: StargateMongoose | null = null;
+    let Product: Model<any>;
+    let Cart: Model<any>;
+    let astraMongoose: StargateMongoose | null;
+    let jsonAPIMongoose: StargateMongoose | null;
     beforeEach(async () => {
         ({Product, Cart, astraMongoose, jsonAPIMongoose} = await createClientsAndModels(isAstra));
     });
@@ -66,8 +71,7 @@ describe(`Mongoose Model API level tests`, async () => {
     });
 
     async function getInstance() {
-        const mongooseInstance = new mongoose.Mongoose();
-        mongooseInstance.setDriver(StargateMongooseDriver);
+        const mongooseInstance = (new mongoose.Mongoose()).setDriver<StargateMongooseDriverOverrides>(StargateMongooseDriver);
         mongooseInstance.set('autoCreate', true);
         mongooseInstance.set('autoIndex', false);
         mongooseInstance.set('strictQuery', false);
@@ -75,7 +79,10 @@ describe(`Mongoose Model API level tests`, async () => {
     }
 
     async function createClientsAndModels(isAstra: boolean) {
-        let Product: Model<any>, Cart: Model<any>, astraMongoose: Mongoose | null = null, jsonAPIMongoose: Mongoose | null = null;
+        let Product: Model<any>;
+        let Cart: Model<any>;
+        let astraMongoose: StargateMongoose | null = null;
+        let jsonAPIMongoose: StargateMongoose | null = null;
         const productSchema = new mongoose.Schema({
             name: String,
             price: Number,
@@ -113,7 +120,7 @@ describe(`Mongoose Model API level tests`, async () => {
         return {Product, Cart, astraMongoose, jsonAPIMongoose};
     }
 
-    async function dropCollections(isAstra: boolean, astraMongoose: mongoose.Mongoose | null, jsonAPIMongoose: mongoose.Mongoose | null, collectionName: string) {
+    async function dropCollections(isAstra: boolean, astraMongoose: StargateMongoose | null, jsonAPIMongoose: StargateMongoose | null, collectionName: string) {
         if (isAstra) {
             await astraMongoose?.connection.dropCollection(collectionName);
         } else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Please consider this PR more of a request for feedback rather than being fully production ready yet. The general idea here is that I'm trying to avoid users needing to use `// @ts-ignore` or `as unknown as Type` workarounds, of which we have a few in `api.test.ts`. Mostly due to accessing connections and collections that are actually stargate-mongoose connections/collections, not plain Mongoose connections/collections

I think the best approach would be to have a `StargateMongoose` type that overrides a bunch of types on the `Mongoose` type, along with a generic param to `setDriver()`. This will enable users to opt in to getting the overridden types using `const mongooseInstance = (new mongoose.Mongoose()).setDriver<StargateMongooseDriverOverrides>(StargateMongooseDriver);`.

I've made progress, but there are a few points of friction:

1. `src/driver/connection` and `src/driver/collection` import Mongoose connections and collections in a non-standard way, `import MongooseCollection from 'mongoose/lib/collection'` rather than `import mongoose from 'mongoose'; mongoose.Collection`. This means that stargate-mongoose Connection and Collection instances are not assignable to values that expect Mongoose Connection and Collection instances. Also means that we can't make `StargateMongoose` extend Mongoose.
2. Mongoose's `model()` functions have fairly complex TypeScript definitions, and we don't want to maintain duplicates.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)