### PR TITLE
createAstraUri change

### DIFF
--- a/APIReference.md
+++ b/APIReference.md
@@ -9,7 +9,7 @@
 ## Functions
 
 <dl>
-<dt><a href="#createAstraUri">createAstraUri(apiEndPoint, keyspace, applicationToken, baseApiPath, logLevel, authHeaderName)</a> ⇒</dt>
+<dt><a href="#createAstraUri">createAstraUri(apiEndPoint, applicationToken, namespace, baseApiPath, logLevel, authHeaderName)</a> ⇒</dt>
 <dd><p>Create an Astra connection URI while connecting to Astra JSON API</p></dd>
 <dt><a href="#createStargateUri">createStargateUri(baseUrl, baseAuthUrl, keyspace, username, password, logLevel)</a> ⇒</dt>
 <dd><p>Create a JSON API connection URI while connecting to Open source JSON API</p></dd>
@@ -326,7 +326,7 @@
 **Kind**: instance method of [<code>Collection</code>](#Collection)  
 <a name="createAstraUri"></a>
 
-## createAstraUri(apiEndPoint, keyspace, applicationToken, baseApiPath, logLevel, authHeaderName) ⇒
+## createAstraUri(apiEndPoint, applicationToken, namespace, baseApiPath, logLevel, authHeaderName) ⇒
 <p>Create an Astra connection URI while connecting to Astra JSON API</p>
 
 **Kind**: global function  

--- a/APIReference.md
+++ b/APIReference.md
@@ -9,7 +9,7 @@
 ## Functions
 
 <dl>
-<dt><a href="#createAstraUri">createAstraUri(databaseId, region, keyspace, applicationToken, baseApiPath, logLevel, authHeaderName)</a> ⇒</dt>
+<dt><a href="#createAstraUri">createAstraUri(apiEndPoint, keyspace, applicationToken, baseApiPath, logLevel, authHeaderName)</a> ⇒</dt>
 <dd><p>Create an Astra connection URI while connecting to Astra JSON API</p></dd>
 <dt><a href="#createStargateUri">createStargateUri(baseUrl, baseAuthUrl, keyspace, username, password, logLevel)</a> ⇒</dt>
 <dd><p>Create a JSON API connection URI while connecting to Open source JSON API</p></dd>
@@ -326,7 +326,7 @@
 **Kind**: instance method of [<code>Collection</code>](#Collection)  
 <a name="createAstraUri"></a>
 
-## createAstraUri(databaseId, region, keyspace, applicationToken, baseApiPath, logLevel, authHeaderName) ⇒
+## createAstraUri(apiEndPoint, keyspace, applicationToken, baseApiPath, logLevel, authHeaderName) ⇒
 <p>Create an Astra connection URI while connecting to Astra JSON API</p>
 
 **Kind**: global function  

--- a/APIReference.md
+++ b/APIReference.md
@@ -9,7 +9,7 @@
 ## Functions
 
 <dl>
-<dt><a href="#createAstraUri">createAstraUri(apiEndPoint, applicationToken, namespace, baseApiPath, logLevel, authHeaderName)</a> ⇒</dt>
+<dt><a href="#createAstraUri">createAstraUri(apiEndpoint, applicationToken, namespace, baseApiPath, logLevel, authHeaderName)</a> ⇒</dt>
 <dd><p>Create an Astra connection URI while connecting to Astra JSON API</p></dd>
 <dt><a href="#createStargateUri">createStargateUri(baseUrl, baseAuthUrl, keyspace, username, password, logLevel)</a> ⇒</dt>
 <dd><p>Create a JSON API connection URI while connecting to Open source JSON API</p></dd>
@@ -326,7 +326,7 @@
 **Kind**: instance method of [<code>Collection</code>](#Collection)  
 <a name="createAstraUri"></a>
 
-## createAstraUri(apiEndPoint, applicationToken, namespace, baseApiPath, logLevel, authHeaderName) ⇒
+## createAstraUri(apiEndpoint, applicationToken, namespace, baseApiPath, logLevel, authHeaderName) ⇒
 <p>Create an Astra connection URI while connecting to Astra JSON API</p>
 
 **Kind**: global function  

--- a/src/collections/utils.ts
+++ b/src/collections/utils.ts
@@ -65,8 +65,7 @@ function getBaseAPIPath(pathFromUrl?: string | null) {
 
 /**
  * Create an Astra connection URI while connecting to Astra JSON API
- * @param databaseId the database id of the Astra database
- * @param region the region of the Astra database
+ * @param apiEndPoint the database API Endpoint of the Astra database
  * @param keyspace the keyspace to connect to
  * @param applicationToken an Astra application token
  * @param baseApiPath baseAPI path defaults to /api/json/v1
@@ -75,18 +74,17 @@ function getBaseAPIPath(pathFromUrl?: string | null) {
  * @returns URL as string
  */
 export function createAstraUri (
-    databaseId: string,
-    region: string,
-    keyspace: string,
+    apiEndPoint: string,
+    keyspace?: string,
     applicationToken?: string,
     baseApiPath?: string,
     logLevel?: string,
     authHeaderName?: string,
 ) {
-    const uri = new url.URL(`https://${databaseId}-${region}.apps.astra.datastax.com`);
+    const uri = new url.URL(apiEndPoint);
     let contextPath = '';
     contextPath += baseApiPath ? `/${baseApiPath}` : '/api/json/v1';
-    contextPath += `/${keyspace}`;
+    contextPath += `/${keyspace || 'default_keyspace'}`;
     uri.pathname = contextPath;
     if (applicationToken) {
         uri.searchParams.append('applicationToken', applicationToken);

--- a/src/collections/utils.ts
+++ b/src/collections/utils.ts
@@ -65,29 +65,29 @@ function getBaseAPIPath(pathFromUrl?: string | null) {
 
 /**
  * Create an Astra connection URI while connecting to Astra JSON API
- * @param apiEndPoint the database API Endpoint of the Astra database
- * @param keyspace the keyspace to connect to
- * @param applicationToken an Astra application token
+ * @param apiEndpoint the database API Endpoint of the Astra database
+ * @param apiToken an Astra application token
+ * @param namespace the namespace to connect to
  * @param baseApiPath baseAPI path defaults to /api/json/v1
  * @param logLevel an winston log level (error: 0, warn: 1, info: 2, http: 3, verbose: 4, debug: 5, silly: 6)
  * @param authHeaderName
  * @returns URL as string
  */
 export function createAstraUri (
-    apiEndPoint: string,
-    keyspace?: string,
-    applicationToken?: string,
+    apiEndpoint: string,
+    apiToken: string,
+    namespace?: string,
     baseApiPath?: string,
     logLevel?: string,
     authHeaderName?: string,
 ) {
-    const uri = new url.URL(apiEndPoint);
+    const uri = new url.URL(apiEndpoint);
     let contextPath = '';
     contextPath += baseApiPath ? `/${baseApiPath}` : '/api/json/v1';
-    contextPath += `/${keyspace || 'default_keyspace'}`;
+    contextPath += `/${namespace ?? 'default_keyspace'}`;
     uri.pathname = contextPath;
-    if (applicationToken) {
-        uri.searchParams.append('applicationToken', applicationToken);
+    if (apiToken) {
+        uri.searchParams.append('applicationToken', apiToken);
     }
     if (logLevel) {
         uri.searchParams.append('logLevel', logLevel);

--- a/tests/collections/utils.test.ts
+++ b/tests/collections/utils.test.ts
@@ -16,35 +16,30 @@ import assert from 'assert';
 import { createAstraUri } from '@/src/collections/utils';
 
 describe('Utils test', () => {
-    it('createProdAstraUri', () => {
-        const apiEndPoint = 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com';
-        const uri: string = createAstraUri(apiEndPoint,'testks1');
-        assert.strictEqual(uri, 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com/api/json/v1/testks1');
-    });
     it('createProdAstraUriDefaultKeyspace', () => {
         const apiEndPoint = 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com';
-        const uri: string = createAstraUri(apiEndPoint);
-        assert.strictEqual(uri, 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com/api/json/v1/default_keyspace');
+        const uri: string = createAstraUri(apiEndPoint,"myToken");
+        assert.strictEqual(uri, 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com/api/json/v1/default_keyspace?applicationToken=myToken');
     });
     it('createProdAstraUriWithToken', () => {
         const apiEndPoint = 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com';
-        const uri: string = createAstraUri(apiEndPoint,'testks1','myToken');
+        const uri: string = createAstraUri(apiEndPoint,'myToken','testks1',);
         assert.strictEqual(uri, 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com/api/json/v1/testks1?applicationToken=myToken');
     });
     it('createProdAstraUriWithTokenAndProdEnum', () => {
         const apiEndPoint = 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com';
-        const uri: string = createAstraUri(apiEndPoint,'testks1','myToken');
+        const uri: string = createAstraUri(apiEndPoint,'myToken','testks1');
         assert.strictEqual(uri, 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com/api/json/v1/testks1?applicationToken=myToken');
     });
     it('createProdAstraUriWithTokenAndProdEnum', () => {
         const apiEndPoint = 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com';
-        const uri: string = createAstraUri(apiEndPoint,'testks1','myToken');
+        const uri: string = createAstraUri(apiEndPoint,'myToken','testks1',);
         assert.strictEqual(uri, 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com/api/json/v1/testks1?applicationToken=myToken');
     });
 
     it('createProdAstraUriWithTokenAndProdEnumWithBaseAPIPath', () => {
         const apiEndPoint = 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com';
-        const uri: string = createAstraUri(apiEndPoint,'testks1', 'myToken', 'apis');
+        const uri: string = createAstraUri(apiEndPoint,'myToken','testks1','apis');
         assert.strictEqual(uri, 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com/apis/testks1?applicationToken=myToken');
     });
 });

--- a/tests/collections/utils.test.ts
+++ b/tests/collections/utils.test.ts
@@ -17,23 +17,34 @@ import { createAstraUri } from '@/src/collections/utils';
 
 describe('Utils test', () => {
     it('createProdAstraUri', () => {
-        const dbIdUUID = 'ddd5843c-3dea-11ee-be56-0242ac120002';
-        const uri: string = createAstraUri(dbIdUUID,'us-east1','testks1');
-        assert.strictEqual(uri, 'https://'+dbIdUUID+'-us-east1.apps.astra.datastax.com/api/json/v1/testks1');
+        const apiEndPoint = 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com';
+        const uri: string = createAstraUri(apiEndPoint,'testks1');
+        assert.strictEqual(uri, 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com/api/json/v1/testks1');
+    });
+    it('createProdAstraUriDefaultKeyspace', () => {
+        const apiEndPoint = 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com';
+        const uri: string = createAstraUri(apiEndPoint);
+        assert.strictEqual(uri, 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com/api/json/v1/default_keyspace');
     });
     it('createProdAstraUriWithToken', () => {
-        const dbIdUUID = 'ddd5843c-3dea-11ee-be56-0242ac120002';
-        const uri: string = createAstraUri(dbIdUUID,'us-east1','testks1', 'myToken');
-        assert.strictEqual(uri, 'https://'+dbIdUUID+'-us-east1.apps.astra.datastax.com/api/json/v1/testks1?applicationToken=myToken');
+        const apiEndPoint = 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com';
+        const uri: string = createAstraUri(apiEndPoint,'testks1','myToken');
+        assert.strictEqual(uri, 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com/api/json/v1/testks1?applicationToken=myToken');
     });
     it('createProdAstraUriWithTokenAndProdEnum', () => {
-        const dbIdUUID = 'ddd5843c-3dea-11ee-be56-0242ac120002';
-        const uri: string = createAstraUri(dbIdUUID,'us-east1','testks1', 'myToken');
-        assert.strictEqual(uri, 'https://'+dbIdUUID+'-us-east1.apps.astra.datastax.com/api/json/v1/testks1?applicationToken=myToken');
+        const apiEndPoint = 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com';
+        const uri: string = createAstraUri(apiEndPoint,'testks1','myToken');
+        assert.strictEqual(uri, 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com/api/json/v1/testks1?applicationToken=myToken');
     });
+    it('createProdAstraUriWithTokenAndProdEnum', () => {
+        const apiEndPoint = 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com';
+        const uri: string = createAstraUri(apiEndPoint,'testks1','myToken');
+        assert.strictEqual(uri, 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com/api/json/v1/testks1?applicationToken=myToken');
+    });
+
     it('createProdAstraUriWithTokenAndProdEnumWithBaseAPIPath', () => {
-        const dbIdUUID = 'ddd5843c-3dea-11ee-be56-0242ac120002';
-        const uri: string = createAstraUri(dbIdUUID,'us-east1','testks1', 'myToken', 'apis');
-        assert.strictEqual(uri, 'https://'+dbIdUUID+'-us-east1.apps.astra.datastax.com/apis/testks1?applicationToken=myToken');
+        const apiEndPoint = 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com';
+        const uri: string = createAstraUri(apiEndPoint,'testks1', 'myToken', 'apis');
+        assert.strictEqual(uri, 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com/apis/testks1?applicationToken=myToken');
     });
 });

--- a/tests/collections/utils.test.ts
+++ b/tests/collections/utils.test.ts
@@ -17,29 +17,29 @@ import { createAstraUri } from '@/src/collections/utils';
 
 describe('Utils test', () => {
     it('createProdAstraUriDefaultKeyspace', () => {
-        const apiEndPoint = 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com';
-        const uri: string = createAstraUri(apiEndPoint,"myToken");
+        const apiEndpoint = 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com';
+        const uri: string = createAstraUri(apiEndpoint,"myToken");
         assert.strictEqual(uri, 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com/api/json/v1/default_keyspace?applicationToken=myToken');
     });
     it('createProdAstraUriWithToken', () => {
-        const apiEndPoint = 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com';
-        const uri: string = createAstraUri(apiEndPoint,'myToken','testks1',);
+        const apiEndpoint = 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com';
+        const uri: string = createAstraUri(apiEndpoint,'myToken','testks1',);
         assert.strictEqual(uri, 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com/api/json/v1/testks1?applicationToken=myToken');
     });
     it('createProdAstraUriWithTokenAndProdEnum', () => {
-        const apiEndPoint = 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com';
-        const uri: string = createAstraUri(apiEndPoint,'myToken','testks1');
+        const apiEndpoint = 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com';
+        const uri: string = createAstraUri(apiEndpoint,'myToken','testks1');
         assert.strictEqual(uri, 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com/api/json/v1/testks1?applicationToken=myToken');
     });
     it('createProdAstraUriWithTokenAndProdEnum', () => {
-        const apiEndPoint = 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com';
-        const uri: string = createAstraUri(apiEndPoint,'myToken','testks1',);
+        const apiEndpoint = 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com';
+        const uri: string = createAstraUri(apiEndpoint,'myToken','testks1',);
         assert.strictEqual(uri, 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com/api/json/v1/testks1?applicationToken=myToken');
     });
 
     it('createProdAstraUriWithTokenAndProdEnumWithBaseAPIPath', () => {
-        const apiEndPoint = 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com';
-        const uri: string = createAstraUri(apiEndPoint,'myToken','testks1','apis');
+        const apiEndpoint = 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com';
+        const uri: string = createAstraUri(apiEndpoint,'myToken','testks1','apis');
         assert.strictEqual(uri, 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com/apis/testks1?applicationToken=myToken');
     });
 });


### PR DESCRIPTION

**What this PR does**:
abandon db_id and region in createAstraUri method, use Api Endpoint instead.
If keyspace is not specified, use 'default_keyspace'

**Which issue(s) this PR fixes**:
Fixes [#<169>](https://github.com/stargate/stargate-mongoose/issues/169)

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)