### PR TITLE
Upgrade to Mongoose 7.5 for better $vector support

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "dotenv": "^16.0.1",
     "jsdoc-babel": "^0.5.0",
     "jsdoc-to-markdown": "^7.1.1",
-    "mongoose": "git@github.com:Automattic/mongoose.git#vkarpov15/handle-top-level-dollar-keys",
+    "mongoose": "^7.5.0",
     "nyc": "^15.1.0",
     "sinon": "15.2.0",
     "ts-mocha": "^10.0.0",
@@ -89,7 +89,7 @@
     "winston": "^3.7.2"
   },
   "peerDependencies": {
-    "mongoose": "^7.4.0"
+    "mongoose": "^7.5.0"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "dotenv": "^16.0.1",
     "jsdoc-babel": "^0.5.0",
     "jsdoc-to-markdown": "^7.1.1",
-    "mongoose": "^7.4.0",
+    "mongoose": "git@github.com:Automattic/mongoose.git#vkarpov15/handle-top-level-dollar-keys",
     "nyc": "^15.1.0",
     "sinon": "15.2.0",
     "ts-mocha": "^10.0.0",

--- a/src/collections/collection.ts
+++ b/src/collections/collection.ts
@@ -107,13 +107,24 @@ export class Collection {
 
   async updateOne(filter: Record<string, any>, update: Record<string, any>, options?: UpdateOneOptions) {
     return executeOperation(async (): Promise<JSONAPIUpdateResult> => {
-      const command = {
+      type UpdateOneCommand = {
+        updateOne: {
+          filter?: Record<string, any>,
+          sort?: SortOption,
+          update?: Record<string, any>,
+          options?: UpdateOneOptions
+        }
+      }
+      const command: UpdateOneCommand = {
         updateOne: {
           filter,
           update,
           options
         }
       };
+      if (options?.sort != null) {
+        command.updateOne.sort = options?.sort;
+      }
       setDefaultIdForUpsert(command.updateOne);
       const updateOneResp = await this.httpClient.executeCommand(command, updateOneInternalOptionsKeys);
       let resp = {

--- a/tests/driver/api.test.ts
+++ b/tests/driver/api.test.ts
@@ -846,27 +846,42 @@ describe(`Mongoose Model API level tests`, async () => {
 
       it('supports sort() with $meta with findOneAndUpdate()', async function() {
         const res = await Vector.
-            findOneAndUpdate({}, { name: 'found vector' }, { returnDocument: 'after' }).
+            findOneAndUpdate(
+              {},
+              { name: 'found vector', $vector: [990, 1] },
+              { returnDocument: 'before' }
+            ).
             sort({ $vector: { $meta: [99, 1] } });
         assert.deepStrictEqual(res.$vector, [100, 1]);
-        assert.strictEqual(res.name, 'found vector');
+        assert.strictEqual(res.name, 'Test vector 2');
+
+        const doc = await Vector.findById(res._id);
+        assert.strictEqual(doc.name, 'found vector');
+        assert.deepStrictEqual(doc.$vector, [990, 1]);
       });
 
       it('supports sort() with $meta with findOneAndReplace()', async function() {
         const res = await Vector.
             findOneAndReplace(
                 {},
-                { name: 'found vector' },
+                { name: 'found vector', $vector: [990, 1] },
                 { returnDocument: 'before' }
             ).
             sort({ $vector: { $meta: [99, 1] } });
         assert.deepStrictEqual(res.$vector, [100, 1]);
         assert.strictEqual(res.name, 'Test vector 2');
+
+        const doc = await Vector.findById(res._id);
+        assert.strictEqual(doc.name, 'found vector');
+        assert.deepStrictEqual(doc.$vector, [990, 1]);
       });
 
       it('supports sort() with $meta with findOneAndDelete()', async function() {
         const res = await Vector.
-            findOneAndDelete({}, { name: 'found vector' }, { returnDocument: 'before' }).
+            findOneAndDelete(
+                {},
+                { returnDocument: 'before' }
+            ).
             sort({ $vector: { $meta: [1, 99] } });
         assert.deepStrictEqual(res.$vector, [1, 100]);
         assert.strictEqual(res.name, 'Test vector 1');


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

We need Mongoose 7.5 in order to be able to update `$vector` using `updateOne()`, `findOneAndUpdate()`, etc. Also fixed an issue where we weren't passing sort option to `updateOne()`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)