### PR TITLE
make http2 request logging consistent with http1, add notes to devguide on enabling http request logging

### DIFF
--- a/DEVGUIDE.md
+++ b/DEVGUIDE.md
@@ -1,9 +1,11 @@
 
 # Contents
 1. [Build & Run tests locally](#build--test)
-2. [Build API Reference Documentation](#build-api-reference-documentation)
-3. [Contributing](CONTRIBUTING.md)
-4. [Creating a release](#publishing-to-npm-registry)
+2. [Debug Mode](#debug-mode)
+3. [Update Stargate and JSON API versions](#update-stargate-and-json-api-versions)
+4. [Build API Reference Documentation](#build-api-reference-documentation)
+5. [Contributing](CONTRIBUTING.md)
+6. [Creating a release](#publishing-to-npm-registry)
 
 ## Build & Test
 
@@ -40,6 +42,41 @@ Run `npm run lint` to run ESLint.
 ESLint will point out any formatting and code quality issues it finds.
 ESLint can automatically fix some issues: run `npm run lint -- --fix` to tell ESLint to automatically fix what issues it can.
 You should try to run `npm run lint` before committing to minimize risk of regressions.
+
+## Debug Mode
+
+You can make stargate-mongoose print all HTTP requests to the console using the `logger` option as follows.
+
+```ts
+import { logger } from 'stargate-mongoose';
+
+logger.setLevel('http');
+```
+
+Once you've enabled the `http` logging level, you should see every HTTP request and response logged to the console in a format similar to the following:
+
+```
+http: --- request POST http://localhost:8181/v1/testks1 {
+  "deleteCollection": {
+    "name": "collection1"
+  }
+}
+http: --- response 200 POST http://localhost:8181/v1/testks1 {
+  "status": {
+    "ok": 1
+  }
+}
+```
+
+When running tests, you can turn on the `http` logging level by setting the `D` environment variable as follows:
+
+```
+env D=1 npm test
+```
+
+[Stargate-mongoose's tests automatically enable `http` logging level if the `D` environment variable is set](https://github.com/stargate/stargate-mongoose/blob/913a6c6934d40848fb89eb5d8763492ee6445ddf/tests/setup.ts#L20-L25).
+Otherwise, all console output is suppressed using `logger.silent = true`.
+This means there's no way to enable console output without setting the `D` environment variable when running `npm test`.
 
 ## Update Stargate and JSON API versions
 

--- a/src/client/httpClient.ts
+++ b/src/client/httpClient.ts
@@ -96,8 +96,10 @@ class HTTP2Session {
     numInFlightRequests: number;
     numRequests: number;
     gracefulCloseInProgress: boolean;
+    origin: string;
 
     constructor(origin: string) {
+        this.origin = origin;
         this.session = http2.connect(origin);
         this.numInFlightRequests = 0;
         this.numRequests = 0;
@@ -133,6 +135,11 @@ class HTTP2Session {
             ++this.numInFlightRequests;
             ++this.numRequests;
             let done = false;
+
+            if (logger.isLevelEnabled('http')) {
+                logger.http(`--- request POST ${this.origin}${path} ${serializeCommand(body, true)}`);
+            }
+            
             const timer = setTimeout(
                 () => {
                     if (!done) {
@@ -185,6 +192,9 @@ class HTTP2Session {
                 let data = {};
                 try {
                     data = JSON.parse(responseBody);
+                    if (logger.isLevelEnabled('http')) {
+                        logger.http(`--- response ${status} POST ${this.origin}${path} ${JSON.stringify(data, null, 2)}`);
+                    }
 
                     resolve({ status, data });
                 } catch (error) {

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -313,14 +313,6 @@ export class Collection extends MongooseCollection {
     replaceOne() {
         throw new OperationNotSupportedError('replaceOne() Not Implemented');
     }
-
-    /**
-     * Sync indexes operation not supported.
-     */
-    syncIndexes() {
-        throw new OperationNotSupportedError('syncIndexes() Not Implemented');
-    }
-
 }
 
 function processSortOption(options: { sort?: SortOption }) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

http2 doesn't currently log to the console using the same format as http1. This PR adds that, and adds a note to the devguide on how to enable logging for convenience.

I also removed the collection `syncIndexes()` implementation, because that is unnecessary. Mongoose's `syncIndexes()` is a custom method implemented in Mongoose that uses `listIndexes()` under the hood, which is what triggers the `OperationNotSupportedError`. So the current stargate-mongoose implementation of `syncIndexes()` is never called.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)