### PR TITLE
avoid dangling reference to old client when disconnecting then reconnecting

### DIFF
--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -50,11 +50,7 @@ export class Collection extends MongooseCollection {
 
     //getter for collection
     get collection() {
-        if (this._collection != null) {
-            return this._collection;
-        }
-        this._collection = this.conn.db.collection(this.name);
-        return this._collection;
+        return this.conn.db.collection(this.name);
     }
 
     /**

--- a/tests/driver/index.test.ts
+++ b/tests/driver/index.test.ts
@@ -210,6 +210,24 @@ describe('Driver based tests', async () => {
 
             assert.ok(httpClient.closed);
         });
+
+        it('handles reconnecting after disconnecting', async () => {
+            const mongooseInstance = await createMongooseInstance();
+            const TestModel = mongooseInstance.model('Person', Person.schema);
+            await TestModel.init();
+            await TestModel.findOne();
+
+            await mongooseInstance.disconnect();
+
+            const options = isAstra ? { isAstra: true } : { username: process.env.STARGATE_USERNAME, password: process.env.STARGATE_PASSWORD, authUrl: process.env.STARGATE_AUTH_URL };
+            // @ts-ignore - these are config options supported by stargate-mongoose but not mongoose
+            await mongooseInstance.connect(dbUri, options);
+
+            // Should be able to execute query after reconnecting
+            await TestModel.findOne();
+
+            await mongooseInstance.disconnect();
+        });
           
         it('handles listCollections()', async () => {
             const Person = mongooseInstance!.model('Person');


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

As reported in Slack, the following script fails with `Cannot make http2 request when client is closed` because driver-layer `collection` caches the collection, which includes a pointer to a `collections/client.ts` instance, and `mongoose.connect()` creates a new `connections/client.ts` instance every time.

```javascript
const mongoose = require('mongoose');

const { driver } = require('stargate-mongoose');
mongoose.set('autoCreate', true);
mongoose.setDriver(driver);
const Email = mongoose.model('Email', mongoose.Schema({ title: String }));

run().catch(error => {
  console.log(error);
  process.exit(-1);
});

async function run() {
  for (let i = 0; i < 4; ++i) {
    console.log(i);
    const title = `testemail${i}`;
    await connectToDb();

    const email = await Email.findOne({ title });
    if (email) {

    } else {
      await Email.create({ title });
    }
  }

  console.log('Done');
}

async function connectToDb() {
  console.log(mongoose.version);

  if (mongoose.connection.readyState !== 0) {
    await mongoose.disconnect();
  }
  
  await mongoose.connect(process.env.ASTRA_URI, { isAstra: true });
}

```

This change shouldn't cause us to create new collections on every request because [`collections/db.ts` also caches collections](https://github.com/stargate/stargate-mongoose/blob/7e005b930a9cb92286eea7078021343678e8db3b/src/collections/db.ts#L53-L58)

**Which issue(s) this PR fixes**:
Fixes #205 

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)