### PR TITLE
consistently use distance+metric for vector options

### DIFF
--- a/src/collections/index.ts
+++ b/src/collections/index.ts
@@ -24,7 +24,8 @@ export {
     InsertManyOptions,
     UpdateManyOptions,
     UpdateOneOptions,
-    DeleteOneOptions
+    DeleteOneOptions,
+    VectorOptions
 } from './options';
 
 // alias for MongoClient shimming

--- a/src/collections/options.ts
+++ b/src/collections/options.ts
@@ -20,6 +20,11 @@ export interface DeleteOneOptions {
     sort?: Record<string, 1 | -1>;
 }
 
+export interface VectorOptions {
+  distance?: number;
+  metric?: 'cosine' | 'euclidean' | 'dot_product';
+}
+
 export interface FindOptions {
     limit?: number;
     skip?: number;
@@ -119,10 +124,7 @@ export const updateOneInternalOptionsKeys: Set<string> = new Set(
 );
 
 class _CreateCollectionOptions {
-    vector?: {
-        dimension: number,
-        metric?: 'cosine' | 'euclidean' | 'dot_product'
-    } = undefined;
+    vector?: VectorOptions = undefined;
 }
 
 export interface CreateCollectionOptions extends _CreateCollectionOptions {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { VectorOptions } from './collections';
+
 export * as collections from './collections';
 export * as driver from './driver';
 export * as client from './client';
@@ -19,10 +21,7 @@ export * as logger from './logger';
 
 declare module 'mongodb' {
   interface CreateCollectionOptions {
-    vector?: {
-      size?: number;
-      function?: 'cosine' | 'euclidean' | 'dot_product'
-    }
+    vector?: VectorOptions
   }
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

I was trying to figure out why I was having some trouble using distance+metric as vector options instead of size+function, turns out we missed a spot when changing that over. I created a consistent `VectorOptions` type so that won't fall out of sync again.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)