### PR TITLE
Throw error when using find cursor with sort but no limit

### DIFF
--- a/src/collections/cursor.ts
+++ b/src/collections/cursor.ts
@@ -82,6 +82,9 @@ export class FindCursor {
       }
 
       if (this.exhausted) {
+        if (this.options && this.options.sort && this.limit > this.pageIndex) {
+          throw new Error('Cannot load additional cursor data with sort');
+        }
         this.status = 'executed';
       }
 

--- a/src/collections/cursor.ts
+++ b/src/collections/cursor.ts
@@ -39,6 +39,11 @@ export class FindCursor {
     this.collection = collection;
     this.filter = filter;
     this.options = options ?? {};
+
+    if (this.options.sort && (this.options.limit == null || this.options.limit > 20)) {
+      throw new Error('Cannot set sort option without limit <= 20, JSON API can currently only return 20 documents with sort');
+    }
+
     this.limit = options?.limit || Infinity;
     this.status = 'initialized';
     this.exhausted = false;
@@ -82,9 +87,6 @@ export class FindCursor {
       }
 
       if (this.exhausted) {
-        if (this.options && this.options.sort && this.limit > this.pageIndex) {
-          throw new Error('Cannot load additional cursor data with sort');
-        }
         this.status = 'executed';
       }
 

--- a/tests/collections/collection.test.ts
+++ b/tests/collections/collection.test.ts
@@ -2011,7 +2011,7 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
       }
 
       const cursor = await collection.find({}, { sort: { num: -1 } });
-      await cursor.toArray();
+      await assert.rejects(cursor.toArray(), /Cannot load additional cursor data with sort/);
     });
     it('should findOne with sort', async () => {
       await collection.deleteMany({});

--- a/tests/collections/collection.test.ts
+++ b/tests/collections/collection.test.ts
@@ -1998,10 +1998,10 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
         { username: 'b' }
       ]);
 
-      let docs = await collection.find({}, { sort: { username: 1 } }).toArray();
+      let docs = await collection.find({}, { sort: { username: 1 }, limit: 20 }).toArray();
       assert.deepStrictEqual(docs.map(doc => doc.username), ['a', 'b', 'c']);
 
-      docs = await collection.find({}, { sort: { username: -1 } }).toArray();
+      docs = await collection.find({}, { sort: { username: -1 }, limit: 20 }).toArray();
       assert.deepStrictEqual(docs.map(doc => doc.username), ['c', 'b', 'a']);
     });
     it('throws if using cursor with sort', async () => {
@@ -2009,9 +2009,10 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
       for (let i = 0; i < 20; ++i) {
         await collection.insertMany(Array(20).fill(0).map((_, i) => ({ num: i })));
       }
-
-      const cursor = await collection.find({}, { sort: { num: -1 } });
-      await assert.rejects(cursor.toArray(), /Cannot load additional cursor data with sort/);
+      await assert.rejects(
+        async () => collection.find({}, { sort: { num: -1 }, limit: 22 }),
+        /JSON API can currently only return 20 documents with sort/
+      );
     });
     it('should findOne with sort', async () => {
       await collection.deleteMany({});
@@ -2071,7 +2072,7 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
       );
       assert.deepStrictEqual(res.value!.username, 'c');
 
-      const docs = await collection.find({}, { sort: { username: 1 } }).toArray();
+      const docs = await collection.find({}, { sort: { username: 1 }, limit: 20 }).toArray();
       assert.deepStrictEqual(docs.map(doc => doc.answer), [undefined, 42, undefined]);
     });
     it('findOneAndReplace should make _id an ObjectId when upserting with no _id', async () => {
@@ -2173,7 +2174,7 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
         { sort: { username: 1 } }
       );
 
-      const docs = await collection.find({}, { sort: { username: 1 } }).toArray();
+      const docs = await collection.find({}, { sort: { username: 1 }, limit: 20 }).toArray();
       assert.deepStrictEqual(docs.map(doc => doc.username), ['b', 'c']);
     });
     it.skip('should updateOne with sort', async () => {

--- a/tests/collections/cursor.test.ts
+++ b/tests/collections/cursor.test.ts
@@ -78,6 +78,18 @@ describe(`StargateMongoose - ${testClient} Connection - collections.cursor`, asy
       assert.strictEqual(res.length, 3);
       assert.strictEqual(cursor.page.length, 3);
     });
+    it('should treat limit 0 as no limit', async () => {
+      await collection.insertMany(sampleUsers);
+      const cursor = new FindCursor(collection, {}, { limit: 0 });
+      const res = await cursor.toArray();
+      assert.strictEqual(res.length, 3);
+      assert.strictEqual(cursor.page.length, 3);
+    });
+    it('should handle negative limit', async () => {
+      await collection.insertMany(sampleUsers);
+      const cursor = new FindCursor(collection, {}, { limit: -2 });
+      await assert.rejects(cursor.toArray(), /limit should be greater than `0`/);
+    });
     it('should execute a limited query with limit set less than default page size', async () => {
       let docList = Array.from({ length: 20 }, () => ({ "username": "id" }));
       docList.forEach((doc, index) => {

--- a/tests/driver/api.test.ts
+++ b/tests/driver/api.test.ts
@@ -744,6 +744,26 @@ describe(`Mongoose Model API level tests`, async () => {
             assert.strictEqual(whereResp.length, 1);
             assert.strictEqual(whereResp[0].name, 'Product 1');
         });
+        it('API ops tests Query cursor', async () => {
+          await Product.create(
+            Array.from({ length: 25 }, (_, index) => ({
+              name: `Product ${(index + 1).toString().padStart(2, '0')}`,
+              price: 10
+            }))
+          );
+
+          let cursor = await Product.find().sort({ product: 1 }).cursor();
+          for (let i = 0; i < 20; ++i) {
+            await cursor.next();
+          }
+          await assert.rejects(cursor.next(), /Cannot load additional cursor data with sort/);
+
+          cursor = await Product.find().sort({ product: 1 }).limit(20).cursor();
+          for (let i = 0; i < 20; ++i) {
+            await cursor.next();
+          }
+          await cursor.next();
+      });
     });
 
     describe('vector search', function() {

--- a/tests/driver/api.test.ts
+++ b/tests/driver/api.test.ts
@@ -752,17 +752,17 @@ describe(`Mongoose Model API level tests`, async () => {
             }))
           );
 
-          let cursor = await Product.find().sort({ product: 1 }).cursor();
-          for (let i = 0; i < 20; ++i) {
-            await cursor.next();
-          }
-          await assert.rejects(cursor.next(), /Cannot load additional cursor data with sort/);
+          let cursor = Product.find().sort({ product: 1 }).cursor();
+          await assert.rejects(
+            cursor.next(),
+            /JSON API can currently only return 20 documents with sort/
+          );
 
           cursor = await Product.find().sort({ product: 1 }).limit(20).cursor();
           for (let i = 0; i < 20; ++i) {
             await cursor.next();
           }
-          await cursor.next();
+          assert.equal(await cursor.next(), null);
       });
     });
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Right now stargate-mongoose doesn't offer any feedback if you use sort without limit, it just returns max 20 documents. While that limit is reasonable, I think we should consider throwing an error if using sort without limit. That will provide users more immediate feedback on limitations, so they aren't wondering why they're only getting 20 docs.

Related to #83 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)