### PR TITLE
support calling `listCollections()` with `explain` option

### DIFF
--- a/src/collections/client.ts
+++ b/src/collections/client.ts
@@ -107,20 +107,22 @@ export class Client {
    * @param dbName the JSON API keyspace to connect to
    * @returns Db
    */
-    db(dbName?: string) {
+    db(dbName?: string): Db {
         if (dbName) {
-            if (this.dbs.has(dbName)) {
-                return this.dbs.get(dbName);
+            let db = this.dbs.get(dbName);
+            if (db != null) {
+                return db;
             }
-            const db = new Db(this.httpClient, dbName);
+            db = new Db(this.httpClient, dbName);
             this.dbs.set(dbName, db);
             return db;
         }
         if (this.keyspaceName) {
-            if (this.dbs.has(this.keyspaceName)) {
-                return this.dbs.get(this.keyspaceName);
+            let db = this.dbs.get(this.keyspaceName);
+            if (db != null) {
+                return db;
             }
-            const db = new Db(this.httpClient, this.keyspaceName);
+            db = new Db(this.httpClient, this.keyspaceName);
             this.dbs.set(this.keyspaceName, db);
             return db;
         }

--- a/src/collections/db.ts
+++ b/src/collections/db.ts
@@ -13,7 +13,12 @@
 // limitations under the License.
 
 import { HTTPClient } from '@/src/client';
-import { CreateCollectionOptions, createCollectionOptionsKeys } from './options';
+import {
+    CreateCollectionOptions,
+    createCollectionOptionsKeys,
+    ListCollectionOptions,
+    listCollectionOptionsKeys
+} from './options';
 import { Collection } from './collection';
 import { executeOperation, createNamespace, dropNamespace } from './utils';
 
@@ -113,15 +118,15 @@ export class Db {
         return await createNamespace(this.rootHttpClient, this.name);
     }
 
-    async findCollections() {
+    async findCollections(options?: ListCollectionOptions) {
         return executeOperation(async () => {
             const command = {
-                findCollections: {}
+                findCollections: options != null ? { options } : {}
             };
             return await this.httpClient.executeCommandWithUrl(
                 '/' + this.name,
                 command,
-                null
+                listCollectionOptionsKeys
             );
         });
     }

--- a/src/collections/options.ts
+++ b/src/collections/options.ts
@@ -135,3 +135,13 @@ export interface CreateCollectionOptions extends _CreateCollectionOptions {}
 export const createCollectionOptionsKeys: Set<string> = new Set(
     Object.keys(new _CreateCollectionOptions)
 );
+
+class _ListCollectionOptions {
+    explain?: boolean = undefined;
+}
+
+export interface ListCollectionOptions extends _ListCollectionOptions {}
+
+export const listCollectionOptionsKeys: Set<string> = new Set(
+    Object.keys(new _ListCollectionOptions)
+);

--- a/src/driver/index.ts
+++ b/src/driver/index.ts
@@ -14,3 +14,8 @@
 
 export { Connection } from './connection';
 export { Collection, OperationNotSupportedError } from './collection';
+
+import { Connection } from './connection';
+import { Mongoose } from 'mongoose';
+
+export type StargateMongoose = Mongoose & { connection: Connection, connections: Connection[] };

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,8 @@ declare module 'mongoose' {
     logSkippedOptions?: boolean;
     authUrl?: string;
   }
+
+  function setDriver<T = Mongoose>(driver: any): T;
 }
 
 import { createStargateUri, createAstraUri } from './collections';

--- a/tests/driver/api.test.ts
+++ b/tests/driver/api.test.ts
@@ -19,7 +19,7 @@ import {
     testClient,
     TEST_COLLECTION_NAME
 } from '@/tests/fixtures';
-import mongoose, {Model, Mongoose, Schema, InferSchemaType} from 'mongoose';
+import mongoose, {Model, Schema, InferSchemaType} from 'mongoose';
 import * as StargateMongooseDriver from '@/src/driver';
 import {randomUUID} from 'crypto';
 import {OperationNotSupportedError} from '@/src/driver';

--- a/tests/driver/api.test.ts
+++ b/tests/driver/api.test.ts
@@ -53,8 +53,11 @@ describe('Mongoose Model API level tests', async () => {
         dbUri = testClient.uri;
         isAstra = testClient.isAstra;
     });
-    let mongooseInstance: Mongoose | null = null;
-    let Product: Model<any>, Cart: Model<any>, astraMongoose: Mongoose | null, jsonAPIMongoose: Mongoose | null;
+    let mongooseInstance: StargateMongooseDriver.StargateMongoose | null = null;
+    let Product: Model<any>;
+    let Cart: Model<any>;
+    let astraMongoose: StargateMongooseDriver.StargateMongoose | null;
+    let jsonAPIMongoose: StargateMongooseDriver.StargateMongoose | null;
     before(async () => {
         ({Product, Cart, astraMongoose, jsonAPIMongoose} = await createClientsAndModels(isAstra));
     });
@@ -71,8 +74,7 @@ describe('Mongoose Model API level tests', async () => {
     });
 
     function getInstance() {
-        const mongooseInstance = new mongoose.Mongoose();
-        mongooseInstance.setDriver(StargateMongooseDriver);
+        const mongooseInstance = new mongoose.Mongoose().setDriver<StargateMongooseDriver.StargateMongoose>(StargateMongooseDriver);
         mongooseInstance.set('autoCreate', true);
         mongooseInstance.set('autoIndex', false);
         mongooseInstance.set('strictQuery', false);
@@ -80,7 +82,10 @@ describe('Mongoose Model API level tests', async () => {
     }
 
     async function createClientsAndModels(isAstra: boolean) {
-        let Product: Model<any>, Cart: Model<any>, astraMongoose: Mongoose | null = null, jsonAPIMongoose: Mongoose | null = null;
+        let Product: Model<any>;
+        let Cart: Model<any>;
+        let astraMongoose: StargateMongooseDriver.StargateMongoose | null = null;
+        let jsonAPIMongoose: StargateMongooseDriver.StargateMongoose | null = null;
         const productSchema = new mongoose.Schema({
             name: String,
             price: Number,
@@ -969,7 +974,7 @@ describe('Mongoose Model API level tests', async () => {
         });
 
         it('contains vector options in listCollections() output with `explain`', async function() {
-            const connection = mongooseInstance.connection as unknown as StargateMongooseDriver.Connection;
+            const connection = mongooseInstance.connection;
             const collections = await connection.listCollections({ explain: true });
             
             const collection = collections.find(collection => collection.name === 'vector');

--- a/tests/driver/api.test.ts
+++ b/tests/driver/api.test.ts
@@ -967,5 +967,16 @@ describe('Mongoose Model API level tests', async () => {
             const fromDb = await Vector.findOne({ name: 'Test vector 1' });
             assert.equal(fromDb, null);
         });
+
+        it('contains vector options in listCollections() output with `explain`', async function() {
+            const connection = mongooseInstance.connection as unknown as StargateMongooseDriver.Connection;
+            const collections = await connection.listCollections({ explain: true });
+            
+            const collection = collections.find(collection => collection.name === 'vector');
+            assert.ok(collection, 'Collection named "vector" not found');
+            assert.deepStrictEqual(collection.options, {
+                vector: { dimension: 2, metric: 'cosine' }
+            });
+        });
     });
 });


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Re: discussion on stargate/jsonapi#559. Right now you can't use `explain: true` with `listCollections()` in stargate-mongoose, which makes it tricky to figure out a model's collection vector settings.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)