### PR TITLE
Support defaultId as a createCollection parameter

### DIFF
--- a/src/client/httpClient.ts
+++ b/src/client/httpClient.ts
@@ -137,7 +137,7 @@ class HTTP2Session {
         }
     }
 
-    request(path: string, token: string, body: Record<string, any>, timeout: number): Promise<{ status: number, data: Record<string, any> }> {
+    request(path: string, token: string, body: Record<string, any>, timeout: number): Promise<{ status: number, data: Record<string, any> }> { 
         return new Promise((resolve, reject) => {
             if (!this.closed && this.session.closed) {
                 this._createSession();
@@ -352,7 +352,7 @@ export class HTTPClient {
             }
             if (response.status === 200) {
                 return {
-                    status: response.data?.status,
+                    status: deserialize(response.data?.status),
                     data: deserialize(response.data?.data),
                     errors: response.data?.errors
                 };

--- a/src/collections/options.ts
+++ b/src/collections/options.ts
@@ -128,9 +128,12 @@ export const updateOneInternalOptionsKeys: Set<string> = new Set(
 
 export type IndexingOptions = { deny: string[], allow?: never } | { allow: string[], deny?: never };
 
+export type DefaultIdOptions = { type: 'objectId' | 'uuid' | 'uuid6' | 'uuid7' };
+
 class _CreateCollectionOptions {
     vector?: VectorOptions = undefined;
     indexing?: IndexingOptions = undefined;
+    defaultId?: DefaultIdOptions = undefined;
 }
 
 export interface CreateCollectionOptions extends _CreateCollectionOptions {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Adds `defaultId` as a parameter to `createCollection()`, and adds a test covering `createCollection()` with `defaultId`. I needed to make some changes to deserialize `status` from the response body, which looks to be what contains the actual command response.

Also left some code commented out for an issue that I'll open in Data API shortly

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)