### PR TITLE
Reverted the version.ts changes and creating a new release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stargate-mongoose",
-  "version": "0.2.0-ALPHA-7",
+  "version": "0.2.0-ALPHA-8",
   "description": "Stargate's NodeJS Mongoose compatability client",
   "contributors": [
     "CRW (http://barnyrubble.tumblr.com/)",
@@ -54,8 +54,10 @@
     "test": "env TEST_DOC_DB=jsonapi ts-mocha --paths -p tsconfig.json tests/**/*.test.ts",
     "test-astra": "env TEST_DOC_DB=astra nyc ts-mocha --paths -p tsconfig.json tests/**/*.test.ts",
     "test-jsonapi": "env TEST_DOC_DB=jsonapi nyc ts-mocha --paths -p tsconfig.json tests/**/*.test.ts",
-    "build": "tsc --project tsconfig.build.json && tscpaths -p tsconfig.build.json -s ./src -o ./dist",
-    "build:docs": "jsdoc2md -t APIReference.hbs --files src/**/*.ts --configure ./jsdoc2md.json > APIReference.md"
+    "preinstall": "npm run update-version-file",
+    "build": "npm run update-version-file && tsc --project tsconfig.build.json && tscpaths -p tsconfig.build.json -s ./src -o ./dist",
+    "build:docs": "jsdoc2md -t APIReference.hbs --files src/**/*.ts --configure ./jsdoc2md.json > APIReference.md",
+    "update-version-file": "node -p \"'export const LIB_NAME = ' + JSON.stringify(require('./package.json').name) + ';'\" > src/version.ts && node -p \"'export const LIB_VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" >> src/version.ts"
   },
   "bugs": {
     "url": "https://github.com/stargate/stargate-mongoose/issues"

--- a/src/client/httpClient.ts
+++ b/src/client/httpClient.ts
@@ -16,11 +16,11 @@ import http from 'http';
 import axios, { AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
 import { logger, setLevel } from '@/src/logger';
 import { inspect } from 'util';
-import { name, version } from '../../package.json';
+import { LIB_NAME, LIB_VERSION } from '../version';
 import { getStargateAccessToken } from '../collections/utils';
 import { EJSON } from 'bson';
 
-const REQUESTED_WITH = name + '/' + version;
+const REQUESTED_WITH = LIB_NAME + '/' + LIB_VERSION;
 const DEFAULT_AUTH_HEADER = 'X-Cassandra-Token';
 const DEFAULT_METHOD = 'get';
 const DEFAULT_TIMEOUT = 30000;

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,2 @@
+export const LIB_NAME = "stargate-mongoose";
+export const LIB_VERSION = "0.2.0-ALPHA-8";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,6 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
-    "resolveJsonModule": true,
     "paths": {
       "@/src/*": ["./src/*"],
       "@/tests/*": ["./tests/*"]


### PR DESCRIPTION
**What this PR does**:
This PR reverts the changes done to remove `version.ts` file in [this commit](https://github.com/stargate/stargate-mongoose/commit/ea5b4976d2544a40f966b8a3ae2d3282e4ff7932).

The reason for reverting is that:
```text
After the changes done to remove the verstion.ts file especially the change done in package.json (`resolveJsonModule: true`)  in tsconfig.json, the packaging is done differently and the apps using the library fails

- https://www.npmjs.com/package/stargate-mongoose/v/0.2.0-ALPHA-5?activeTab=code (index.js is packaged under dist directly) 
- https://www.npmjs.com/package/stargate-mongoose/v/0.2.0-ALPHA-7?activeTab=code (index.js is packaged under src under dist)

_Error from the apps using stargate-mongoose latest version:
Error: Cannot find module '/node_modules/stargate-mongoose/dist/index.js'. Please verify that the package.json has a valid "main" entry_

I tried to change main property inside package.json from "main": "dist/index.js"  to "main": "dist/src/index.js" but that didn't help.
```

**Checklist**
- [X] Changes manually tested
- [X] Automated Tests added/updated
- [X] Documentation added/updated
- [X] CLA Signed: [DataStax CLA](https://cla.datastax.com/)