### PR TITLE
Fix to add single quotes instead of double in version.ts file

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "preinstall": "npm run update-version-file",
     "build": "npm run update-version-file && tsc --project tsconfig.build.json && tscpaths -p tsconfig.build.json -s ./src -o ./dist",
     "build:docs": "jsdoc2md -t APIReference.hbs --files src/**/*.ts --configure ./jsdoc2md.json > APIReference.md",
-    "update-version-file": "node -p \"'export const LIB_NAME = ' + JSON.stringify(require('./package.json').name) + ';'\" > src/version.ts && node -p \"'export const LIB_VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" >> src/version.ts"
+    "update-version-file": "node -p \"'export const LIB_NAME = \\'' + require('./package.json').name + '\\';'\" > src/version.ts && node -p \"'export const LIB_VERSION = \\'' + require('./package.json').version + '\\';'\" >> src/version.ts"
   },
   "bugs": {
     "url": "https://github.com/stargate/stargate-mongoose/issues"

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
-export const LIB_NAME = "stargate-mongoose";
-export const LIB_VERSION = "0.3.1";
+export const LIB_NAME = 'stargate-mongoose';
+export const LIB_VERSION = '0.3.1';


### PR DESCRIPTION
**What this PR does**:
`npm run update-version-file` updates the `src/version.ts` file with double quotes for the values and then `eslint` complains about usage of double quotes instead of single quotes on every PR. This PR fixes that by setting single quotes as expected by `eslint`.


**Checklist**
- [X] Changes manually tested
- [X] Automated Tests added/updated
- [X] Documentation added/updated
- [X] CLA Signed: [DataStax CLA](https://cla.datastax.com/)