### PR TITLE
add indexing options to CreateCollectionOptions

### DIFF
--- a/api-compatibility.versions
+++ b/api-compatibility.versions
@@ -1,2 +1,2 @@
-stargate_version=v2.1.0-BETA-7
-json_api_version=v1.0.0-BETA-6
+stargate_version=v2.1.0-BETA-8
+json_api_version=v1.0.0

--- a/api-compatibility.versions
+++ b/api-compatibility.versions
@@ -1,2 +1,2 @@
-stargate_version=v2.1.0-BETA-8
-json_api_version=v1.0.0
+stargate_version=v2.1.0-BETA-9
+json_api_version=v1.0.1

--- a/package.json
+++ b/package.json
@@ -69,8 +69,6 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.18.0",
     "@babel/preset-env": "^7.18.2",
     "@babel/preset-typescript": "^7.17.12",
-    "@ngneat/falso": "^5.4.0",
-    "@types/expect": "^24.3.0",
     "@types/mocha": "^9.1.1",
     "@types/node": "^17.0.36",
     "@types/sinon": "10.0.15",

--- a/src/collections/index.ts
+++ b/src/collections/index.ts
@@ -21,6 +21,7 @@ export {
     FindOneAndUpdateOptions,
     FindOneOptions,
     FindOptions,
+    IndexingOptions,
     InsertManyOptions,
     UpdateManyOptions,
     UpdateOneOptions,

--- a/src/collections/options.ts
+++ b/src/collections/options.ts
@@ -123,7 +123,7 @@ export const updateOneInternalOptionsKeys: Set<string> = new Set(
     Object.keys(new _UpdateOneOptions)
 );
 
-type IndexingOptions = { deny: string[], allow?: never } | { allow: string[], deny?: never };
+export type IndexingOptions = { deny: string[], allow?: never } | { allow: string[], deny?: never };
 
 class _CreateCollectionOptions {
     vector?: VectorOptions = undefined;

--- a/src/collections/options.ts
+++ b/src/collections/options.ts
@@ -123,7 +123,7 @@ export const updateOneInternalOptionsKeys: Set<string> = new Set(
     Object.keys(new _UpdateOneOptions)
 );
 
-type IndexingOptions = { deny: string[], allow: never } | { allow: string[], deny: never };
+type IndexingOptions = { deny: string[], allow?: never } | { allow: string[], deny?: never };
 
 class _CreateCollectionOptions {
     vector?: VectorOptions = undefined;

--- a/src/collections/options.ts
+++ b/src/collections/options.ts
@@ -123,8 +123,11 @@ export const updateOneInternalOptionsKeys: Set<string> = new Set(
     Object.keys(new _UpdateOneOptions)
 );
 
+type IndexingOptions = { deny: string[], allow: never } | { allow: string[], deny: never };
+
 class _CreateCollectionOptions {
     vector?: VectorOptions = undefined;
+    indexing?: IndexingOptions = undefined;
 }
 
 export interface CreateCollectionOptions extends _CreateCollectionOptions {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { VectorOptions } from './collections';
+import { IndexingOptions, VectorOptions } from './collections';
 
 export * as collections from './collections';
 export * as driver from './driver';
@@ -21,7 +21,8 @@ export * as logger from './logger';
 
 declare module 'mongodb' {
   interface CreateCollectionOptions {
-    vector?: VectorOptions
+    vector?: VectorOptions;
+    indexing?: IndexingOptions;
   }
 }
 

--- a/tests/collections/collection.test.ts
+++ b/tests/collections/collection.test.ts
@@ -45,12 +45,16 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
         await db.dropCollection(TEST_COLLECTION_NAME);
     });
 
-    beforeEach(async function() {
+    before(async function() {
         await db.createCollection(TEST_COLLECTION_NAME);
         collection = db.collection(TEST_COLLECTION_NAME);
     });
 
-    afterEach(async function() {
+    beforeEach(async function() {
+        await collection.deleteMany({});
+    });
+
+    after(async function() {
         await db.dropCollection(TEST_COLLECTION_NAME);
     });
 

--- a/tests/collections/collection.test.ts
+++ b/tests/collections/collection.test.ts
@@ -139,9 +139,9 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
             assert.ok(error);
             assert.strictEqual(error.errors[0].message, 'Document size limitation violated: number of elements an indexable Array (\'tags\') has (10001) exceeds maximum allowed (1000)');
         });
-        it('Should fail if a doc contains more than 64 properties', async () => {
+        it('Should fail if a doc contains more than 1000 properties', async () => {
             const docToInsert: any = { _id: '123' };
-            for (let i = 1; i <= 64; i++) {
+            for (let i = 1; i <= 1001; i++) {
                 docToInsert[`prop${i}`] = `prop${i}value`;
             }
             let error: any;
@@ -151,7 +151,10 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
                 error = e;
             }
             assert.ok(error);
-            assert.strictEqual(error.errors[0].message, 'Document size limitation violated: number of properties an Object has (65) exceeds maximum allowed (64)');
+            assert.strictEqual(
+                error.errors[0].message, 
+                'Document size limitation violated: number of properties an indexable Object (\'null\') has (1002) exceeds maximum allowed (1000)'
+            );
         });
     });
     describe('insertMany tests', () => {

--- a/tests/collections/collection.test.ts
+++ b/tests/collections/collection.test.ts
@@ -107,7 +107,10 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
                 //In Astra, it returns a 413 error prior to reaching the JSON API
                 assert.strictEqual(error.errors[0].message, 'Request failed with status code 413');
             } else {
-                assert.strictEqual(error.errors[0].message, 'Document size limitation violated: indexed String value length (1048576 bytes) exceeds maximum allowed (8000 bytes)');
+                assert.strictEqual(
+                    error.errors[0].message,
+                    'Document size limitation violated: indexed String value (property \'username\') length (1048576 bytes) exceeds maximum allowed (8000 bytes)'
+                );
             }
         });
         it('Should fail if the field length is > 1000', async () => {
@@ -132,7 +135,10 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
                 error = e;
             }
             assert.ok(error);
-            assert.strictEqual(error.errors[0].message, 'Document size limitation violated: indexed String value length (16001 bytes) exceeds maximum allowed (8000 bytes)');
+            assert.strictEqual(
+                error.errors[0].message,
+                'Document size limitation violated: indexed String value (property \'username\') length (16001 bytes) exceeds maximum allowed (8000 bytes)'
+            );
         });
         it('Should fail if an array field size is > 10000', async () => {
             const docToInsert = { tags: new Array(10001).fill('tag') };
@@ -143,7 +149,10 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
                 error = e;
             }
             assert.ok(error);
-            assert.strictEqual(error.errors[0].message, 'Document size limitation violated: number of elements an indexable Array (\'tags\') has (10001) exceeds maximum allowed (1000)');
+            assert.strictEqual(
+                error.errors[0].message,
+                'Document size limitation violated: number of elements an indexable Array (property \'tags\') has (10001) exceeds maximum allowed (1000)'
+            );
         });
         it('Should fail if a doc contains more than 1000 properties', async () => {
             const docToInsert: any = { _id: '123' };
@@ -159,7 +168,7 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
             assert.ok(error);
             assert.strictEqual(
                 error.errors[0].message, 
-                'Document size limitation violated: number of properties an indexable Object (\'null\') has (1002) exceeds maximum allowed (1000)'
+                'Document size limitation violated: number of properties an indexable Object (property \'null\') has (1002) exceeds maximum allowed (1000)'
             );
         });
     });
@@ -192,7 +201,10 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
                 error = e;
             }
             assert.ok(error);
-            assert.strictEqual(error.errors[0].message, 'Request invalid, the field postCommand.command.documents not valid: amount of documents to insert is over the max limit (21 vs 20).');
+            assert.strictEqual(
+                error.errors[0].message,
+                'Request invalid: field \'command.documents\' value "[{"username":"id1"}, {"username":"id2"}, {"username":"id3"}, {"username":"id4"}, {"username":"id5"}, {"username":"id6"}, {"username":"id7"}, {"username":"id8"}, {"username":"id9"}, {"username":"id10"}, {"username":"id11"}, {"username":"id12"}, {"username":"id13"}, {"username":"id14"}, {"username":"id15"}, {"username":"id16"}, {"username":"id17"}, {"username":"id18"}, {"username":"id19"}, {"username":"id20"}, {"username":"id21"}]" not valid. Problem: amount of documents to insert is over the max limit (21 vs 20).'
+            );
         });
         it('should error out when docs list is empty in insertMany', async () => {
             let error: any;
@@ -201,7 +213,10 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
             } catch (e: any) {
                 error = e;
             }
-            assert.strictEqual(error.errors[0].message, 'Request invalid, the field postCommand.command.documents not valid: must not be empty.');
+            assert.strictEqual(
+                error.errors[0].message,
+                'Request invalid: field \'command.documents\' value "[]" not valid. Problem: must not be empty.'
+            );
         });
         it('should insertMany documents ordered', async () => {
             const docList: { _id?: string, username: string }[] = Array.from({ length: 20 }, () => ({ 'username': 'id' }));

--- a/tests/collections/cursor.test.ts
+++ b/tests/collections/cursor.test.ts
@@ -39,13 +39,16 @@ describe(`StargateMongoose - ${testClient} Connection - collections.cursor`, asy
         await collection?.deleteMany({});
     });
 
-    beforeEach(async function () {
+    before(async function () {
         await db.createCollection(TEST_COLLECTION_NAME);
         collection = db.collection(TEST_COLLECTION_NAME);
     });
 
-    afterEach(async () => {
-    // run drop collection async to save time
+    afterEach(async function() {
+        await collection.deleteMany({});
+    });
+
+    after(async () => {
         await db?.dropCollection(TEST_COLLECTION_NAME);
     });
 

--- a/tests/collections/db.test.ts
+++ b/tests/collections/db.test.ts
@@ -82,6 +82,10 @@ describe('StargateMongoose - collections.Db', async () => {
         it('should create a Collection', async () => {
             const collectionName = TEST_COLLECTION_NAME;
             const db = new Db(httpClient, parseUri(dbUri).keyspaceName);
+
+            let collections = await db.findCollections().then(res => res.status.collections);
+            assert.ok(!collections.includes(collectionName));
+
             const res = await db.createCollection(collectionName);
             assert.ok(res);
             assert.strictEqual(res.status.ok, 1);
@@ -89,8 +93,8 @@ describe('StargateMongoose - collections.Db', async () => {
             assert.ok(res2);
             assert.strictEqual(res2.status.ok, 1);
 
-            const { status } = await db.findCollections();
-            assert.deepStrictEqual(status.collections, ['collection1']);
+            collections = await db.findCollections().then(res => res.status.collections);
+            assert.ok(collections.includes(collectionName));
         });
 
         it('should drop a Collection', async () => {

--- a/tests/collections/db.test.ts
+++ b/tests/collections/db.test.ts
@@ -103,54 +103,62 @@ describe('StargateMongoose - collections.Db', async () => {
             const collectionName = TEST_COLLECTION_NAME + '_allow';
             const db = new Db(httpClient, parseUri(dbUri).keyspaceName);
 
-            let collections = await db.findCollections().then(res => res.status.collections);
-            assert.ok(!collections.includes(collectionName));
+            try {
+                let collections = await db.findCollections().then(res => res.status.collections);
+                assert.ok(!collections.includes(collectionName));
 
-            const res = await db.createCollection(
-                collectionName,
-                { indexing: { allow: ['name'] } }
-            );
-            assert.ok(res);
-            assert.strictEqual(res.status.ok, 1);
+                const res = await db.createCollection(
+                    collectionName,
+                    { indexing: { allow: ['name'] } }
+                );
+                assert.ok(res);
+                assert.strictEqual(res.status.ok, 1);
 
-            collections = await db.findCollections().then(res => res.status.collections);
-            assert.ok(collections.includes(collectionName));
+                collections = await db.findCollections().then(res => res.status.collections);
+                assert.ok(collections.includes(collectionName));
 
-            await db.collection(collectionName).insertOne({ name: 'test', description: 'test' });
-            await assert.rejects(
-                () => db.collection(collectionName).findOne({ description: 'test' }),
-                /filter path 'description' is not indexed/
-            );
+                await db.collection(collectionName).insertOne({ name: 'test', description: 'test' });
+                await assert.rejects(
+                    () => db.collection(collectionName).findOne({ description: 'test' }),
+                    /filter path 'description' is not indexed/
+                );
 
-            const doc = await db.collection(collectionName).findOne({ name: 'test' });
-            assert.equal(doc!.description, 'test');
+                const doc = await db.collection(collectionName).findOne({ name: 'test' });
+                assert.equal(doc!.description, 'test');
+            } finally {
+                await db.dropCollection(collectionName);
+            }
         });
 
         it('should create a Collection with deny indexing options', async () => {
             const collectionName = TEST_COLLECTION_NAME + '_deny';
             const db = new Db(httpClient, parseUri(dbUri).keyspaceName);
 
-            let collections = await db.findCollections().then(res => res.status.collections);
-            assert.ok(!collections.includes(collectionName));
-
-            const res = await db.createCollection(
-                collectionName,
-                { indexing: { deny: ['description'] } }
-            );
-            assert.ok(res);
-            assert.strictEqual(res.status.ok, 1);
-
-            collections = await db.findCollections().then(res => res.status.collections);
-            assert.ok(collections.includes(collectionName));
-
-            await db.collection(collectionName).insertOne({ name: 'test', description: 'test' });
-            await assert.rejects(
-                () => db.collection(collectionName).findOne({ description: 'test' }),
-                /filter path 'description' is not indexed/
-            );
-
-            const doc = await db.collection(collectionName).findOne({ name: 'test' });
-            assert.equal(doc!.description, 'test');
+            try {
+                let collections = await db.findCollections().then(res => res.status.collections);
+                assert.ok(!collections.includes(collectionName));
+    
+                const res = await db.createCollection(
+                    collectionName,
+                    { indexing: { deny: ['description'] } }
+                );
+                assert.ok(res);
+                assert.strictEqual(res.status.ok, 1);
+    
+                collections = await db.findCollections().then(res => res.status.collections);
+                assert.ok(collections.includes(collectionName));
+    
+                await db.collection(collectionName).insertOne({ name: 'test', description: 'test' });
+                await assert.rejects(
+                    () => db.collection(collectionName).findOne({ description: 'test' }),
+                    /filter path 'description' is not indexed/
+                );
+    
+                const doc = await db.collection(collectionName).findOne({ name: 'test' });
+                assert.equal(doc!.description, 'test');
+            } finally {
+                await db.dropCollection(collectionName);
+            }
         });
 
         it('should drop a Collection', async () => {

--- a/tests/collections/db.test.ts
+++ b/tests/collections/db.test.ts
@@ -100,7 +100,7 @@ describe('StargateMongoose - collections.Db', async () => {
         });
 
         it('should create a Collection with allow indexing options', async () => {
-            const collectionName = TEST_COLLECTION_NAME;
+            const collectionName = TEST_COLLECTION_NAME + '_allow';
             const db = new Db(httpClient, parseUri(dbUri).keyspaceName);
 
             let collections = await db.findCollections().then(res => res.status.collections);
@@ -127,7 +127,7 @@ describe('StargateMongoose - collections.Db', async () => {
         });
 
         it('should create a Collection with deny indexing options', async () => {
-            const collectionName = TEST_COLLECTION_NAME;
+            const collectionName = TEST_COLLECTION_NAME + '_deny';
             const db = new Db(httpClient, parseUri(dbUri).keyspaceName);
 
             let collections = await db.findCollections().then(res => res.status.collections);

--- a/tests/collections/db.test.ts
+++ b/tests/collections/db.test.ts
@@ -17,8 +17,10 @@ import { Db } from '@/src/collections/db';
 import { Client } from '@/src/collections/client';
 import { parseUri, createNamespace } from '@/src/collections/utils';
 import { testClient, TEST_COLLECTION_NAME } from '@/tests/fixtures';
-import { randAlphaNumeric } from '@ngneat/falso';
 import {HTTPClient} from '@/src/client';
+import { randomBytes } from 'crypto';
+
+const randString = (length: number) => randomBytes(Math.ceil(length / 2)).toString('hex').slice(0, length);
 
 describe('StargateMongoose - collections.Db', async () => {
     let astraClient: Client | null;
@@ -99,7 +101,7 @@ describe('StargateMongoose - collections.Db', async () => {
 
         it('should drop a Collection', async () => {
             const db = new Db(httpClient, parseUri(dbUri).keyspaceName);
-            const suffix = randAlphaNumeric({ length: 4 }).join('');
+            const suffix = randString(4);
             await db.createCollection(`test_db_collection_${suffix}`);
             const res = await db.dropCollection(`test_db_collection_${suffix}`);
             assert.strictEqual(res.status?.ok, 1);
@@ -122,7 +124,7 @@ describe('StargateMongoose - collections.Db', async () => {
             }
             const keyspaceName = parseUri(dbUri).keyspaceName;
             const db = new Db(httpClient, keyspaceName);
-            const suffix = randAlphaNumeric({ length: 4 }).join('');
+            const suffix = randString(4);
             await db.createCollection(`test_db_collection_${suffix}`);
             const res = await db.dropDatabase();
             assert.strictEqual(res.status?.ok, 1);
@@ -156,7 +158,7 @@ describe('StargateMongoose - collections.Db', async () => {
             }
             const keyspaceName = parseUri(dbUri).keyspaceName;
             const db = new Db(httpClient, keyspaceName);
-            const suffix = randAlphaNumeric({ length: 4 }).join('');
+            const suffix = randString(4);
 
             await db.dropDatabase().catch(err => {
                 if (err.errors[0].exceptionClass === 'NotFoundException') {

--- a/tests/collections/options.test.ts
+++ b/tests/collections/options.test.ts
@@ -52,11 +52,6 @@ describe('Options tests', async () => {
         await dropCollections(isAstra, astraMongoose, jsonAPIMongoose, 'products');
     });
 
-    afterEach(function() {
-        jsonAPIMongoose?.connection?.getClient()?.close();
-        astraMongoose?.connection?.getClient()?.close();
-    });
-
     async function createClientsAndModels(isAstra: boolean) {
         let Product, astraMongoose, jsonAPIMongoose;
         const productSchema = new mongoose.Schema({

--- a/tests/collections/options.test.ts
+++ b/tests/collections/options.test.ts
@@ -40,11 +40,15 @@ describe('Options tests', async () => {
         isAstra = testClient.isAstra;
     });
 
-    beforeEach(async function () {
+    before(async function () {
         ({ Product, astraMongoose, jsonAPIMongoose } = await createClientsAndModels(isAstra));
     });
 
-    afterEach(async function () {
+    afterEach(async function() {
+        await Product.deleteMany({});
+    });
+
+    after(async function () {
         await dropCollections(isAstra, astraMongoose, jsonAPIMongoose, 'products');
     });
 

--- a/tests/collections/options.test.ts
+++ b/tests/collections/options.test.ts
@@ -128,7 +128,7 @@ describe('Options tests', async () => {
             //rawResult options should be cleaned up by stargate-mongoose, but 'upsert' should be preserved
             const updateOneResp = await Product.updateOne({ name: 'Product 4' },
                 { $set : { isCertified : true }, $inc: { price: 5 } },
-                { upsert: true, rawResult: false, sort: { name : 1 } }
+                { upsert: true, rawResult: false, sort: { name : 1 } } as unknown as Record<string, never>
             );
             assert.ok(updateOneResp.acknowledged);
             assert.strictEqual(updateOneResp.matchedCount, 0);
@@ -152,7 +152,7 @@ describe('Options tests', async () => {
             //rawResult options should be cleaned up by stargate-mongoose, but 'upsert' should be preserved
             const updateManyResp = await Product.updateMany({ category: 'cat1' },
                 { $set : { isCertified : true }, $inc: { price: 5 } },
-                { upsert: true, rawResult: false, sort: { name : 1 } }
+                { upsert: true, rawResult: false, sort: { name : 1 } } as unknown as Record<string, never>
             );
             assert.ok(updateManyResp.acknowledged);
             assert.strictEqual(updateManyResp.matchedCount, 2);
@@ -172,7 +172,7 @@ describe('Options tests', async () => {
             const product1 = new Product({ name: 'Product 1', price: 10, isCertified: true });
             await product1.save();
             //runValidations is not a flag supported by JSON API, so it should be removed by stargate-mongoose
-            await Product.deleteOne({ name: 'Product 1' }, { runValidations: true });
+            await Product.deleteOne({ name: 'Product 1' }, { runValidations: true } as unknown as Record<string, never>);
             const product1Deleted = await Product.findOne({ name: 'Product 1' });
             assert.strictEqual(product1Deleted, null);
         });

--- a/tests/driver/api.test.ts
+++ b/tests/driver/api.test.ts
@@ -815,7 +815,8 @@ describe('Mongoose Model API level tests', async () => {
         it('supports sort() and similarity score with $meta with findOne()', async function() {
             const doc2 = await Vector
                 .findOne({}, null, { includeSimilarity: true })
-                .sort({ $vector: { $meta: [1, 99] } });
+                .sort({ $vector: { $meta: [1, 99] } })
+                .orFail();
             assert.strictEqual(doc2.name, 'Test vector 1');
             assert.strictEqual(doc2.get('$similarity'), 1);
         });

--- a/tests/driver/api.test.ts
+++ b/tests/driver/api.test.ts
@@ -55,10 +55,13 @@ describe('Mongoose Model API level tests', async () => {
     });
     let mongooseInstance: Mongoose | null = null;
     let Product: Model<any>, Cart: Model<any>, astraMongoose: Mongoose | null, jsonAPIMongoose: Mongoose | null;
-    beforeEach(async () => {
+    before(async () => {
         ({Product, Cart, astraMongoose, jsonAPIMongoose} = await createClientsAndModels(isAstra));
     });
     afterEach(async () => {
+      await Promise.all([Product.deleteMany({}), Cart.deleteMany({})]);
+    });
+    after(async () => {
         await dropCollections(isAstra, astraMongoose, jsonAPIMongoose, 'products');
         await dropCollections(isAstra, astraMongoose, jsonAPIMongoose, 'carts');
     });
@@ -377,22 +380,11 @@ describe('Mongoose Model API level tests', async () => {
             assert.strictEqual(findDeletedDoc, null);
         });
         it('API ops tests Model.diffIndexes()', async () => {
-            const modelName = 'User';
             let error: OperationNotSupportedError | null = null;
             try {
-                const userSchema = new mongoose.Schema({
-                    name: String,
-                    age: Number,
-                    dob: Date
-                });
-                userSchema.index({name: 1});
-                const User = mongooseInstance!.model(modelName, userSchema);
-                await Promise.all(Object.values(mongooseInstance!.connection.models).map(Model => Model.init()));
-                await User.diffIndexes();
+                await Product.diffIndexes();
             } catch (err: any) {
                 error = err;
-            } finally {
-                await dropCollections(isAstra, astraMongoose, jsonAPIMongoose, 'users');
             }
             assert.ok(error);
             assert.strictEqual(error?.message, 'listIndexes() Not Implemented');
@@ -782,19 +774,23 @@ describe('Mongoose Model API level tests', async () => {
         });
         
 
-        beforeEach(async function() {
+        before(async function() {
             await mongooseInstance!.connection.dropCollection('vector');
             await Vector.createCollection();
-            await Vector.create([
-                {
-                    name: 'Test vector 1',
-                    $vector: [1, 100]
-                },
-                {
-                    name: 'Test vector 2',
-                    $vector: [100, 1]
-                }
-            ]);
+        });
+
+        beforeEach(async function() {
+          await Vector.deleteMany({});
+          await Vector.create([
+              {
+                  name: 'Test vector 1',
+                  $vector: [1, 100]
+              },
+              {
+                  name: 'Test vector 2',
+                  $vector: [100, 1]
+              }
+          ]);
         });
 
         it('supports updating $vector with save()', async function() {

--- a/tests/driver/api.test.ts
+++ b/tests/driver/api.test.ts
@@ -65,10 +65,6 @@ describe('Mongoose Model API level tests', async () => {
         await dropCollections(isAstra, astraMongoose, jsonAPIMongoose, 'products');
         await dropCollections(isAstra, astraMongoose, jsonAPIMongoose, 'carts');
     });
-    afterEach(function() {
-        jsonAPIMongoose?.connection?.getClient()?.close();
-        astraMongoose?.connection?.getClient()?.close();
-    });
 
     function getInstance() {
         const mongooseInstance = new mongoose.Mongoose();
@@ -776,10 +772,6 @@ describe('Mongoose Model API level tests', async () => {
                 await mongooseInstance.connect(dbUri, options);
             }
         });
-        
-        after(function() {
-            mongooseInstance.connection.getClient().close();
-        });
 
         before(async function() {
             await mongooseInstance!.connection.dropCollection('vector');
@@ -801,7 +793,11 @@ describe('Mongoose Model API level tests', async () => {
         });
 
         after(async function() {
-          await mongooseInstance!.connection.dropCollection('vector');
+            await mongooseInstance!.connection.dropCollection('vector');
+        });
+
+        after(function() {
+            mongooseInstance.connection.getClient().close();
         });
 
         it('supports updating $vector with save()', async function() {

--- a/tests/driver/api.test.ts
+++ b/tests/driver/api.test.ts
@@ -59,7 +59,7 @@ describe('Mongoose Model API level tests', async () => {
         ({Product, Cart, astraMongoose, jsonAPIMongoose} = await createClientsAndModels(isAstra));
     });
     afterEach(async () => {
-      await Promise.all([Product.deleteMany({}), Cart.deleteMany({})]);
+        await Promise.all([Product.deleteMany({}), Cart.deleteMany({})]);
     });
     after(async () => {
         await dropCollections(isAstra, astraMongoose, jsonAPIMongoose, 'products');
@@ -780,17 +780,21 @@ describe('Mongoose Model API level tests', async () => {
         });
 
         beforeEach(async function() {
-          await Vector.deleteMany({});
-          await Vector.create([
-              {
-                  name: 'Test vector 1',
-                  $vector: [1, 100]
-              },
-              {
-                  name: 'Test vector 2',
-                  $vector: [100, 1]
-              }
-          ]);
+            await Vector.deleteMany({});
+            await Vector.create([
+                {
+                    name: 'Test vector 1',
+                    $vector: [1, 100]
+                },
+                {
+                    name: 'Test vector 2',
+                    $vector: [100, 1]
+                }
+            ]);
+        });
+
+        after(async function() {
+          await mongooseInstance!.connection.dropCollection('vector');
         });
 
         it('supports updating $vector with save()', async function() {

--- a/tests/driver/index.test.ts
+++ b/tests/driver/index.test.ts
@@ -135,26 +135,39 @@ describe('Driver based tests', async () => {
     });
     describe('Mongoose API', () => {
         let mongooseInstance: mongoose.Mongoose | undefined;
-        beforeEach(async function () {
+        before(async function () {
             mongooseInstance = await createMongooseInstance();
+
+            const personSchema = new mongooseInstance.Schema({
+                name: { type: String, required: true }
+            });
+            const Person = mongooseInstance.model('Person', personSchema);
+            await Person.createCollection();
         });
-        afterEach(async function () {
+
+        before(async function() {
+            const cartSchema = new mongooseInstance!.Schema({
+                name: String,
+                products: [{ type: 'ObjectId', ref: 'Product' }]
+            });
+            const productSchema = new mongooseInstance!.Schema({
+                name: String,
+                price: Number
+            });
+            const Cart = mongooseInstance!.model('Cart', cartSchema);
+            await Cart.createCollection();
+            const Product = mongooseInstance!.model('Product', productSchema);
+            await Product.createCollection();
+        });
+
+        after(async function () {
             //add all unique collections here that are used across tests
             await mongooseInstance?.connection.dropCollection('people');
-            await mongooseInstance?.connection.dropCollection('parents');
-            await mongooseInstance?.connection.dropCollection('children');
-            await mongooseInstance?.connection.dropCollection('grandchildren');
             await mongooseInstance?.connection.dropCollection('carts');
             await mongooseInstance?.connection.dropCollection('products');
         });
         it('handles find cursors', async () => {
-            // @ts-ignore
-            const personSchema = new mongooseInstance.Schema({
-                name: { type: String, required: true }
-            });
-            // @ts-ignore
-            const Person = mongooseInstance.model('Person', personSchema);
-            await Person.init();
+            const Person = mongooseInstance!.model('Person');
             await Person.deleteMany({});
             await Person.create([{name: 'John'}, {name: 'Bill'}]);
 
@@ -165,13 +178,7 @@ describe('Driver based tests', async () => {
         });
 
         it('handles document deleteOne() and updateOne()', async () => {
-            // @ts-ignore
-            const personSchema = new mongooseInstance.Schema({
-                name: String
-            });
-            // @ts-ignore
-            const Person = mongooseInstance.model('Person', personSchema);
-            await Person.init();
+            const Person = mongooseInstance!.model('Person');
             await Person.deleteMany({});
             const [person1] = await Person.create([{name: 'John'}, {name: 'Bill'}]);
 
@@ -185,13 +192,7 @@ describe('Driver based tests', async () => {
         });
 
         it('handles updating existing document with save()', async () => {
-        // @ts-ignore
-            const personSchema = new mongooseInstance.Schema({
-                name: String
-            });
-            // @ts-ignore
-            const Person = mongooseInstance.model('Person', personSchema);
-            await Person.init();
+            const Person = mongooseInstance!.model('Person');
             await Person.deleteMany({});
             const [person] = await Person.create([{name: 'John'}]);
 
@@ -202,21 +203,8 @@ describe('Driver based tests', async () => {
         });
 
         it('handles populate()', async () => {
-            // @ts-ignore
-            const cartSchema = new mongooseInstance.Schema({
-                name: String,
-                products: [{ type: 'ObjectId', ref: 'Product' }]
-            });
-            // @ts-ignore
-            const productSchema = new mongooseInstance.Schema({
-                name: String,
-                price: Number
-            });
-            // @ts-ignore
-            const Cart = mongooseInstance.model('Cart', cartSchema);
-            // @ts-ignore
-            const Product = mongooseInstance.model('Product', productSchema);
-            await Promise.all([Cart.init(), Product.init()]);
+            const Cart = mongooseInstance!.model('Cart');
+            const Product = mongooseInstance!.model('Product');
             await Promise.all([Cart.deleteMany({}), Product.deleteMany({})]);
             const [{ _id: productId }] = await Product.create([
                 { name: 'iPhone 12', price: 500 },
@@ -228,65 +216,8 @@ describe('Driver based tests', async () => {
             assert.deepEqual(cart.products.map(p => p.name), ['iPhone 12']);
         });
 
-        it('handles nested populate()', async () => {
-            // @ts-ignore
-            const parentSchema = new mongooseInstance.Schema({
-                name: String,
-                children: [{type: 'ObjectId', ref: 'Child'}]
-            });
-            // @ts-ignore
-            const childSchema = new mongooseInstance.Schema({
-                name: String,
-                children: [{type: 'ObjectId', ref: 'Grandchild'}]
-            });
-            // @ts-ignore
-            const grandchildSchema = new mongooseInstance.Schema({
-                name: String
-            });
-            // @ts-ignore
-            const Parent = mongooseInstance.model('Parent', parentSchema);
-            // @ts-ignore
-            const Child = mongooseInstance.model('Child', childSchema);
-            // @ts-ignore
-            const Grandchild = mongooseInstance.model('Grandchild', grandchildSchema);
-            await Promise.all([Parent.init(), Child.init(), Grandchild.init()]);
-            await Promise.all([Parent.deleteMany({}), Child.deleteMany({}), Grandchild.deleteMany({})]);
-            const [{_id: grandchildId}] = await Grandchild.create([
-                {name: 'Ben Skywalker'},
-                {name: 'Jacen Solo'}
-            ]);
-            const [{_id: childId}] = await Child.create([
-                {name: 'Luke Skywalker', children: [grandchildId]},
-                {name: 'Han Solo'}
-            ]);
-            const {_id: parentId} = await Parent.create({
-                name: 'Anakin Skywalker',
-                children: [childId]
-            });
-
-      type PopulateTypeOverride = {
-        children: { name?: string, children: (typeof Grandchild)[] }[]
-      };
-      const parent = await Parent
-          .findById(parentId)
-          .populate<PopulateTypeOverride>({
-              path: 'children',
-              populate: {path: 'children'}
-          });
-      assert.equal(parent!.children.length, 1);
-      assert.equal(parent!.children[0]!.name, 'Luke Skywalker');
-      assert.equal(parent!.children[0]!.children.length, 1);
-      assert.equal(parent!.children[0]!.children[0].name, 'Ben Skywalker');
-        });
-
         it('handles exists()', async () => {
-            // @ts-ignore
-            const personSchema = new mongooseInstance.Schema({
-                name: String
-            });
-            // @ts-ignore
-            const Person = mongooseInstance.model('Person', personSchema);
-            await Person.init();
+            const Person = mongooseInstance!.model('Person');
             await Person.deleteMany({});
             await Person.create([{name: 'John'}]);
 
@@ -295,13 +226,7 @@ describe('Driver based tests', async () => {
         });
 
         it('handles insertMany()', async () => {
-            // @ts-ignore
-            const personSchema = new mongooseInstance.Schema({
-                name: String
-            });
-            // @ts-ignore
-            const Person = mongooseInstance.model('Person', personSchema);
-            await Person.init();
+            const Person = mongooseInstance!.model('Person');
             await Person.deleteMany({});
             await Person.insertMany([{ name: 'John' }, { name: 'Bill' }]);
 
@@ -310,13 +235,7 @@ describe('Driver based tests', async () => {
         });
 
         it('throws readable error on bulkWrite()', async () => {
-            // @ts-ignore
-            const personSchema = new mongooseInstance.Schema({
-                name: String
-            });
-            // @ts-ignore
-            const Person = mongooseInstance.model('Person', personSchema);
-            await Person.init();
+            const Person = mongooseInstance!.model('Person');
             await Person.deleteMany({});
             await assert.rejects(
                 Person.bulkWrite([{insertOne: {document: {name: 'John'}}}]),
@@ -325,13 +244,7 @@ describe('Driver based tests', async () => {
         });
 
         it('throws readable error on aggregate()', async () => {
-            // @ts-ignore
-            const personSchema = new mongooseInstance.Schema({
-                name: String
-            });
-            // @ts-ignore
-            const Person = mongooseInstance.model('Person', personSchema);
-            await Person.init();
+            const Person = mongooseInstance!.model('Person');
             await Person.deleteMany({});
             // @ts-ignore
             await assert.rejects(
@@ -341,12 +254,7 @@ describe('Driver based tests', async () => {
         });
 
         it('throws readable error on change stream', async () => {
-            // @ts-ignore
-            const personSchema = new mongooseInstance.Schema({
-                name: String
-            });
-            // @ts-ignore
-            const Person = mongooseInstance.model('Person', personSchema);
+            const Person = mongooseInstance!.model('Person');
             await Person.init();
             await Person.deleteMany({});
             await assert.throws(
@@ -356,10 +264,7 @@ describe('Driver based tests', async () => {
         });
 
         it('handles listCollections()', async () => {
-            const personSchema = new mongooseInstance!.Schema({
-                name: { type: String, required: true }
-            });
-            const Person = mongooseInstance!.model('Person', personSchema);
+            const Person = mongooseInstance!.model('Person');
             await Person.init();
             await Person.deleteMany({});
             const collections = await mongooseInstance!.connection.listCollections();
@@ -373,7 +278,7 @@ describe('Driver based tests', async () => {
         async function createMongooseInstance() {
             const mongooseInstance = new mongoose.Mongoose();
             mongooseInstance.setDriver(StargateMongooseDriver);
-            mongooseInstance.set('autoCreate', true);
+            mongooseInstance.set('autoCreate', false);
             mongooseInstance.set('autoIndex', false);
 
             const options = isAstra ? { isAstra: true } : { username: process.env.STARGATE_USERNAME, password: process.env.STARGATE_PASSWORD, authUrl: process.env.STARGATE_AUTH_URL };

--- a/tests/driver/index.test.ts
+++ b/tests/driver/index.test.ts
@@ -356,13 +356,13 @@ describe('Driver based tests', async () => {
         });
 
         it('handles listCollections()', async () => {
-            const personSchema = new mongooseInstance.Schema({
+            const personSchema = new mongooseInstance!.Schema({
                 name: { type: String, required: true }
             });
-            const Person = mongooseInstance.model('Person', personSchema);
+            const Person = mongooseInstance!.model('Person', personSchema);
             await Person.init();
             await Person.deleteMany({});
-            const collections = await mongooseInstance.connection.listCollections();
+            const collections = await mongooseInstance!.connection.listCollections();
             assert.ok(collections.includes('people'), collections);
         });
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Adds `indexing` to `CreateCollectionOptions`. The `allow: never` and `deny: never` are [unfortunately necessary](https://stackoverflow.com/questions/37688318/typescript-interface-possible-to-make-one-or-the-other-properties-required).

I also fixed a couple of build failures in the test cases that I found while testing the `CreateCollectionOptions` type changes.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)