### PR TITLE
add support for includeSimilarity option re: stargate/jsonapi#500

### DIFF
--- a/src/collections/collection.ts
+++ b/src/collections/collection.ts
@@ -32,6 +32,7 @@ import {
     UpdateOneOptions,
     FindOptions,
     SortOption,
+    findOneInternalOptionsKeys
 } from './options';
 
 export interface JSONAPIUpdateResult {
@@ -266,7 +267,7 @@ export class Collection {
                 command.findOne.projection = options.projection;
             }
 
-            const resp = await this.httpClient.executeCommand(command, null);
+            const resp = await this.httpClient.executeCommand(command, findOneInternalOptionsKeys);
             return resp.data.document;
         });
     }

--- a/src/collections/collection.ts
+++ b/src/collections/collection.ts
@@ -259,6 +259,7 @@ export class Collection {
 
             if (options?.sort) {
                 command.findOne.sort = options.sort;
+                delete options.sort;
             }
 
             if (options?.projection && Object.keys(options.projection).length > 0) {

--- a/src/collections/cursor.ts
+++ b/src/collections/cursor.ts
@@ -134,7 +134,6 @@ export class FindCursor {
         if (Object.keys(options).length > 0) {
             command.find.options = options;
         }
-        console.log('FX', command);
         const resp = await this.collection.httpClient.executeCommand(command, findInternalOptionsKeys);
         this.nextPageState = resp.data.nextPageState;
         if (this.nextPageState == null) {

--- a/src/collections/cursor.ts
+++ b/src/collections/cursor.ts
@@ -125,12 +125,16 @@ export class FindCursor {
         if (this.options?.skip) {
             options.skip = this.options.skip;
         }
+        if (this.options.includeSimilarity) {
+          options.includeSimilarity = this.options.includeSimilarity;
+        }
         if (this.options?.projection && Object.keys(this.options.projection).length > 0) {
             command.find.projection = this.options.projection;
         }
         if (Object.keys(options).length > 0) {
             command.find.options = options;
         }
+        console.log('FX', command);
         const resp = await this.collection.httpClient.executeCommand(command, findInternalOptionsKeys);
         this.nextPageState = resp.data.nextPageState;
         if (this.nextPageState == null) {

--- a/src/collections/cursor.ts
+++ b/src/collections/cursor.ts
@@ -126,7 +126,7 @@ export class FindCursor {
             options.skip = this.options.skip;
         }
         if (this.options.includeSimilarity) {
-          options.includeSimilarity = this.options.includeSimilarity;
+            options.includeSimilarity = this.options.includeSimilarity;
         }
         if (this.options?.projection && Object.keys(this.options.projection).length > 0) {
             command.find.projection = this.options.projection;

--- a/src/collections/options.ts
+++ b/src/collections/options.ts
@@ -44,6 +44,7 @@ export const findInternalOptionsKeys: Set<string> = new Set(
 export interface FindOneOptions {
     sort?: Record<string, 1 | -1>;
     projection?: ProjectionOption;
+    includeSimilarity?: boolean;
 }
 
 export interface FindOneAndDeleteOptions {

--- a/src/collections/options.ts
+++ b/src/collections/options.ts
@@ -47,6 +47,14 @@ export interface FindOneOptions {
     includeSimilarity?: boolean;
 }
 
+class _FindOneOptionsInternal {
+    includeSimilarity?: boolean = undefined;
+}
+
+export const findOneInternalOptionsKeys: Set<string> = new Set(
+    Object.keys(new _FindOneOptionsInternal)
+);
+
 export interface FindOneAndDeleteOptions {
     sort?: SortOption;
 }

--- a/src/collections/options.ts
+++ b/src/collections/options.ts
@@ -25,12 +25,14 @@ export interface FindOptions {
     skip?: number;
     sort?: SortOption;
     projection?: ProjectionOption;
+    includeSimilarity?: boolean;
 }
 
 class _FindOptionsInternal {
     limit?: number = undefined;
     skip?: number = undefined;
     pagingState?: string = undefined;
+    includeSimilarity?: boolean = undefined;
 }
 
 export interface FindOptionsInternal extends _FindOptionsInternal {}

--- a/tests/driver/api.test.ts
+++ b/tests/driver/api.test.ts
@@ -813,10 +813,18 @@ describe('Mongoose Model API level tests', async () => {
             assert.deepStrictEqual(res.map(doc => doc.get('$similarity')), [1, 0.51004946]);
         });
 
-        it('supports sort() and similarity score with $meta with findOne()', async function() {
-            const doc: any = await Vector.findOne({}, { name: 1, $similarity : 1}).sort({ $vector: { $meta: [1, 99] } });
+        it('supports sort() and similarity score with $meta with findOne() XX', async function() {
+            const doc = await Vector
+                .findOne({}, { name: 1, $similarity : 1 })
+                .sort({ $vector: { $meta: [1, 99] } });
             assert.strictEqual(doc.name, 'Test vector 1');
             assert.strictEqual(doc.get('$similarity'), 1);
+
+            const doc2 = await Vector
+                .findOne({}, null, { includeSimilarity: true })
+                .sort({ $vector: { $meta: [1, 99] } });
+            assert.strictEqual(doc2.name, 'Test vector 1');
+            assert.strictEqual(doc2.get('$similarity'), 1);
         });
 
         it('supports sort() with $meta with find()', async function() {

--- a/tests/driver/api.test.ts
+++ b/tests/driver/api.test.ts
@@ -808,7 +808,7 @@ describe('Mongoose Model API level tests', async () => {
         });
 
         it('supports sort() and similarity score with $meta with find()', async function() {
-            const res = await Vector.find({}, { name: 1, $similarity : 1}).sort({ $vector: { $meta: [1, 99] } });
+            const res = await Vector.find({}, null, { includeSimilarity: true }).sort({ $vector: { $meta: [1, 99] } });
             assert.deepStrictEqual(res.map(doc => doc.name), ['Test vector 1', 'Test vector 2']);
             assert.deepStrictEqual(res.map(doc => doc.get('$similarity')), [1, 0.51004946]);
         });

--- a/tests/driver/api.test.ts
+++ b/tests/driver/api.test.ts
@@ -813,7 +813,7 @@ describe('Mongoose Model API level tests', async () => {
             assert.deepStrictEqual(res.map(doc => doc.get('$similarity')), [1, 0.51004946]);
         });
 
-        it('supports sort() and similarity score with $meta with findOne() XX', async function() {
+        it('supports sort() and similarity score with $meta with findOne()', async function() {
             const doc = await Vector
                 .findOne({}, { name: 1, $similarity : 1 })
                 .sort({ $vector: { $meta: [1, 99] } });


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Make it possible to set the `includeSimilarity` option on `find()` re: stargate/jsonapi#500

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)