### PR TITLE
run mocha with --forbid-only

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,9 +51,9 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "test": "env TEST_DOC_DB=jsonapi ts-mocha --paths -p tsconfig.json tests/**/*.test.ts",
-    "test-astra": "env TEST_DOC_DB=astra nyc ts-mocha --paths -p tsconfig.json tests/**/*.test.ts",
-    "test-jsonapi": "env TEST_DOC_DB=jsonapi nyc ts-mocha --paths -p tsconfig.json tests/**/*.test.ts",
+    "test": "env TEST_DOC_DB=jsonapi ts-mocha --forbid-only --paths -p tsconfig.json tests/**/*.test.ts",
+    "test-astra": "env TEST_DOC_DB=astra nyc ts-mocha --forbid-only --paths -p tsconfig.json tests/**/*.test.ts",
+    "test-jsonapi": "env TEST_DOC_DB=jsonapi nyc ts-mocha --forbid-only --paths -p tsconfig.json tests/**/*.test.ts",
     "preinstall": "npm run update-version-file",
     "build": "npm run update-version-file && tsc --project tsconfig.build.json && tscpaths -p tsconfig.build.json -s ./src -o ./dist",
     "build:docs": "jsdoc2md -t APIReference.hbs --files src/**/*.ts --configure ./jsdoc2md.json > APIReference.md",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

`.only()` is a very dangerous and can easily sneak through code review, but it is a convenient way to run a single test. I generally recommend using the `-g` flag: https://masteringjs.io/tutorials/mocha/run-single-test, but `.only()` still ends up being used, like in #165. This PR will at least make it easier to spot `.only()` calls because tests will fail.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)