### PR TITLE
release 0.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stargate-mongoose",
-  "version": "0.2.0-ALPHA-6",
+  "version": "0.2.1",
   "description": "Stargate's NodeJS Mongoose compatability client",
   "contributors": [
     "CRW (http://barnyrubble.tumblr.com/)",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

I was looking into why dependabot on stargate-mongoose-sample-apps didn't pick up yesterday's release, and it looks like dependabot doesn't handle pre-releases: https://github.com/dependabot/dependabot-core/issues/2250 . So we would need to ship a v0.2.1 release to test #57.

I don't think there's any reason for us to continue doing `-ALPHA` releases, because in npm semantics `v0.2.0-ALPHA-6` is a pre-release for `v0.2.0`, not an indicator that "this entire package is an alpha release". What do you think @kathirsvn ?

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)