### PR TITLE
rename size -> dimension, function -> metric

### DIFF
--- a/api-compatibility.versions
+++ b/api-compatibility.versions
@@ -1,2 +1,2 @@
-stargate_version=v2.1.0-ALPHA-6
-json_api_version=v1.0.0-ALPHA-12
+stargate_version=v2.1.0-BETA-2
+json_api_version=v1.0.0-BETA-3

--- a/src/collections/options.ts
+++ b/src/collections/options.ts
@@ -117,8 +117,8 @@ export const updateOneInternalOptionsKeys: Set<string> = new Set(
 
 class _CreateCollectionOptions {
     vector?: {
-        size: number,
-        function?: 'cosine' | 'euclidean' | 'dot_product'
+        dimension: number,
+        metric?: 'cosine' | 'euclidean' | 'dot_product'
     } = undefined;
 }
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
-export const LIB_NAME = "stargate-mongoose";
-export const LIB_VERSION = "0.3.0";
+export const LIB_NAME = 'stargate-mongoose';
+export const LIB_VERSION = '0.3.0';

--- a/tests/collections/db.test.ts
+++ b/tests/collections/db.test.ts
@@ -127,7 +127,7 @@ describe('StargateMongoose - collections.Db', async () => {
                 assert.strictEqual(err.errors.length, 1);
                 assert.strictEqual(
                     err.errors[0].message,
-                    'INVALID_ARGUMENT: Keyspace \'' + keyspaceName + '\' doesn\'t exist'
+                    'INVALID_ARGUMENT: Unknown namespace \'' + keyspaceName + '\', you must create it first.'
                 );
             }
         });
@@ -166,7 +166,7 @@ describe('StargateMongoose - collections.Db', async () => {
                 assert.strictEqual(err.errors.length, 1);
                 assert.strictEqual(
                     err.errors[0].message,
-                    'INVALID_ARGUMENT: Keyspace \'' + keyspaceName + '\' doesn\'t exist'
+                    'INVALID_ARGUMENT: Unknown namespace \'' + keyspaceName + '\', you must create it first.'
                 );
             }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Change vector option names per https://github.com/stargate/jsonapi/issues/567 since I was already changing them in the [RAG blog post](https://thecodebarbarian.com/rag-vector-search-with-astra-and-mongoose.html) and I wanted to make sure the new names work. The new option names work great in Astra, but I think we may need to bump stargate version in this repo because `./bin/start_json_api.sh` doesn't recognize the new option names.

I also fixed an issue that prevented running just the vector search tests: since `mongooseInstance` is only set in `beforeEach()` hook on top level "Mongoose Model API level tests", if you run `npm test -- -g "vector search"` then `mongooseInstance` will be null and tests will fail. I did some refactor to fix that.

**Which issue(s) this PR fixes**:
Fixes #147

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)