### PR TITLE
add test coverage for #83

### DIFF
--- a/src/collections/cursor.ts
+++ b/src/collections/cursor.ts
@@ -35,8 +35,8 @@ export class FindCursor {
         this.options = options ?? {};
 
         const isOverPageSizeLimit = this.options.sort &&
-      this.options.sort.$vector == null &&
-      (this.options.limit == null || this.options.limit > 20);
+            this.options.sort.$vector == null &&
+            (this.options.limit == null || this.options.limit > 20);
         if (isOverPageSizeLimit) {
             throw new Error('Cannot set sort option without limit <= 20, JSON API can currently only return 20 documents with sort');
         }

--- a/tests/collections/cursor.test.ts
+++ b/tests/collections/cursor.test.ts
@@ -183,6 +183,24 @@ describe(`StargateMongoose - ${testClient} Connection - collections.cursor`, asy
             });
             assert.strictEqual(docCount, sampleUsers.length);
         });
+        it('should only store at most `pageSize` documents at a time', async () => {
+            const docs = [];
+            for (let i = 0; i < 35; ++i) {
+                docs.push({ name: `doc ${i}` });
+            }
+            while (docs.length > 0) {
+                const toInsert = docs.splice(0, 20);
+                await collection.insertMany(toInsert);
+            }
+
+            const cursor = new FindCursor(collection, {});
+            let docCount = 0;
+            await cursor.forEach(() => {
+                assert.equal(cursor.page.length, docCount < 20 ? 20 : 15);
+                docCount++;
+            });
+            assert.strictEqual(docCount, 35);
+        });
     });
 
     describe('Cursor noops', () => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Test to prove that #83 is fixed. We don't have an explicit `batchSize` parameter for now, which is fine, but we at least don't load the entire result set into memory. Just max `pageSize` at a time if using `next()`. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)