### PR TITLE
bump data-api to 1.0.5, stargate to 2.1.0-BETA-10

### DIFF
--- a/api-compatibility.versions
+++ b/api-compatibility.versions
@@ -1,2 +1,2 @@
-stargate_version=v2.1.0-BETA-9
-data_api_version=v1.0.4
+stargate_version=v2.1.0-BETA-10
+data_api_version=v1.0.5


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Use the new data-api release, including the fact that data-api bumps stargate version.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)