### PR TITLE
remove version.ts file in favor of importing from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "test": "env TEST_DOC_DB=jsonapi ts-mocha --paths -p tsconfig.json tests/**/*.test.ts",
     "test-astra": "env TEST_DOC_DB=astra nyc ts-mocha --paths -p tsconfig.json tests/**/*.test.ts",
     "test-jsonapi": "env TEST_DOC_DB=jsonapi nyc ts-mocha --paths -p tsconfig.json tests/**/*.test.ts",
-    "preinstall": "node -p \"'export const LIB_NAME = ' + JSON.stringify(require('./package.json').name) + ';'\" > src/version.ts && node -p \"'export const LIB_VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" >> src/version.ts",
     "build": "tsc --project tsconfig.build.json && tscpaths -p tsconfig.build.json -s ./src -o ./dist",
     "build:docs": "jsdoc2md -t APIReference.hbs --files src/**/*.ts --configure ./jsdoc2md.json > APIReference.md"
   },

--- a/src/client/httpClient.ts
+++ b/src/client/httpClient.ts
@@ -16,11 +16,11 @@ import http from 'http';
 import axios, { AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
 import { logger, setLevel } from '@/src/logger';
 import { inspect } from 'util';
-import { LIB_NAME, LIB_VERSION } from '../version';
+import { name, version } from '../../package.json';
 import { getStargateAccessToken } from '../collections/utils';
 import { EJSON } from 'bson';
 
-const REQUESTED_WITH = LIB_NAME + '/' + LIB_VERSION;
+const REQUESTED_WITH = name + '/' + version;
 const DEFAULT_AUTH_HEADER = 'X-Cassandra-Token';
 const DEFAULT_METHOD = 'get';
 const DEFAULT_TIMEOUT = 30000;

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,0 @@
-export const LIB_NAME = "stargate-mongoose";
-export const LIB_VERSION = "0.2.0-ALPHA-5";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
+    "resolveJsonModule": true,
     "paths": {
       "@/src/*": ["./src/*"],
       "@/tests/*": ["./tests/*"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Alternative approach for #126: I'm not entirely convinced we even need the `version.ts` file. Having the current version and package name in two places makes it possible that they will fall out of sync, and TypeScript does support importing json files with an additional compiler flag. So perhaps we just import `package.json`?

Only potential downside is that stargate-mongoose will now ship with a duplicate copy of `package.json` in `dist/package.json`, but that doesn't seem like a big problem. But I figure I'll put this out there as an option.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)