### PR TITLE
make eslint ignore arguments for no-unused-vars rule so we don't need to prefix unused args with `_`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,8 +45,9 @@ module.exports = {
                 '@typescript-eslint/no-empty-function': 'off',
                 '@typescript-eslint/no-unused-vars': [
                     'warn',
-                    // https://stackoverflow.com/questions/64052318/how-to-disable-warn-about-some-unused-params-but-keep-typescript-eslint-no-un
-                    {  'argsIgnorePattern': '^_' }
+                    // Never warn about unused parameters
+                    // See: https://eslint.org/docs/latest/rules/no-unused-vars#args
+                    {'args': 'none'}
                 ]
             }
         }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,10 +3,6 @@
 module.exports = {
     rules: {
         'semi': 'error',
-        'no-dupe-keys': 'error',
-        'no-const-assign': 'error',
-        'no-undef': 'error',
-        'no-unreachable': 'error',
 
         // Warnings: style and readability concerns
         'indent': [
@@ -37,6 +33,8 @@ module.exports = {
                 '@typescript-eslint'
             ],
             rules: {
+                'no-dupe-keys': 'error',
+                'no-unreachable': 'error',
                 '@typescript-eslint/ban-ts-comment': 'off',
                 '@typescript-eslint/no-non-null-assertion': 'off',
                 '@typescript-eslint/no-explicit-any': 'off',

--- a/src/collections/cursor.ts
+++ b/src/collections/cursor.ts
@@ -163,7 +163,7 @@ export class FindCursor {
    * @param options
    * @returns Promise<number>
    */
-    async count(_options?: any) {
+    async count(options?: any) {
         return executeOperation(async () => {
             await this.getAll();
             return this.documents.length;
@@ -176,7 +176,7 @@ export class FindCursor {
    *
    * @param options
    */
-    stream(_options?: any) {
+    stream(options?: any) {
         throw new Error('Streaming cursors are not supported');
     }
 }

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -134,27 +134,27 @@ export class Collection extends MongooseCollection {
         return this.collection.updateMany(filter, update, options);
     }
 
-    bulkWrite(_ops: any[], _options?: any) {
+    bulkWrite(ops: any[], options?: any) {
         throw new OperationNotSupportedError('bulkWrite() Not Implemented');
     }
 
-    aggregate(_pipeline: any[], _options?: any) {
+    aggregate(pipeline: any[], options?: any) {
         throw new OperationNotSupportedError('aggregate() Not Implemented');
     }
 
-    bulkSave(_docs: any[], _options?: any) {
+    bulkSave(docs: any[], options?: any) {
         throw new OperationNotSupportedError('bulkSave() Not Implemented');
     }
 
-    cleanIndexes(_options?: any) {
+    cleanIndexes(options?: any) {
         throw new OperationNotSupportedError('cleanIndexes() Not Implemented');
     }
 
-    listIndexes(_options?: any) {
+    listIndexes(options?: any) {
         throw new OperationNotSupportedError('listIndexes() Not Implemented');
     }
 
-    createIndex(_fieldOrSpec: any, _options?: any) {
+    createIndex(fieldOrSpec: any, options?: any) {
         throw new OperationNotSupportedError('createIndex() Not Implemented');
     }
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

We previously prefixed unused args with `_` to appease eslint, but turns out there's a way to ignore arguments for the purposes of the `no-unused-vars` rule, so we should just do that. That way, we don't need to name arguments with `_` in JSDoc comments.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)