### PR TITLE
add `listCollections()` function to driver as wrapper around `findCollections()`

### DIFF
--- a/src/collections/db.ts
+++ b/src/collections/db.ts
@@ -17,6 +17,13 @@ import { CreateCollectionOptions, createCollectionOptionsKeys } from './options'
 import { Collection } from './collection';
 import { executeOperation, createNamespace, dropNamespace } from './utils';
 
+interface CreateCollectionCommand {
+  createCollection: {
+    name: string,
+    options?: CreateCollectionOptions
+  }
+}
+
 export class Db {
     rootHttpClient: HTTPClient;
     httpClient: HTTPClient;
@@ -61,21 +68,15 @@ export class Db {
    */
     async createCollection(collectionName: string, options?: CreateCollectionOptions) {
         return executeOperation(async () => {
-      type CreateCollectionCommand = {
-        createCollection: {
-          name: string,
-          options?: CreateCollectionOptions
-        }
-      };
-      const command: CreateCollectionCommand = {
-          createCollection: {
-              name: collectionName
-          }
-      };
-      if (options != null) {
-          command.createCollection.options = options;
-      }
-      return await this.httpClient.executeCommand(command, createCollectionOptionsKeys);
+            const command: CreateCollectionCommand = {
+                createCollection: {
+                    name: collectionName
+                }
+            };
+            if (options != null) {
+                command.createCollection.options = options;
+            }
+            return await this.httpClient.executeCommand(command, createCollectionOptionsKeys);
         });
     }
 
@@ -110,6 +111,15 @@ export class Db {
    */
     async createDatabase() {
         return await createNamespace(this.rootHttpClient, this.name);
+    }
+
+    async findCollections() {
+        return executeOperation(async () => {
+            const command = {
+                findCollections: {}
+            };
+            return await this.httpClient.executeCommand(command, null);
+        });
     }
 }
 

--- a/src/driver/connection.ts
+++ b/src/driver/connection.ts
@@ -75,6 +75,15 @@ export class Connection extends MongooseConnection {
         });
     }
 
+    async listCollections() {
+        return executeOperation(async () => {
+            await this._waitForClient();
+            const db = this.client.db();
+            const res = await db.findCollections();
+            return res?.status?.collections ?? [];
+        });
+    }
+
     async openUri(uri: string, options: any) {
         let _fireAndForget = false;
         if (options && '_fireAndForget' in options) {

--- a/tests/collections/collection.test.ts
+++ b/tests/collections/collection.test.ts
@@ -1192,7 +1192,7 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
           const findRespDocs = await collection.find(filter).toArray();
           assert.strictEqual(findRespDocs.length, 2);
           assert.deepStrictEqual(findRespDocs.map(doc => doc.age).sort(), [4, 5]);
-            });
+        });
 
         it('should find & find doc $gte test', async () => {
           interface Doc {

--- a/tests/collections/db.test.ts
+++ b/tests/collections/db.test.ts
@@ -88,6 +88,9 @@ describe('StargateMongoose - collections.Db', async () => {
             const res2 = await db.createCollection(collectionName);
             assert.ok(res2);
             assert.strictEqual(res2.status.ok, 1);
+
+            const { status } = await db.findCollections();
+            assert.deepStrictEqual(status.collections, ['collection1']);
         });
 
         it('should drop a Collection', async () => {

--- a/tests/collections/utils.test.ts
+++ b/tests/collections/utils.test.ts
@@ -18,7 +18,7 @@ import { createAstraUri } from '@/src/collections/utils';
 describe('Utils test', () => {
     it('createProdAstraUriDefaultKeyspace', () => {
         const apiEndpoint = 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com';
-        const uri: string = createAstraUri(apiEndpoint,"myToken");
+        const uri: string = createAstraUri(apiEndpoint,'myToken');
         assert.strictEqual(uri, 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com/api/json/v1/default_keyspace?applicationToken=myToken');
     });
     it('createProdAstraUriWithToken', () => {

--- a/tests/driver/index.test.ts
+++ b/tests/driver/index.test.ts
@@ -355,6 +355,17 @@ describe('Driver based tests', async () => {
             );
         });
 
+        it('handles listCollections()', async () => {
+            const personSchema = new mongooseInstance.Schema({
+                name: { type: String, required: true }
+            });
+            const Person = mongooseInstance.model('Person', personSchema);
+            await Person.init();
+            await Person.deleteMany({});
+            const collections = await mongooseInstance.connection.listCollections();
+            assert.ok(collections.includes('people'), collections);
+        });
+
         async function createMongooseInstance() {
             const mongooseInstance = new mongoose.Mongoose();
             mongooseInstance.setDriver(StargateMongooseDriver);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

stargate-mongoose currently doesn't have a way to list out the current collections. I added `findCollections()` to the client layer, and `listCollections()` to the Mongoose layer as a wrapper around `findCollections()`. In MongoDB the function is called `listCollections()`, not `findCollections()`, so that's the name that the Mongoose wrapper should use.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)