### PR TITLE
allow calling `Model.db.collection()`

### DIFF
--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -42,8 +42,8 @@ export class Collection extends MongooseCollection {
     constructor(name: string, conn: any, options?: any) {
         super(name, conn, options);
         if (options?.modelName != null) {
-          this.modelName = options.modelName;
-          delete options.modelName;
+            this.modelName = options.modelName;
+            delete options.modelName;
         }
         this._closed = false;
     }

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -39,10 +39,12 @@ type NodeCallback<ResultType = any> = (err: Error | null, res: ResultType | null
 export class Collection extends MongooseCollection {
     debugType = 'StargateMongooseCollection';
 
-    constructor(name: string, conn: any, options: any) {
+    constructor(name: string, conn: any, options?: any) {
         super(name, conn, options);
-        this.modelName = options.modelName;
-        delete options.modelName;
+        if (options?.modelName != null) {
+          this.modelName = options.modelName;
+          delete options.modelName;
+        }
         this._closed = false;
     }
 

--- a/tests/driver/api.test.ts
+++ b/tests/driver/api.test.ts
@@ -742,6 +742,12 @@ describe('Mongoose Model API level tests', async () => {
             }
             assert.equal(await cursor.next(), null);
         });
+        it('API ops tests Model.db.collection()', async () => {
+            const product1 = new Product({name: 'Product 1', price: 10, isCertified: true, category: 'cat 2'});
+            await product1.save();
+            const res = await Product.db.collection('products').findOne();
+            assert.equal(res!.name, 'Product 1');
+        });
     });
 
     describe('vector search', function() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

I ran into a minor issue while working on a RAG blog post. Sometimes it is convenient to use `Model.db.collection('foo')` to get access to the raw driver collection, particularly when working from Node CLI. I was using this pattern to make modifications to delete a document from the 'notes' collection from a different project and ran into an error:

```
> mongoose.model('Order').db.collection('notes').deleteOne({ _id: mongoose.Types.ObjectId('65dff23226eb788328b8df7b') })
Uncaught TypeError: Cannot read properties of undefined (reading 'modelName')
    at new Collection (/node_modules/stargate-mongoose/dist/driver/collection.js:30:34)
> 

```

With this PR, `Model.db.collection('foo')` now works

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)