### PR TITLE
speed up tests by avoiding dropping/recreating collections unnecessarily

### DIFF
--- a/tests/collections/collection.test.ts
+++ b/tests/collections/collection.test.ts
@@ -42,20 +42,17 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
         }
 
         db = astraClient.db();
-        await db.dropCollection(TEST_COLLECTION_NAME);
-    });
-
-    before(async function() {
-        await db.createCollection(TEST_COLLECTION_NAME);
+        const collections = await db.findCollections().then(res => {
+            return res.status.collections;
+        });
+        if (!collections.includes(TEST_COLLECTION_NAME)) {
+            await db.createCollection(TEST_COLLECTION_NAME);
+        }
         collection = db.collection(TEST_COLLECTION_NAME);
     });
 
     beforeEach(async function() {
         await collection.deleteMany({});
-    });
-
-    after(async function() {
-        await db.dropCollection(TEST_COLLECTION_NAME);
     });
 
     describe('Collection initialization', () => {

--- a/tests/collections/cursor.test.ts
+++ b/tests/collections/cursor.test.ts
@@ -33,23 +33,17 @@ describe(`StargateMongoose - ${testClient} Connection - collections.cursor`, asy
             return this.skip();
         }
         db = astraClient.db();
-        const collectionName: string = TEST_COLLECTION_NAME;
-        await db.createCollection(collectionName);
-        collection = db.collection(collectionName);
-        await collection?.deleteMany({});
-    });
-
-    before(async function () {
-        await db.createCollection(TEST_COLLECTION_NAME);
+        const collections = await db.findCollections().then(res => {
+            return res.status.collections;
+        });
+        if (!collections.includes(TEST_COLLECTION_NAME)) {
+            await db.createCollection(TEST_COLLECTION_NAME);
+        }
         collection = db.collection(TEST_COLLECTION_NAME);
     });
 
-    afterEach(async function() {
+    beforeEach(async function() {
         await collection.deleteMany({});
-    });
-
-    after(async () => {
-        await db?.dropCollection(TEST_COLLECTION_NAME);
     });
 
     describe('Cursor initialization', () => {

--- a/tests/driver/index.test.ts
+++ b/tests/driver/index.test.ts
@@ -20,6 +20,7 @@ import { logger } from '@/src/logger';
 import { parseUri } from '@/src/collections/utils';
 import { HTTPClient } from '@/src/client';
 import { Client } from '@/src/collections';
+import { Product, Cart, mongooseInstance } from '@/tests/mongooseFixtures';
 
 describe('Driver based tests', async () => {
     let dbUri: string;
@@ -38,139 +39,62 @@ describe('Driver based tests', async () => {
     });
     describe('StargateMongoose - index', () => {
         it('should leverage astradb', async function () {
-            let Cart, Product;
-            let astraMongoose, jsonAPIMongoose;
-            try {
-                const cartSchema = new mongoose.Schema({
-                    name: String,
-                    cartName: {type: String, lowercase: true, unique: true, index: true},
-                    products: [{type: mongoose.Schema.Types.ObjectId, ref: 'Product'}]
-                });
+            await Promise.all([Product.deleteMany({}), Cart.deleteMany({})]);
+            const product1 = new Product({
+                name: 'Product 1',
+                price: 10,
+                expiryDate: new Date('2024-04-20T00:00:00.000Z'),
+                isCertified: true
+            });
+            await product1.save();
 
-                const productSchema = new mongoose.Schema({
-                    name: String,
-                    price: Number,
-                    expiryDate: Date,
-                    isCertified: Boolean
-                });
-                if (isAstra) {
-                    astraMongoose = new mongoose.Mongoose();
-                    astraMongoose.setDriver(StargateMongooseDriver);
-                    astraMongoose.set('autoCreate', true);
-                    astraMongoose.set('autoIndex', false);
-                    Cart = astraMongoose.model('Cart', cartSchema);
-                    Product = astraMongoose.model('Product', productSchema);
+            const product2 = new Product({
+                name: 'Product 2',
+                price: 10,
+                expiryDate: new Date('2024-11-20T00:00:00.000Z'),
+                isCertified: false
+            });
+            await product2.save();
 
-                    // @ts-ignore - these are config options supported by stargate-mongoose but not mongoose
-                    await astraMongoose.connect(dbUri, {isAstra: true});
-                    await Promise.all(Object.values(astraMongoose.connection.models).map(Model => Model.init()));
-                } else {
-                    // @ts-ignore
-                    jsonAPIMongoose = new mongoose.Mongoose();
-                    jsonAPIMongoose.setDriver(StargateMongooseDriver);
-                    jsonAPIMongoose.set('autoCreate', true);
-                    jsonAPIMongoose.set('autoIndex', false);
-                    Cart = jsonAPIMongoose.model('Cart', cartSchema);
-                    Product = jsonAPIMongoose.model('Product', productSchema);
+            const cart = new Cart({
+                name: 'My Cart',
+                cartName: 'wewson',
+                products: [product1._id, product2._id]
+            });
+            await cart.save();
+            assert.strictEqual(await Cart.findOne({cartName: 'wewson'}).select('name').exec().then((doc: any) => doc.name), cart.name);
+            //compare if product expiryDate is same as saved
+            assert.strictEqual(await Product.findOne({name: 'Product 1'}).select('expiryDate').exec().then((doc: any) => doc.expiryDate.toISOString()), product1.expiryDate!.toISOString());
 
-                    const options = {
-                        username: process.env.STARGATE_USERNAME,
-                        password: process.env.STARGATE_PASSWORD,
-                        authUrl: process.env.STARGATE_AUTH_URL,
-                        logSkippedOptions: true
-                    };
-                    // @ts-ignore - these are config options supported by stargate-mongoose but not mongoose
-                    await jsonAPIMongoose.connect(dbUri, options);
-                    await Promise.all(Object.values(jsonAPIMongoose.connection.models).map(Model => Model.init()));
-                }
-                await Promise.all([Product.deleteMany({}), Cart.deleteMany({})]);
-                const product1 = new Product({
-                    name: 'Product 1',
-                    price: 10,
-                    expiryDate: new Date('2024-04-20T00:00:00.000Z'),
-                    isCertified: true
-                });
-                await product1.save();
+            const findOneAndReplaceResp = await Cart.findOneAndReplace({cartName: 'wewson'}, {
+                name: 'My Cart 2',
+                cartName: 'wewson1'
+            }, {returnDocument: 'after'}).exec();
+            assert.strictEqual(findOneAndReplaceResp!.name, 'My Cart 2');
+            assert.strictEqual(findOneAndReplaceResp!.cartName, 'wewson1');
 
-                const product2 = new Product({
-                    name: 'Product 2',
-                    price: 10,
-                    expiryDate: new Date('2024-11-20T00:00:00.000Z'),
-                    isCertified: false
-                });
-                await product2.save();
+            const productNames: string[] = [];
+            const cursor = await Product.find().cursor();
+            await cursor.eachAsync(p => productNames.push(p.name!));
+            assert.deepEqual(productNames.sort(), ['Product 1', 'Product 2']);
 
-                const cart = new Cart({
-                    name: 'My Cart',
-                    cartName: 'wewson',
-                    products: [product1._id, product2._id]
-                });
-                await cart.save();
-                assert.strictEqual(await Cart.findOne({cartName: 'wewson'}).select('name').exec().then((doc: any) => doc.name), cart.name);
-                //compare if product expiryDate is same as saved
-                assert.strictEqual(await Product.findOne({name: 'Product 1'}).select('expiryDate').exec().then((doc: any) => doc.expiryDate.toISOString()), product1.expiryDate!.toISOString());
-
-                const findOneAndReplaceResp = await Cart.findOneAndReplace({cartName: 'wewson'}, {
-                    name: 'My Cart 2',
-                    cartName: 'wewson1'
-                }, {returnDocument: 'after'}).exec();
-                assert.strictEqual(findOneAndReplaceResp!.name, 'My Cart 2');
-                assert.strictEqual(findOneAndReplaceResp!.cartName, 'wewson1');
-
-                const productNames: string[] = [];
-                const cursor = await Product.find().cursor();
-                await cursor.eachAsync(p => productNames.push(p.name!));
-                assert.deepEqual(productNames.sort(), ['Product 1', 'Product 2']);
-
-                await cart.deleteOne();
-                assert.strictEqual(await Cart.findOne({cartName: 'wewson'}), null);
-            } finally {
-                if (isAstra) {
-                    astraMongoose?.connection.dropCollection('carts');
-                    astraMongoose?.connection.dropCollection('products');
-                    astraMongoose?.connection?.getClient()?.close();
-                } else {
-                    jsonAPIMongoose?.connection.dropCollection('carts');
-                    jsonAPIMongoose?.connection.dropCollection('products');
-                    jsonAPIMongoose?.connection?.getClient()?.close();
-                }
-            }
+            await cart.deleteOne();
+            assert.strictEqual(await Cart.findOne({cartName: 'wewson'}), null);
         });
     });
     describe('Mongoose API', () => {
-        let mongooseInstance: mongoose.Mongoose | undefined;
+        const personSchema = new mongooseInstance.Schema({
+            name: { type: String, required: true }
+        });
+        const Person = mongooseInstance.model('Person', personSchema);
         before(async function () {
-            mongooseInstance = await createMongooseInstance();
-
-            const personSchema = new mongooseInstance.Schema({
-                name: { type: String, required: true }
-            });
-            const Person = mongooseInstance.model('Person', personSchema);
             await Person.createCollection();
         });
 
-        before(async function() {
-            const cartSchema = new mongooseInstance!.Schema({
-                name: String,
-                products: [{ type: 'ObjectId', ref: 'Product' }]
-            });
-            const productSchema = new mongooseInstance!.Schema({
-                name: String,
-                price: Number
-            });
-            const Cart = mongooseInstance!.model('Cart', cartSchema);
-            await Cart.createCollection();
-            const Product = mongooseInstance!.model('Product', productSchema);
-            await Product.createCollection();
+        after(async () => {
+            await Person.db.dropCollection(Person.collection.collectionName);
         });
 
-        after(async function () {
-            //add all unique collections here that are used across tests
-            await mongooseInstance?.connection.dropCollection('people');
-            await mongooseInstance?.connection.dropCollection('carts');
-            await mongooseInstance?.connection.dropCollection('products');
-            mongooseInstance?.connection?.getClient()?.close();
-        });
         it('handles find cursors', async () => {
             const Person = mongooseInstance!.model('Person');
             await Person.deleteMany({});

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -129,17 +129,19 @@ export const sleep = async (ms = 100) => new Promise(resolve => setTimeout(resol
 export const testClientName = process.env.TEST_DOC_DB;
 assert.ok(testClientName === 'astra' || testClientName === 'jsonapi');
 
+export const isAstra = process.env.TEST_DOC_DB === 'astra' && !!process.env.ASTRA_URI;
+
 export const testClient = process.env.TEST_DOC_DB === 'astra' ?
     (process.env.ASTRA_URI ?
         {
             client: getAstraClient(),
-            isAstra: true,
+            isAstra,
             uri: process.env.ASTRA_URI
         } : null)
     : (process.env.TEST_DOC_DB === 'jsonapi' ? (process.env.JSON_API_URI ?
         {
             client: getJSONAPIClient(),
-            isAstra: false,
+            isAstra,
             uri: process.env.JSON_API_URI
         } : null
     ) : null);

--- a/tests/mongooseFixtures.ts
+++ b/tests/mongooseFixtures.ts
@@ -1,0 +1,66 @@
+import { isAstra, testClient } from './fixtures';
+import { Schema, Mongoose } from 'mongoose';
+import * as StargateMongooseDriver from '@/src/driver';
+import { parseUri, createNamespace } from '@/src/collections/utils';
+
+const cartSchema = new Schema({
+    name: String,
+    cartName: {type: String, lowercase: true, unique: true, index: true},
+    products: [{type: Schema.Types.ObjectId, ref: 'Product'}]
+});
+
+const productSchema = new Schema({
+    name: String,
+    price: Number,
+    expiryDate: Date,
+    isCertified: Boolean,
+    category: String
+});
+
+export const mongooseInstance = new Mongoose();
+mongooseInstance.setDriver(StargateMongooseDriver);
+mongooseInstance.set('autoCreate', false);
+mongooseInstance.set('autoIndex', false);
+export const Cart = mongooseInstance.model('Cart', cartSchema);
+export const Product = mongooseInstance.model('Product', productSchema);
+
+export async function createMongooseCollections() {
+    const collections = await mongooseInstance.connection.listCollections();
+    const collectionNames = collections.map(({ name }) => name);
+    if (!collectionNames.includes(Cart.collection.collectionName)) {
+        await Cart.createCollection();
+    }
+    if (!collectionNames.includes(Product.collection.collectionName)) {
+        await Product.createCollection();
+    }
+}
+
+before(async function connectMongooseFixtures() {
+    if (isAstra) {
+    // @ts-ignore - these are config options supported by stargate-mongoose but not mongoose
+        await mongooseInstance.connect(testClient.uri, {isAstra: true});
+    } else {
+        const options = {
+            username: process.env.STARGATE_USERNAME,
+            password: process.env.STARGATE_PASSWORD,
+            authUrl: process.env.STARGATE_AUTH_URL,
+            logSkippedOptions: true
+        };
+        // @ts-ignore - these are config options supported by stargate-mongoose but not mongoose
+        await mongooseInstance.connect(testClient.uri, options);
+        const client = await testClient.client;
+        const keyspace = parseUri(testClient!.uri).keyspaceName;
+        await createNamespace(client.httpClient, keyspace);
+    }
+});
+
+before(createMongooseCollections);
+
+after(async function cleanupMongooseCollections() {
+    await Cart.db.dropCollection(Cart.collection.collectionName);
+    await Product.db.dropCollection(Product.collection.collectionName);
+});
+
+after(async function disconnectMongooseFixtures() {
+    await mongooseInstance.disconnect();
+});


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Right now tests take over 4 minutes to run on my local machine, with this PR that number goes down to about 2m45s. Most of that time is dropping/creating collections. In some places, like tests that explicitly test creating collections, the overhead is unavoidable. But there's several places where we unnecessarily create collections, like the whole `jsonapiMongoose` construct. This PR simplifies the test suite and makes the tests run much faster, which makes development quicker as well.


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)