### PR TITLE
improve typings in api.test.ts for vector tests

### DIFF
--- a/tests/driver/api.test.ts
+++ b/tests/driver/api.test.ts
@@ -775,15 +775,14 @@ describe('Mongoose Model API level tests', async () => {
                 autoCreate: true
             }
         );
-        let Vector: Model<any>;
+        const Vector = mongooseInstance!.model(
+            'Vector',
+            vectorSchema,
+            'vector'
+        );
 
         this.beforeEach(async function() {
-            await mongooseInstance.connection.dropCollection('vector');
-            Vector = mongooseInstance.model(
-                'Vector',
-                vectorSchema,
-                'vector'
-            );
+            await mongooseInstance!.connection.dropCollection('vector');
         
             await Vector.init();
             await Vector.create([
@@ -838,10 +837,11 @@ describe('Mongoose Model API level tests', async () => {
                 sort({ $vector: { $meta: [99, 1] } });
             assert.deepStrictEqual(res.map(doc => doc.name), ['Test vector 2', 'Test vector 1']);
 
-            res = await Vector.
+            const doc = await Vector.
                 findOne({}).
+                orFail().
                 sort({ $vector: { $meta: [99, 1] } });
-            assert.deepStrictEqual(res.name, 'Test vector 2');
+            assert.deepStrictEqual(doc.name, 'Test vector 2');
 
             await assert.rejects(
                 Vector.find().limit(1001).sort({ $vector: { $meta: [99, 1] } }),
@@ -868,11 +868,12 @@ describe('Mongoose Model API level tests', async () => {
                     { name: 'found vector', $vector: [990, 1] },
                     { returnDocument: 'before' }
                 ).
+                orFail().
                 sort({ $vector: { $meta: [99, 1] } });
             assert.deepStrictEqual(res.$vector, [100, 1]);
             assert.strictEqual(res.name, 'Test vector 2');
 
-            const doc = await Vector.findById(res._id);
+            const doc = await Vector.findById(res._id).orFail();
             assert.strictEqual(doc.name, 'found vector');
             assert.deepStrictEqual(doc.$vector, [990, 1]);
         });
@@ -903,7 +904,8 @@ describe('Mongoose Model API level tests', async () => {
                     { name: 'Test vector 2' },
                     { $unset: { $vector: 1 } },
                     { returnDocument: 'after' }
-                );
+                ).
+                orFail();
             assert.deepStrictEqual(res.$vector, undefined);
             assert.strictEqual(res.name, 'Test vector 2');
         });
@@ -915,11 +917,12 @@ describe('Mongoose Model API level tests', async () => {
                     { name: 'found vector', $vector: [990, 1] },
                     { returnDocument: 'before' }
                 ).
+                orFail().
                 sort({ $vector: { $meta: [99, 1] } });
             assert.deepStrictEqual(res.$vector, [100, 1]);
             assert.strictEqual(res.name, 'Test vector 2');
 
-            const doc = await Vector.findById(res._id);
+            const doc = await Vector.findById(res._id).orFail();
             assert.strictEqual(doc.name, 'found vector');
             assert.deepStrictEqual(doc.$vector, [990, 1]);
         });
@@ -930,6 +933,7 @@ describe('Mongoose Model API level tests', async () => {
                     {},
                     { returnDocument: 'before' }
                 ).
+                orFail().
                 sort({ $vector: { $meta: [1, 99] } });
             assert.deepStrictEqual(res.$vector, [1, 100]);
             assert.strictEqual(res.name, 'Test vector 1');


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Re: discussion from https://github.com/stargate/stargate-mongoose/pull/140#discussion_r1347817301, the issue is that `Model<any>` type definition. Better to let TypeScript infer `Vector` as the correct type and then use `Vector` correctly throughout.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)