### PR TITLE
Integration with Mongoose 8.4 listDatabases()

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "eslint": "8.47.0",
     "jsdoc-babel": "^0.5.0",
     "jsdoc-to-markdown": "^7.1.1",
-    "mongoose": "8.x",
+    "mongoose": "^8.4.0",
     "nyc": "^15.1.0",
     "sinon": "15.2.0",
     "ts-mocha": "^10.0.0",

--- a/src/collections/client.ts
+++ b/src/collections/client.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { Db } from './db';
-import { createNamespace, parseUri } from './utils';
+import { createNamespace, executeOperation, parseUri } from './utils';
 import { HTTPClient } from '@/src/client';
 import { logger } from '@/src/logger';
 import {OperationNotSupportedError} from '@/src/driver';
@@ -127,6 +127,19 @@ export class Client {
             return db;
         }
         throw new Error('Database name must be provided');
+    }
+
+    async findNamespaces() {
+        return executeOperation(async () => {
+            const command = {
+                findNamespaces: {}
+            };
+            return await this.httpClient.executeCommandWithUrl(
+                '/',
+                command,
+                null
+            );
+        });
     }
 
     /**

--- a/src/driver/connection.ts
+++ b/src/driver/connection.ts
@@ -29,10 +29,8 @@ export class Connection extends MongooseConnection {
 
     _waitForClient() {
         return new Promise<void>((resolve, reject) => {
-            if (
-                (this.readyState === STATES.connecting || this.readyState === STATES.disconnected) &&
-        this._shouldBufferCommands()
-            ) {
+            const shouldWaitForClient = (this.readyState === STATES.connecting || this.readyState === STATES.disconnected) && this._shouldBufferCommands();
+            if (shouldWaitForClient) {
                 this._queue.push({ fn: resolve });
             } else if (this.readyState === STATES.disconnected && this.db == null) {
                 reject(new Error('Connection is disconnected'));

--- a/src/driver/connection.ts
+++ b/src/driver/connection.ts
@@ -91,6 +91,14 @@ export class Connection extends MongooseConnection {
         });
     }
 
+    async listDatabases(): Promise<{ databases: string[] }> {
+      return executeOperation(async () => {
+          await this._waitForClient();
+          const { status } = await this.client.findNamespaces();
+          return { databases: status.namespaces };
+      });
+  }
+
     async openUri(uri: string, options: any) {
         let _fireAndForget = false;
         if (options && '_fireAndForget' in options) {

--- a/src/driver/connection.ts
+++ b/src/driver/connection.ts
@@ -92,12 +92,12 @@ export class Connection extends MongooseConnection {
     }
 
     async listDatabases(): Promise<{ databases: string[] }> {
-      return executeOperation(async () => {
-          await this._waitForClient();
-          const { status } = await this.client.findNamespaces();
-          return { databases: status.namespaces };
-      });
-  }
+        return executeOperation(async () => {
+            await this._waitForClient();
+            const { status } = await this.client.findNamespaces();
+            return { databases: status.namespaces };
+        });
+    }
 
     async openUri(uri: string, options: any) {
         let _fireAndForget = false;

--- a/tests/collections/client.test.ts
+++ b/tests/collections/client.test.ts
@@ -336,6 +336,13 @@ describe('StargateMongoose clients test', () => {
             assert.ok(error);
             assert.ok(error.message.includes('Cannot make http2 request when client is closed'), error.message);
         });
+        it('findNamespaces should list all namespaces', async () => {
+            const parsedUri = parseUri(clientURI);
+            const { status } = await appClient!.findNamespaces();
+            assert.ok(Array.isArray(status.namespaces));
+            assert.ok(parsedUri.keyspaceName);
+            assert.ok(status.namespaces.includes(parsedUri.keyspaceName));
+        });
     });
     describe('Client noops', () => {
         it('should handle noop: setMaxListeners', async () => {

--- a/tests/driver/api.test.ts
+++ b/tests/driver/api.test.ts
@@ -624,6 +624,14 @@ describe('Mongoose Model API level tests', async () => {
             const res = await Product.db.collection('products').findOne();
             assert.equal(res!.name, 'Product 1');
         });
+        it('API ops tests connection.listDatabases()', async () => {
+            const { databases } = await mongooseInstance!.connection.listDatabases();
+            assert.ok(Array.isArray(databases));
+            // @ts-ignore
+            assert.ok(mongooseInstance.connection.db.name);
+            // @ts-ignore
+            assert.ok(databases.includes(mongooseInstance.connection.db.name));
+        });
     });
 
     describe('vector search', function() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Mongoose 8.4 is introducing a `listDatabases()` function, which lines up nicely with `findNamespaces()`. Once Mongoose 8.4 is released, we can ship this. This change should be backwards compatible with older versions of Mongoose too.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)