### PR TITLE
reconnect http2 session if session timed out

### DIFF
--- a/src/client/httpClient.ts
+++ b/src/client/httpClient.ts
@@ -97,15 +97,20 @@ class HTTP2Session {
     numInFlightRequests: number;
     numRequests: number;
     gracefulCloseInProgress: boolean;
+    closed: boolean;
     origin: string;
 
     constructor(origin: string) {
         this.origin = origin;
-        this.session = http2.connect(origin);
-        this.numInFlightRequests = 0;
         this.numRequests = 0;
+        this.closed = false;
         this.gracefulCloseInProgress = false;
+        this._createSession();
+    }
 
+    _createSession() {
+        this.numInFlightRequests = 0;
+        this.session = http2.connect(this.origin);
         // Without these handlers, any errors will end up as uncaught exceptions,
         // even if they are handled in `_request()`.
         // More info: https://github.com/nodejs/node/issues/16345
@@ -115,6 +120,7 @@ class HTTP2Session {
 
     close() {
         this.session.close();
+        this.closed = true;
     }
 
     gracefulClose() {
@@ -133,6 +139,9 @@ class HTTP2Session {
 
     request(path: string, token: string, body: Record<string, any>, timeout: number): Promise<{ status: number, data: Record<string, any> }> {
         return new Promise((resolve, reject) => {
+            if (!this.closed && this.session.closed) {
+                this._createSession();
+            }
             ++this.numInFlightRequests;
             ++this.numRequests;
             let done = false;

--- a/src/client/httpClient.ts
+++ b/src/client/httpClient.ts
@@ -93,8 +93,8 @@ axiosAgent.interceptors.request.use(requestInterceptor);
 axiosAgent.interceptors.response.use(responseInterceptor);
 
 class HTTP2Session {
-    session: http2.ClientHttp2Session;
-    numInFlightRequests: number;
+    session!: http2.ClientHttp2Session;
+    numInFlightRequests!: number;
     numRequests: number;
     gracefulCloseInProgress: boolean;
     closed: boolean;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

I noticed while working on a sample app that http2 sessions time out after about 1 minute of inactivity, so that means all operations start erroring out after 1 minute of inactivity.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)