### PR TITLE
remove unnecessary internal TypeScript interfaces in favor of optional properties pattern

### DIFF
--- a/src/collections/collection.ts
+++ b/src/collections/collection.ts
@@ -14,7 +14,7 @@
 
 import {FindCursor} from './cursor';
 import {HTTPClient} from '@/src/client';
-import {executeOperation, setDefaultIdForUpsert} from './utils';
+import {executeOperation, omit, setDefaultIdForUpsert} from './utils';
 import {InsertManyResult} from 'mongoose';
 import {
     DeleteOneOptions,
@@ -119,7 +119,7 @@ export class Collection {
                 updateOne: {
                     filter,
                     update,
-                    options,
+                    options: omit(options, ['sort']),
                     ...(options?.sort != null ? { sort: options?.sort } : {})
                 }
             };
@@ -225,7 +225,7 @@ export class Collection {
                 findOneAndReplace: {
                     filter,
                     replacement,
-                    options,
+                    options: omit(options, ['sort']),
                     ...(options?.sort != null ? { sort: options?.sort } : {})
                 }
             };
@@ -282,7 +282,7 @@ export class Collection {
                 findOneAndUpdate: {
                     filter,
                     update,
-                    options,
+                    options: omit(options, ['sort']),
                     ...(options?.sort != null ? { sort: options?.sort } : {})
                 }
             };

--- a/src/collections/collection.ts
+++ b/src/collections/collection.ts
@@ -31,7 +31,6 @@ import {
     updateOneInternalOptionsKeys,
     UpdateOneOptions,
     FindOptions,
-    SortOption,
     findOneInternalOptionsKeys
 } from './options';
 
@@ -57,47 +56,6 @@ export interface JSONAPIModifyResult {
   ok: number;
   value: Record<string, any> | null;
 }
-
-export type FindOneAndUpdateCommand = {
-  findOneAndUpdate: {
-    filter?: Record<string, any>,
-    update?: Record<string, any>,
-    options?: FindOneAndUpdateOptions,
-    sort?: SortOption
-  }
-};
-
-export type FindOneAndDeleteCommand = {
-  findOneAndDelete: {
-    filter?: Record<string, any>,
-    sort?: SortOption
-  }
-};
-
-export type FindOneCommand = {
-  findOne: {
-    filter?: Record<string, any>,
-    options?: FindOneOptions,
-    sort?: SortOption,
-    projection?: Record<string, any>
-  }
-};
-
-export type DeleteOneCommand = {
-  deleteOne: {
-    filter?: Record<string, any>,
-    sort?: SortOption
-  }
-};
-
-export type UpdateOneCommand = {
-  updateOne: {
-    filter?: Record<string, any>,
-    sort?: SortOption,
-    update?: Record<string, any>,
-    options?: UpdateOneOptions
-  }
-};
 
 export class Collection {
     httpClient: any;
@@ -157,16 +115,14 @@ export class Collection {
 
     async updateOne(filter: Record<string, any>, update: Record<string, any>, options?: UpdateOneOptions) {
         return executeOperation(async (): Promise<JSONAPIUpdateResult> => {
-            const command: UpdateOneCommand = {
+            const command = {
                 updateOne: {
                     filter,
                     update,
-                    options
+                    options,
+                    ...(options?.sort != null ? { sort: options?.sort } : {})
                 }
             };
-            if (options?.sort != null) {
-                command.updateOne.sort = options?.sort;
-            }
             setDefaultIdForUpsert(command.updateOne);
             const updateOneResp = await this.httpClient.executeCommand(command, updateOneInternalOptionsKeys);
             const resp = {
@@ -211,14 +167,12 @@ export class Collection {
 
     async deleteOne(filter: Record<string, any>, options?: DeleteOneOptions): Promise<JSONAPIDeleteResult> {
         return executeOperation(async (): Promise<JSONAPIDeleteResult> => {
-            const command: DeleteOneCommand = {
+            const command = {
                 deleteOne: {
-                    filter
+                    filter,
+                    ...(options?.sort != null ? { sort: options.sort } : {})
                 }
             };
-            if (options?.sort) {
-                command.deleteOne.sort = options.sort;
-            }
             const deleteOneResp = await this.httpClient.executeCommand(command, null);
             return {
                 acknowledged: true,
@@ -251,21 +205,14 @@ export class Collection {
 
     async findOne(filter: Record<string, any>, options?: FindOneOptions): Promise<Record<string, any> | null> {
         return executeOperation(async (): Promise<Record<string, any> | null> => {
-            const command: FindOneCommand = {
+            const command = {
                 findOne: {
                     filter,
-                    options
+                    options,
+                    ...(options?.sort != null ? { sort: options?.sort } : {}),
+                    ...(options?.projection != null ? { sort: options?.projection } : {}),
                 }
             };
-
-            if (options?.sort) {
-                command.findOne.sort = options.sort;
-                delete options.sort;
-            }
-
-            if (options?.projection && Object.keys(options.projection).length > 0) {
-                command.findOne.projection = options.projection;
-            }
 
             const resp = await this.httpClient.executeCommand(command, findOneInternalOptionsKeys);
             return resp.data.document;
@@ -274,28 +221,15 @@ export class Collection {
 
     async findOneAndReplace(filter: Record<string, any>, replacement: Record<string, any>, options?: FindOneAndReplaceOptions): Promise<JSONAPIModifyResult> {
         return executeOperation(async (): Promise<JSONAPIModifyResult> => {
-            type FindOneAndReplaceCommand = {
-              findOneAndReplace: {
-                filter?: Record<string, any>,
-                replacement?: Record<string, any>,
-                options?: FindOneAndReplaceOptions,
-                sort?: SortOption
-              }
-            };
-            const command: FindOneAndReplaceCommand = {
+            const command = {
                 findOneAndReplace: {
                     filter,
                     replacement,
-                    options
+                    options,
+                    ...(options?.sort != null ? { sort: options?.sort } : {})
                 }
             };
             setDefaultIdForUpsert(command.findOneAndReplace, true);
-            if (options?.sort) {
-                command.findOneAndReplace.sort = options.sort;
-                if (options.sort != null) {
-                    delete options.sort;
-                }
-            }
             const resp = await this.httpClient.executeCommand(command, findOneAndReplaceInternalOptionsKeys);
             return {
                 value : resp.data?.document,
@@ -321,14 +255,12 @@ export class Collection {
     }
 
     async findOneAndDelete(filter: Record<string, any>, options?: FindOneAndDeleteOptions): Promise<JSONAPIModifyResult> {
-        const command: FindOneAndDeleteCommand = {
+        const command = {
             findOneAndDelete: {
-                filter
+                filter,
+                ...(options?.sort != null ? { sort: options?.sort } : {})
             }
         };
-        if (options?.sort) {
-            command.findOneAndDelete.sort = options.sort;
-        }
 
         const resp = await this.httpClient.executeCommand(command, null);
         return {
@@ -346,18 +278,15 @@ export class Collection {
 
     async findOneAndUpdate(filter: Record<string, any>, update: Record<string, any>, options?: FindOneAndUpdateOptions): Promise<JSONAPIModifyResult> {
         return executeOperation(async (): Promise<JSONAPIModifyResult> => {
-            const command: FindOneAndUpdateCommand = {
+            const command = {
                 findOneAndUpdate: {
                     filter,
                     update,
-                    options
+                    options,
+                    ...(options?.sort != null ? { sort: options?.sort } : {})
                 }
             };
             setDefaultIdForUpsert(command.findOneAndUpdate);
-            if (options?.sort) {
-                command.findOneAndUpdate.sort = options.sort;
-                delete options.sort;
-            }
             const resp = await this.httpClient.executeCommand(command, findOneAndUpdateInternalOptionsKeys);
             return {
                 value : resp.data?.document,

--- a/src/collections/cursor.ts
+++ b/src/collections/cursor.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { Collection } from './collection';
-import { executeOperation } from './utils';
+import { executeOperation, omit } from './utils';
 import {findInternalOptionsKeys, FindOptions, FindOptionsInternal} from './options';
 
 export class FindCursor {
@@ -114,12 +114,14 @@ export class FindCursor {
             options.includeSimilarity = this.options.includeSimilarity;
         }
 
+        const cleanOptions = omit(options, ['sort', 'projection']) ?? {};
+
         const command = {
             find: {
                 filter: this.filter,
                 ...(this.options?.sort != null ? { sort: this.options?.sort } : {}),
                 ...(this.options?.projection != null ? { projection: this.options?.projection } : {}),
-                ...(Object.keys(options).length > 0 ? { options } : {})
+                ...(Object.keys(cleanOptions).length > 0 ? { options: cleanOptions } : {})
             }
         };
         

--- a/src/collections/cursor.ts
+++ b/src/collections/cursor.ts
@@ -16,15 +16,6 @@ import { Collection } from './collection';
 import { executeOperation } from './utils';
 import {findInternalOptionsKeys, FindOptions, FindOptionsInternal} from './options';
 
-interface FindCommand {
-  find: {
-    filter?: Record<string, any>,
-    options?: FindOptionsInternal,
-    sort?: Record<string, any>,
-    projection?: Record<string, any>
-  }
-}
-
 export class FindCursor {
     collection: Collection;
     filter: Record<string, any>;
@@ -109,14 +100,6 @@ export class FindCursor {
     }
 
     async _getMore() {
-        const command: FindCommand = {
-            find: {
-                filter: this.filter
-            }
-        };
-        if (this.options && this.options.sort) {
-            command.find.sort = this.options.sort;
-        }
         const options: FindOptionsInternal = {};
         if (this.limit != Infinity) {
             options.limit = this.limit;
@@ -130,12 +113,16 @@ export class FindCursor {
         if (this.options.includeSimilarity) {
             options.includeSimilarity = this.options.includeSimilarity;
         }
-        if (this.options?.projection && Object.keys(this.options.projection).length > 0) {
-            command.find.projection = this.options.projection;
-        }
-        if (Object.keys(options).length > 0) {
-            command.find.options = options;
-        }
+
+        const command = {
+            find: {
+                filter: this.filter,
+                ...(this.options?.sort != null ? { sort: this.options?.sort } : {}),
+                ...(this.options?.projection != null ? { projection: this.options?.projection } : {}),
+                ...(Object.keys(options).length > 0 ? { options } : {})
+            }
+        };
+        
         const resp = await this.collection.httpClient.executeCommand(command, findInternalOptionsKeys);
         this.nextPageState = resp.data.nextPageState;
         if (this.nextPageState == null) {

--- a/src/collections/db.ts
+++ b/src/collections/db.ts
@@ -17,13 +17,6 @@ import { CreateCollectionOptions, createCollectionOptionsKeys } from './options'
 import { Collection } from './collection';
 import { executeOperation, createNamespace, dropNamespace } from './utils';
 
-interface CreateCollectionCommand {
-  createCollection: {
-    name: string,
-    options?: CreateCollectionOptions
-  }
-}
-
 export class Db {
     rootHttpClient: HTTPClient;
     httpClient: HTTPClient;
@@ -68,14 +61,12 @@ export class Db {
    */
     async createCollection(collectionName: string, options?: CreateCollectionOptions) {
         return executeOperation(async () => {
-            const command: CreateCollectionCommand = {
+            const command = {
                 createCollection: {
-                    name: collectionName
+                    name: collectionName,
+                    ...(options == null ? {} : { options })
                 }
             };
-            if (options != null) {
-                command.createCollection.options = options;
-            }
             return await this.httpClient.executeCommand(command, createCollectionOptionsKeys);
         });
     }

--- a/src/collections/utils.ts
+++ b/src/collections/utils.ts
@@ -248,3 +248,23 @@ function _updateHasKey(update: Record<string, any>, key: string) {
     }
     return false;
 }
+
+export function omit<T extends Record<string, any>>(obj: T | null | undefined, keys: string[]): T | null | undefined {
+    if (obj == null) {
+      return obj;
+    }
+    const hasKeys: string[] = [];
+    for (const key of keys) {
+      if (key in obj) {
+        hasKeys.push(key);
+      }
+    }
+    if (hasKeys.length === 0) {
+      return obj;
+    }
+    obj = { ...obj };
+    for (const key of hasKeys) {
+      delete obj[key];
+    }
+    return obj;
+}

--- a/tests/collections/db.test.ts
+++ b/tests/collections/db.test.ts
@@ -81,7 +81,12 @@ describe('StargateMongoose - collections.Db', async () => {
         });
         it('should create a Collection', async () => {
             const collectionName = TEST_COLLECTION_NAME;
+
             const db = new Db(httpClient, parseUri(dbUri).keyspaceName);
+
+            let collections = await db.findCollections().then(res => res.status.collections);
+            assert.ok(!collections.includes(collectionName));
+
             const res = await db.createCollection(collectionName);
             assert.ok(res);
             assert.strictEqual(res.status.ok, 1);
@@ -89,8 +94,8 @@ describe('StargateMongoose - collections.Db', async () => {
             assert.ok(res2);
             assert.strictEqual(res2.status.ok, 1);
 
-            const { status } = await db.findCollections();
-            assert.deepStrictEqual(status.collections, ['collection1']);
+            collections = await db.findCollections().then(res => res.status.collections);
+            assert.ok(collections.includes(collectionName));
         });
 
         it('should drop a Collection', async () => {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

I wasn't liking how we had a bunch of `*Command` interfaces that are only used internally to appease TypeScript, so I refactored to use the spread operator to add optional properties. The problem is that, if we pass `options: null` or `options: undefined` to JSON API we get an error back, so we need to be careful to omit those properties if they're nullish. And the spread operator is a neat way to do that without losing TypeScript's type inference.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)