### PR TITLE
remove MongoDB Node driver dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "winston": "^3.7.2"
   },
   "peerDependencies": {
-    "mongodb": "^5.8.0",
     "mongoose": "^7.5.0"
   },
   "engines": {

--- a/src/collections/utils.ts
+++ b/src/collections/utils.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { ObjectId } from 'mongodb';
+import { Types } from 'mongoose';
 import url from 'url';
 import { logger } from '@/src/logger';
 import axios from 'axios';
@@ -236,7 +236,7 @@ export function setDefaultIdForUpsert(command: Record<string, any>, replace?: bo
         if (command.replacement != null && '_id' in command.replacement) {
             return;
         }
-        command.replacement._id = new ObjectId();
+        command.replacement._id = new Types.ObjectId();
     } else {
         if (command.update != null && _updateHasKey(command.update, '_id')) {
             return;
@@ -248,7 +248,7 @@ export function setDefaultIdForUpsert(command: Record<string, any>, replace?: bo
             command.update.$setOnInsert = {};
         }
         if (!('_id' in command.update.$setOnInsert)) {
-            command.update.$setOnInsert._id = new ObjectId();
+            command.update.$setOnInsert._id = new Types.ObjectId();
         }
     }
 }

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -25,7 +25,7 @@ import {
     UpdateManyOptions,
     UpdateOneOptions
 } from '@/src/collections/options';
-import { DeleteResult } from 'mongodb';
+import { JSONAPIDeleteResult } from '../collections/collection';
 
 type NodeCallback<ResultType = any> = (err: Error | null, res: ResultType | null) => unknown;
 
@@ -109,7 +109,7 @@ export class Collection extends MongooseCollection {
         return this.collection.deleteMany(filter);
     }
 
-    deleteOne(filter: Record<string, any>, options?: DeleteOneOptions, callback?: NodeCallback<DeleteResult>) {
+    deleteOne(filter: Record<string, any>, options?: DeleteOneOptions, callback?: NodeCallback<JSONAPIDeleteResult>) {
         if (options != null) {
             processSortOption(options);
         }
@@ -117,7 +117,7 @@ export class Collection extends MongooseCollection {
         const promise = this.collection.deleteOne(filter, options);
 
         if (callback != null) {
-            promise.then((res: DeleteResult) => callback(null, res), (err: Error) => callback(err, null));
+            promise.then((res: JSONAPIDeleteResult) => callback(null, res), (err: Error) => callback(err, null));
         }
 
         return promise;

--- a/src/driver/index.ts
+++ b/src/driver/index.ts
@@ -13,5 +13,4 @@
 // limitations under the License.
 
 export { Connection } from './connection';
-export { Binary, ObjectId, Decimal128, ReadPreference } from 'mongodb';
 export { Collection, OperationNotSupportedError } from './collection';

--- a/tests/collections/options.test.ts
+++ b/tests/collections/options.test.ts
@@ -18,7 +18,6 @@ import { Client } from '@/src/collections/client';
 import { testClient, TEST_COLLECTION_NAME } from '@/tests/fixtures';
 import mongoose from 'mongoose';
 import * as StargateMongooseDriver from '@/src/driver';
-import {ObjectId} from 'mongodb';
 
 describe('Options tests', async () => {
     let astraClient: Client | null;
@@ -257,7 +256,7 @@ describe('Options tests', async () => {
             }
             await Product.insertMany(products, { ordered: true, rawResult: false });
             //findOneAndUpdate with rawResult option
-            const upsertId: ObjectId = new ObjectId();
+            const upsertId = new mongoose.Types.ObjectId();
             const findOneAndUpdateResp = await Product.findOneAndUpdate({ name: 'Product 25' },
                 { '$set' : {price: 20, isCertified: false, name: 'Product 25'}, '$setOnInsert' : {_id: upsertId} },
                 { rawResult: false, upsert: true, returnDocument: 'after' });


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Re: discussion from #131, removes any imports of the MongoDB Node driver in favor of declaring stargate-mongoose's own types inline and using `mongoose.Types.ObjectId`.

I also moved `type` definitions to top-level in `collections.ts` because that was causing the linter to not pick up indentation correctly.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)