### PR TITLE
fix version compatibility markdown formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,10 +113,10 @@ docker compose -f bin/docker-compose.yml down -v
 The current implementation of the JSON API uses DataStax Enterprise (DSE) as the backend database.
 
 ## Version compatibility
-| Component/Library Name | Version          |
-|------------------------|------------------|
-| Mongoose               | ^7.5.0 || ^8.0.0 |
-| DataStax Enterprise    | 6.8.x            |
+| Component/Library Name | Version            |
+|------------------------|--------------------|
+| Mongoose               | ^7.5.0 \|\| ^8.0.0 |
+| DataStax Enterprise    | 6.8.x              |
 
 CI tests are run using the Stargate and JSON API versions specified in the [api-compatibility.versions](api-compatibility.versions) file.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

#186 doesn't quite render correctly:

![image](https://github.com/stargate/stargate-mongoose/assets/1620265/60539105-5fbc-4105-a32b-b3b779108c7c)

Looks like you need to escape `|` characters in markdown tables, this PR should fix that

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)