### PR TITLE
make listCollections() return array of objects rather than strings to match Mongoose types

### DIFF
--- a/src/driver/connection.ts
+++ b/src/driver/connection.ts
@@ -75,12 +75,13 @@ export class Connection extends MongooseConnection {
         });
     }
 
-    async listCollections() {
+    async listCollections(): Promise<Array<{ name: string }>> {
         return executeOperation(async () => {
             await this._waitForClient();
             const db = this.client.db();
             const res = await db.findCollections();
-            return res?.status?.collections ?? [];
+            const collectionNames = res?.status?.collections ?? [];
+            return collectionNames.map((name: string) => ({ name }));
         });
     }
 

--- a/tests/driver/index.test.ts
+++ b/tests/driver/index.test.ts
@@ -363,7 +363,11 @@ describe('Driver based tests', async () => {
             await Person.init();
             await Person.deleteMany({});
             const collections = await mongooseInstance.connection.listCollections();
-            assert.ok(collections.includes('people'), collections);
+            const collectionNames = collections.map(({ name }) => name);
+            assert.ok(
+                collectionNames.includes('people'),
+                collections
+            );
         });
 
         async function createMongooseInstance() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Mongoose's `listCollections()` returns an array of objects with a `name` property, but with stargate-mongoose it returns an array of strings. I tried to find a way to make the TypeScript types match, but there doesn't seem to be a good way to override the return type of `Connection.prototype.listCollections()` from stargate-mongoose. This PR makes the Mongoose driver layer in stargate-mongoose wrap the result of `findCollections()` in objects.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)