### PR TITLE
improve error message when httpClient doesn't have applicationToken, username, or password

### DIFF
--- a/src/client/httpClient.ts
+++ b/src/client/httpClient.ts
@@ -237,7 +237,7 @@ export class HTTPClient {
             this.applicationToken = options.applicationToken;
         } else {
             if (this.username === '' || this.password === '') {
-                throw new Error('applicationToken/auth info required for initialization');
+                throw new Error('stargate-mongoose: must set `username` and `password` option when connecting if `applicationToken` not set');
             }
             this.applicationToken = '';//We will set this by accessing the auth url when the first request is received
         }

--- a/tests/collections/client.test.ts
+++ b/tests/collections/client.test.ts
@@ -253,7 +253,7 @@ describe('StargateMongoose clients test', () => {
                 error = e;
             }
             assert.ok(error);
-            assert.strictEqual(error.message, 'applicationToken/auth info required for initialization');
+            assert.strictEqual(error.message, 'stargate-mongoose: must set `username` and `password` option when connecting if `applicationToken` not set');
         });
         it('should set the auth url based on options when provided', async () => {
             const TEST_AUTH_URL = 'authurl1';


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Current error message when `username`, `password`, `applicationToken` all not set is a little confusing, I ran into this earlier today because I had some incorrect environment variables.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)