### PR TITLE
Support Mongoose 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "eslint": "8.47.0",
     "jsdoc-babel": "^0.5.0",
     "jsdoc-to-markdown": "^7.1.1",
-    "mongoose": "8.0.0-rc0",
+    "mongoose": "^8.0.0",
     "nyc": "^15.1.0",
     "sinon": "15.2.0",
     "ts-mocha": "^10.0.0",
@@ -94,7 +94,7 @@
     "winston": "^3.7.2"
   },
   "peerDependencies": {
-    "mongoose": "^7.5.0"
+    "mongoose": "^8.0.0"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "eslint": "8.47.0",
     "jsdoc-babel": "^0.5.0",
     "jsdoc-to-markdown": "^7.1.1",
-    "mongoose": "7.6.x",
+    "mongoose": "8.x",
     "nyc": "^15.1.0",
     "sinon": "15.2.0",
     "ts-mocha": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "eslint": "8.47.0",
     "jsdoc-babel": "^0.5.0",
     "jsdoc-to-markdown": "^7.1.1",
-    "mongoose": "^8.0.0",
+    "mongoose": "7.6.x",
     "nyc": "^15.1.0",
     "sinon": "15.2.0",
     "ts-mocha": "^10.0.0",
@@ -94,7 +94,7 @@
     "winston": "^3.7.2"
   },
   "peerDependencies": {
-    "mongoose": "^8.0.0"
+    "mongoose": "^7.5.0 || ^8.0.0"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "eslint": "8.47.0",
     "jsdoc-babel": "^0.5.0",
     "jsdoc-to-markdown": "^7.1.1",
-    "mongoose": "git@github.com:Automattic/mongoose.git#8.0",
+    "mongoose": "8.0.0-rc0",
     "nyc": "^15.1.0",
     "sinon": "15.2.0",
     "ts-mocha": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "eslint": "8.47.0",
     "jsdoc-babel": "^0.5.0",
     "jsdoc-to-markdown": "^7.1.1",
-    "mongoose": "^7.5.0",
+    "mongoose": "git@github.com:Automattic/mongoose.git#8.0",
     "nyc": "^15.1.0",
     "sinon": "15.2.0",
     "ts-mocha": "^10.0.0",

--- a/src/collections/options.ts
+++ b/src/collections/options.ts
@@ -46,6 +46,7 @@ export interface FindOneOptions {
 
 export interface FindOneAndDeleteOptions {
     sort?: SortOption;
+    includeResultMetadata?: boolean;
 }
 
 
@@ -53,6 +54,7 @@ class _FindOneAndReplaceOptions {
     upsert?: boolean = undefined;
     returnDocument?: 'before' | 'after' = undefined;
     sort?: SortOption;
+    includeResultMetadata?: boolean;
 }
 
 export interface FindOneAndReplaceOptions extends _FindOneAndReplaceOptions {}
@@ -65,6 +67,7 @@ class _FindOneAndUpdateOptions {
     upsert?: boolean = undefined;
     returnDocument?: 'before' | 'after' = undefined;
     sort?: SortOption;
+    includeResultMetadata?: boolean;
 }
 
 export interface FindOneAndUpdateOptions extends _FindOneAndUpdateOptions {}

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -120,11 +120,15 @@ export class Collection extends MongooseCollection {
      * @param update
      * @param options
      */
-    findOneAndUpdate(filter: Record<string, any>, update: Record<string, any>, options?: FindOneAndUpdateOptions) {
+    async findOneAndUpdate(filter: Record<string, any>, update: Record<string, any>, options?: FindOneAndUpdateOptions) {
         if (options != null) {
             processSortOption(options);
         }
-        return this.collection.findOneAndUpdate(filter, update, options);
+        const res = await this.collection.findOneAndUpdate(filter, update, options);
+        if (options?.includeResultMetadata !== false) {
+            return res.value;
+        }
+        return res;
     }
 
     /**
@@ -132,11 +136,15 @@ export class Collection extends MongooseCollection {
      * @param filter
      * @param options
      */
-    findOneAndDelete(filter: Record<string, any>, options?: FindOneAndDeleteOptions) {
+    async findOneAndDelete(filter: Record<string, any>, options?: FindOneAndDeleteOptions) {
         if (options != null) {
             processSortOption(options);
         }
-        return this.collection.findOneAndDelete(filter, options);
+        const res = await this.collection.findOneAndDelete(filter, options);
+        if (options?.includeResultMetadata !== false) {
+            return res.value;
+        }
+        return res;
     }
 
     /**
@@ -145,11 +153,15 @@ export class Collection extends MongooseCollection {
      * @param newDoc
      * @param options
      */
-    findOneAndReplace(filter: Record<string, any>, newDoc: Record<string, any>, options?: FindOneAndReplaceOptions) {
+    async findOneAndReplace(filter: Record<string, any>, newDoc: Record<string, any>, options?: FindOneAndReplaceOptions) {
         if (options != null) {
             processSortOption(options);
         }
-        return this.collection.findOneAndReplace(filter, newDoc, options);
+        const res = await this.collection.findOneAndReplace(filter, newDoc, options);
+        if (options?.includeResultMetadata !== false) {
+            return res.value;
+        }
+        return res;
     }
 
     /**

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -27,6 +27,10 @@ import {
 } from '@/src/collections/options';
 import { JSONAPIDeleteResult } from '../collections/collection';
 
+import { version } from 'mongoose';
+
+const IS_MONGOOSE_7 = version.startsWith('7.');
+
 type NodeCallback<ResultType = any> = (err: Error | null, res: ResultType | null) => unknown;
 
 /**
@@ -125,7 +129,9 @@ export class Collection extends MongooseCollection {
             processSortOption(options);
         }
         const res = await this.collection.findOneAndUpdate(filter, update, options);
-        if (options?.includeResultMetadata !== false) {
+        if (IS_MONGOOSE_7) {
+            return options?.includeResultMetadata === false ? res.value : res;
+        } else if (options?.includeResultMetadata !== false) {
             return res.value;
         }
         return res;
@@ -141,7 +147,9 @@ export class Collection extends MongooseCollection {
             processSortOption(options);
         }
         const res = await this.collection.findOneAndDelete(filter, options);
-        if (options?.includeResultMetadata !== false) {
+        if (IS_MONGOOSE_7) {
+            return options?.includeResultMetadata === false ? res.value : res;
+        } else if (options?.includeResultMetadata !== false) {
             return res.value;
         }
         return res;
@@ -158,7 +166,9 @@ export class Collection extends MongooseCollection {
             processSortOption(options);
         }
         const res = await this.collection.findOneAndReplace(filter, newDoc, options);
-        if (options?.includeResultMetadata !== false) {
+        if (IS_MONGOOSE_7) {
+            return options?.includeResultMetadata === false ? res.value : res;
+        } else if (options?.includeResultMetadata !== false) {
             return res.value;
         }
         return res;

--- a/src/driver/connection.ts
+++ b/src/driver/connection.ts
@@ -15,7 +15,7 @@
 import { Client } from '@/src/collections/client';
 import { Collection } from './collection';
 import { default as MongooseConnection } from 'mongoose/lib/connection';
-import STATES from 'mongoose/lib/connectionState';
+import { STATES } from 'mongoose';
 import { executeOperation } from '../collections/utils';
 
 export class Connection extends MongooseConnection {

--- a/src/driver/connection.ts
+++ b/src/driver/connection.ts
@@ -15,7 +15,7 @@
 import { Client } from '@/src/collections/client';
 import { Collection } from './collection';
 import { default as MongooseConnection } from 'mongoose/lib/connection';
-import STATES from 'mongoose/lib/connectionstate';
+import STATES from 'mongoose/lib/connectionState';
 import { executeOperation } from '../collections/utils';
 
 export class Connection extends MongooseConnection {

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -15,4 +15,3 @@
 declare module '@astrajs/client';
 declare module 'mongoose/lib/collection';
 declare module 'mongoose/lib/connection';
-declare module 'mongoose/lib/connectionState';

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -15,4 +15,4 @@
 declare module '@astrajs/client';
 declare module 'mongoose/lib/collection';
 declare module 'mongoose/lib/connection';
-declare module 'mongoose/lib/connectionstate';
+declare module 'mongoose/lib/connectionState';

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
-export const LIB_NAME = 'stargate-mongoose';
-export const LIB_VERSION = '0.3.0';
+export const LIB_NAME = "stargate-mongoose";
+export const LIB_VERSION = "0.3.0";

--- a/tests/collections/options.test.ts
+++ b/tests/collections/options.test.ts
@@ -210,7 +210,8 @@ describe('Options tests', async () => {
             //findOneAndReplace with rawResult option
             const findOneAndReplaceResp = await Product.findOneAndReplace({ name: 'Product 25' },
                 { price: 20, isCertified: false, name: 'Product 25'},
-                { rawResult: false, upsert: true, returnDocument: 'after' });
+                { rawResult: false, upsert: true, returnDocument: 'after' }
+            );
             assert.strictEqual(findOneAndReplaceResp.isCertified,false);
             assert.strictEqual(findOneAndReplaceResp.price,20);
             assert.ok(findOneAndReplaceResp._id);

--- a/tests/driver/api.test.ts
+++ b/tests/driver/api.test.ts
@@ -323,10 +323,10 @@ describe('Mongoose Model API level tests', async () => {
             //cleanIndexes invokes listIndexes() which is not supported
             assert.strictEqual(error!.message, 'listIndexes() Not Implemented');
         });
-        it('API ops tests Model.count()', async () => {
+        it('API ops tests Model.countDocuments()', async () => {
             const product1 = new Product({name: 'Product 1', price: 10, isCertified: true, category: 'cat 1'});
             await product1.save();
-            const countResp = await Product.count({name: 'Product 1'});
+            const countResp = await Product.countDocuments({name: 'Product 1'});
             assert.strictEqual(countResp, 1);
         });
         it('API ops tests Model.create()', async () => {
@@ -512,14 +512,6 @@ describe('Mongoose Model API level tests', async () => {
             const findDeletedDoc = await Product.findById(product1._id);
             assert.strictEqual(findDeletedDoc, null);
         });
-        it('API ops tests Model.findByIdAndRemove()', async () => {
-            const product1 = new Product({name: 'Product 1', price: 10, isCertified: true, category: 'cat 1'});
-            await product1.save();
-            const deleteResp = await Product.findByIdAndRemove(product1._id);
-            assert.strictEqual(deleteResp?.name, 'Product 1');
-            const findDeletedDoc = await Product.findById(product1._id);
-            assert.strictEqual(findDeletedDoc, null);
-        });
         it('API ops tests Model.findByIdAndUpdate()', async () => {
             const product1 = new Product({name: 'Product 1', price: 10, isCertified: true, category: 'cat 1', url: 'http://product1.com'});
             await product1.save();
@@ -542,17 +534,6 @@ describe('Mongoose Model API level tests', async () => {
             const product3 = new Product({name: 'Product 3', price: 10, isCertified: true, category: 'cat 1'});
             await Product.insertMany([product1, product2, product3]);
             const deleteResp = await Product.findOneAndDelete({category: 'cat 1'});
-            assert.strictEqual(deleteResp?.category, 'cat 1');
-            //check if it exists again
-            const findDeletedDoc = await Product.findOne({category: 'cat 1'});
-            assert.strictEqual(findDeletedDoc, null);
-        });
-        it('API ops tests Model.findOneAndRemove()', async () => {
-            const product1 = new Product({name: 'Product 1', price: 10, isCertified: true, category: 'cat 2'});
-            const product2 = new Product({name: 'Product 2', price: 10, isCertified: true, category: 'cat 2'});
-            const product3 = new Product({name: 'Product 3', price: 10, isCertified: true, category: 'cat 1'});
-            await Product.insertMany([product1, product2, product3]);
-            const deleteResp = await Product.findOneAndRemove({category: 'cat 1'});
             assert.strictEqual(deleteResp?.category, 'cat 1');
             //check if it exists again
             const findDeletedDoc = await Product.findOne({category: 'cat 1'});
@@ -633,8 +614,7 @@ describe('Mongoose Model API level tests', async () => {
             await product1.save();
             const docSaved = await Product.findOne({name: 'Product 1'});
             assert.strictEqual(docSaved.name, 'Product 1');
-            const deleteOneResp = await product1.deleteOne();
-            assert.strictEqual(deleteOneResp.name, 'Product 1');
+            await product1.deleteOne();
             const findDeletedDoc = await Product.findOne({name: 'Product 1'});
             assert.strictEqual(findDeletedDoc, null);
         });


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Adds support for Mongoose 8. The big change between Mongoose 7 and Mongoose 8 as far as stargate-mongoose is concerned is that Mongoose 8 expects the underlying driver to return the document from `findOneAndUpdate()`, etc. unless `includeResultMetadata` is explicitly set to `false`. I made a slight switch for this in the driver layer using an `IS_MONGOOSE_7` flag.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)