### PR TITLE
add MongoDB as peer dependency to avoid module not found errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "winston": "^3.7.2"
   },
   "peerDependencies": {
+    "mongodb": "^5.8.0",
     "mongoose": "^7.5.0"
   },
   "engines": {

--- a/src/collections/index.ts
+++ b/src/collections/index.ts
@@ -14,7 +14,6 @@
 
 export { Client } from './client';
 export { Collection } from './collection';
-export { Binary, Decimal128, ObjectId, ReadPreference } from 'mongodb';
 
 export {
     FindOneAndDeleteOptions,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Turns out that https://github.com/stargate/stargate-mongoose-sample-apps/pull/58 actually was necessary in some cases. Without that dependency, seed script started failing on my local with the following error:

```
$ npm run seed

> photography-site@1.0.0 seed
> env NODE_ENV=development node ./server/models/seed

node:internal/modules/cjs/loader:998
  throw err;
  ^

Error: Cannot find module 'mongodb'
Require stack:
- /home/val/Workspace/stargate/stargate-mongoose-sample-apps/photography-site-demo.js/node_modules/stargate-mongoose/dist/collections/utils.js
- /home/val/Workspace/stargate/stargate-mongoose-sample-apps/photography-site-demo.js/node_modules/stargate-mongoose/dist/client/httpClient.js
- /home/val/Workspace/stargate/stargate-mongoose-sample-apps/photography-site-demo.js/node_modules/stargate-mongoose/dist/client/index.js
- /home/val/Workspace/stargate/stargate-mongoose-sample-apps/photography-site-demo.js/node_modules/stargate-mongoose/dist/collections/db.js
- /home/val/Workspace/stargate/stargate-mongoose-sample-apps/photography-site-demo.js/node_modules/stargate-mongoose/dist/collections/client.js
- /home/val/Workspace/stargate/stargate-mongoose-sample-apps/photography-site-demo.js/node_modules/stargate-mongoose/dist/collections/index.js
- /home/val/Workspace/stargate/stargate-mongoose-sample-apps/photography-site-demo.js/node_modules/stargate-mongoose/dist/index.js
- /home/val/Workspace/stargate/stargate-mongoose-sample-apps/photography-site-demo.js/server/models/mongoose.js
- /home/val/Workspace/stargate/stargate-mongoose-sample-apps/photography-site-demo.js/server/models/Category.js
- /home/val/Workspace/stargate/stargate-mongoose-sample-apps/photography-site-demo.js/server/models/seed.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:995:15)
    at Module._load (node:internal/modules/cjs/loader:841:27)
    at Module.require (node:internal/modules/cjs/loader:1061:19)
    at require (node:internal/modules/cjs/helpers:103:18)
    at Object.<anonymous> (/home/val/Workspace/stargate/stargate-mongoose-sample-apps/photography-site-demo.js/node_modules/stargate-mongoose/dist/collections/utils.js:20:19)
    at Module._compile (node:internal/modules/cjs/loader:1159:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1213:10)
    at Module.load (node:internal/modules/cjs/loader:1037:32)
    at Module._load (node:internal/modules/cjs/loader:878:12)
    at Module.require (node:internal/modules/cjs/loader:1061:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/home/val/Workspace/stargate/stargate-mongoose-sample-apps/photography-site-demo.js/node_modules/stargate-mongoose/dist/collections/utils.js',
    '/home/val/Workspace/stargate/stargate-mongoose-sample-apps/photography-site-demo.js/node_modules/stargate-mongoose/dist/client/httpClient.js',
    '/home/val/Workspace/stargate/stargate-mongoose-sample-apps/photography-site-demo.js/node_modules/stargate-mongoose/dist/client/index.js',
    '/home/val/Workspace/stargate/stargate-mongoose-sample-apps/photography-site-demo.js/node_modules/stargate-mongoose/dist/collections/db.js',
    '/home/val/Workspace/stargate/stargate-mongoose-sample-apps/photography-site-demo.js/node_modules/stargate-mongoose/dist/collections/client.js',
    '/home/val/Workspace/stargate/stargate-mongoose-sample-apps/photography-site-demo.js/node_modules/stargate-mongoose/dist/collections/index.js',
    '/home/val/Workspace/stargate/stargate-mongoose-sample-apps/photography-site-demo.js/node_modules/stargate-mongoose/dist/index.js',
    '/home/val/Workspace/stargate/stargate-mongoose-sample-apps/photography-site-demo.js/server/models/mongoose.js',
    '/home/val/Workspace/stargate/stargate-mongoose-sample-apps/photography-site-demo.js/server/models/Category.js',
    '/home/val/Workspace/stargate/stargate-mongoose-sample-apps/photography-site-demo.js/server/models/seed.js'
  ]
}

Node.js v18.12.1
```

I guess that, although npm _should_ pull mongodb as a top-level dependency, it doesn't have to unless stargate-mongoose explicitly lists mongodb as a peer dependency.

@kathirsvn what do you think about removing all dependencies on mongodb from stargate-mongoose? Right now we use the mongodb package for ObjectId and some return types: we can declare the return types in stargate-mongoose, and we can use Mongoose's `mongoose.Types.ObjectId` for ObjectIds.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)