### PR TITLE
don't throw error if limit is not set on vector search

### DIFF
--- a/src/collections/cursor.ts
+++ b/src/collections/cursor.ts
@@ -40,7 +40,10 @@ export class FindCursor {
     this.filter = filter;
     this.options = options ?? {};
 
-    if (this.options.sort && (this.options.limit == null || this.options.limit > 20)) {
+    const isOverPageSizeLimit = this.options.sort &&
+      this.options.sort.$vector == null &&
+      (this.options.limit == null || this.options.limit > 20);
+    if (isOverPageSizeLimit) {
       throw new Error('Cannot set sort option without limit <= 20, JSON API can currently only return 20 documents with sort');
     }
 

--- a/tests/driver/api.test.ts
+++ b/tests/driver/api.test.ts
@@ -819,6 +819,17 @@ describe(`Mongoose Model API level tests`, async () => {
             find({}).
             sort({ $vector: { $meta: [99, 1] } });
         assert.deepStrictEqual(res.map(doc => doc.name), ['Test vector 2', 'Test vector 1']);
+
+        res = await Vector.
+            find({}).
+            limit(999).
+            sort({ $vector: { $meta: [99, 1] } });
+        assert.deepStrictEqual(res.map(doc => doc.name), ['Test vector 2', 'Test vector 1']);
+
+        await assert.rejects(
+            Vector.find().limit(1001).sort({ $vector: { $meta: [99, 1] } }),
+            /limit options should not be greater than 1000 for vector search/
+        );
       });
 
       it('supports sort() with $meta with findOne()', async function() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Fix tests in main erroring out because vector search supports larger `limit` than regular sort. Given that JSON API throws an error for limit > 1000 for vector search, it doesn't look like stargate-mongoose needs error handling for the case where user specifies an invalid limit with vector search.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)