### PR TITLE
Local cassandra instance token fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,8 +17,6 @@
 #    keyspaceName - testks1 (must be part of the URL, as the last path component)
 #    applicationToken - Query parameter. This can be passed as part of the URL or as part of the connection options
 DATA_API_URI=http://localhost:8181/v1/testks1
-# Stargate coordinator URL for authentication purposes.
-STARGATE_AUTH_URL=http://localhost:8081/v1/auth
 # Stargate Authentication username.
 STARGATE_USERNAME=cassandra
 # Stargate Authentication password.

--- a/README.md
+++ b/README.md
@@ -62,8 +62,7 @@ mongoose.setDriver(driver);
 const Product = mongoose.model('Product', new Schema({ name: String, price: Number }));
 mongoose.connect('http://localhost:8181/v1/inventory', {
     username: 'cassandra',
-    password: 'cassandra',
-    authUrl: 'http://localhost:8081/v1/auth'
+    password: 'cassandra'
 });
 Object.values(mongoose.connection.models).map(Model => Model.init());
 const app = express();

--- a/src/client/httpClient.ts
+++ b/src/client/httpClient.ts
@@ -283,7 +283,7 @@ export class HTTPClient {
             if (this.applicationToken === '') {
                 logger.debug('@stargate-mongoose/rest: getting token');
                 try {
-                    this.applicationToken = await getStargateAccessToken(this.username, this.password);
+                    this.applicationToken = getStargateAccessToken(this.username, this.password);
                 } catch (authError: any) {
                     return {
                         errors: [

--- a/src/client/httpClient.ts
+++ b/src/client/httpClient.ts
@@ -27,7 +27,6 @@ const REQUESTED_WITH = LIB_NAME + '/' + LIB_VERSION;
 const DEFAULT_AUTH_HEADER = 'X-Cassandra-Token';
 const DEFAULT_METHOD = 'get';
 const DEFAULT_TIMEOUT = 30000;
-export const AUTH_API_PATH = '/v1/auth';
 const HTTP_METHODS = {
     get: 'GET',
     post: 'POST',
@@ -46,7 +45,6 @@ interface APIClientOptions {
   logLevel?: string;
   username?: string;
   password?: string;
-  authUrl?: string;
   isAstra?: boolean;
   logSkippedOptions?: boolean;
   useHTTP2?: boolean;
@@ -223,7 +221,6 @@ export class HTTPClient {
     authHeaderName: string;
     username: string;
     password: string;
-    authUrl: string;
     isAstra: boolean;
     logSkippedOptions: boolean;
     http2Session?: HTTP2Session;
@@ -242,7 +239,6 @@ export class HTTPClient {
         }
         this.username = options.username || '';
         this.password = options.password || '';
-        this.authUrl = options.authUrl || this.baseUrl + AUTH_API_PATH;
         if (options.applicationToken) {
             this.applicationToken = options.applicationToken;
         } else {
@@ -287,7 +283,7 @@ export class HTTPClient {
             if (this.applicationToken === '') {
                 logger.debug('@stargate-mongoose/rest: getting token');
                 try {
-                    this.applicationToken = await getStargateAccessToken(this.authUrl, this.username, this.password);
+                    this.applicationToken = await getStargateAccessToken(this.username, this.password);
                 } catch (authError: any) {
                     return {
                         errors: [
@@ -334,22 +330,7 @@ export class HTTPClient {
                         [this.authHeaderName]: this.applicationToken
                     }
                 });
-   
-            if (!this.isAstra && (response.status === 401 || (response.data?.errors?.length > 0 && response.data?.errors?.[0]?.message === 'UNAUTHENTICATED: Invalid token'))) {
-                logger.debug('@stargate-mongoose/rest: reconnecting');
-                try {
-                    this.applicationToken = await getStargateAccessToken(this.authUrl, this.username, this.password);
-                } catch (authError: any) {
-                    return {
-                        errors: [
-                            {
-                                message: authError.message ? authError.message : 'Authentication failed, please retry!'
-                            }
-                        ]
-                    };
-                }
-                return this._request(requestInfo);
-            }
+
             if (response.status === 200) {
                 return {
                     status: response.data?.status,

--- a/src/collections/client.ts
+++ b/src/collections/client.ts
@@ -26,7 +26,6 @@ export interface ClientOptions {
   createNamespaceOnConnect?: boolean;
   username?: string;
   password?: string;
-  authUrl?: string;
   isAstra?: boolean;
   logSkippedOptions?: boolean;
   useHTTP2?: boolean;
@@ -56,7 +55,6 @@ export class Client {
             authHeaderName: options.authHeaderName,
             username: options.username,
             password: options.password,
-            authUrl: options.authUrl,
             isAstra: options.isAstra,
             logSkippedOptions: options.logSkippedOptions,
             useHTTP2: options.useHTTP2
@@ -79,7 +77,6 @@ export class Client {
             createNamespaceOnConnect: options?.createNamespaceOnConnect,
             username: options?.username,
             password: options?.password,
-            authUrl: options?.authUrl,
             isAstra: options?.isAstra,
             logSkippedOptions: options?.logSkippedOptions,
             useHTTP2: options?.useHTTP2

--- a/src/collections/utils.ts
+++ b/src/collections/utils.ts
@@ -101,7 +101,6 @@ export function createAstraUri (
 /**
  * Create a JSON API connection URI while connecting to Open source JSON API
  * @param baseUrl the base URL of the JSON API
- * @param baseAuthUrl the base URL of the JSON API auth (this is generally the Stargate Coordinator auth URL)
  * @param keyspace the keyspace to connect to
  * @param username the username to connect with
  * @param password the password to connect with
@@ -110,7 +109,6 @@ export function createAstraUri (
  */
 export async function createStargateUri (
     baseUrl: string,
-    baseAuthUrl: string,
     keyspace: string,
     username: string,
     password: string,
@@ -121,42 +119,21 @@ export async function createStargateUri (
     if (logLevel) {
         uri.searchParams.append('logLevel', logLevel);
     }
-    const accessToken = await getStargateAccessToken(baseAuthUrl, username, password);
+    const accessToken = await getStargateAccessToken(username, password);
     uri.searchParams.append('applicationToken', accessToken);
     return uri.toString();
 }
 
 /**
  * Get an access token from Stargate (this is useful while connecting to open source JSON API)
- * @param authUrl the base URL of the JSON API auth (this is generally the Stargate Coordinator auth URL)
  * @param username Username
  * @param password Password
  * @returns access token as string
  */
 export async function getStargateAccessToken(
-    authUrl: string,
     username: string,
     password: string) {
-    try {
-        const response = await axios({
-            url: authUrl,
-            data: { username, password },
-            method: 'POST',
-            headers: {
-                Accepts: 'application/json',
-                'Content-Type': 'application/json'
-            }
-        });
-        if (response.status === 401) {
-            throw new StargateAuthError(response.data?.description || 'Invalid credentials provided');
-        }
-        return response.data?.authToken;
-    } catch (e: any) {
-        if (e.response?.data?.description) {
-            e.message = e.response?.data?.description;
-        }
-        throw e;
-    }
+    return 'Cassandra:' + Buffer.from(username).toString('base64') + ':' + Buffer.from(password).toString('base64');
 }
 
 export class StargateAuthError extends Error {

--- a/src/collections/utils.ts
+++ b/src/collections/utils.ts
@@ -107,7 +107,7 @@ export function createAstraUri (
  * @param logLevel an winston log level (error: 0, warn: 1, info: 2, http: 3, verbose: 4, debug: 5, silly: 6)
 * @returns URL as string
  */
-export async function createStargateUri (
+export function createStargateUri(
     baseUrl: string,
     keyspace: string,
     username: string,
@@ -119,7 +119,7 @@ export async function createStargateUri (
     if (logLevel) {
         uri.searchParams.append('logLevel', logLevel);
     }
-    const accessToken = await getStargateAccessToken(username, password);
+    const accessToken = getStargateAccessToken(username, password);
     uri.searchParams.append('applicationToken', accessToken);
     return uri.toString();
 }
@@ -130,7 +130,7 @@ export async function createStargateUri (
  * @param password Password
  * @returns access token as string
  */
-export async function getStargateAccessToken(
+export function getStargateAccessToken(
     username: string,
     password: string) {
     return 'Cassandra:' + Buffer.from(username).toString('base64') + ':' + Buffer.from(password).toString('base64');

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,6 @@ declare module 'mongoose' {
   interface ConnectOptions {
     isAstra?: boolean;
     logSkippedOptions?: boolean;
-    authUrl?: string;
   }
 
   function setDriver<T = Mongoose>(driver: any): T;

--- a/tests/collections/client.test.ts
+++ b/tests/collections/client.test.ts
@@ -255,32 +255,6 @@ describe('StargateMongoose clients test', () => {
             assert.ok(error);
             assert.strictEqual(error.message, 'stargate-mongoose: must set `username` and `password` option when connecting if `applicationToken` not set');
         });
-        it('should set the auth url based on options when provided', async () => {
-            const TEST_AUTH_URL = 'authurl1';
-            const client = new Client(baseUrl, 'keyspace1', {
-                username: 'user1',
-                password: 'pass1',
-                authUrl: TEST_AUTH_URL,
-                createNamespaceOnConnect: false
-            });
-            const connectedClient = client.connect();
-            assert.ok(connectedClient);
-            assert.strictEqual((await connectedClient).httpClient.authUrl, TEST_AUTH_URL);
-        
-            await client.close();
-        });
-        it('should construct the auth url with baseUrl when not provided', async () => {
-            const client = new Client(baseUrl, 'keyspace1', {
-                username: 'user1',
-                password: 'pass1',
-                createNamespaceOnConnect: false
-            });
-            const connectedClient = client.connect();
-            assert.ok(connectedClient);
-            assert.strictEqual((await connectedClient).httpClient.authUrl, baseUrl + AUTH_API_PATH);
-            
-            await client.close();
-        });
     });
     describe('Client Db operations', () => {
         it('should return a db after setting up the client with a constructor', async () => {

--- a/tests/collections/client.test.ts
+++ b/tests/collections/client.test.ts
@@ -16,7 +16,6 @@ import assert from 'assert';
 import { Client } from '@/src/collections/client';
 import { testClient } from '@/tests/fixtures';
 import { parseUri } from '@/src/collections/utils';
-import { AUTH_API_PATH } from '@/src/client/httpClient';
 
 const localBaseUrl = 'http://localhost:8181';
 

--- a/tests/driver/index.test.ts
+++ b/tests/driver/index.test.ts
@@ -219,7 +219,7 @@ describe('Driver based tests', async () => {
 
             await mongooseInstance.disconnect();
 
-            const options = isAstra ? { isAstra: true } : { username: process.env.STARGATE_USERNAME, password: process.env.STARGATE_PASSWORD, authUrl: process.env.STARGATE_AUTH_URL };
+            const options = isAstra ? { isAstra: true } : { username: process.env.STARGATE_USERNAME, password: process.env.STARGATE_PASSWORD };
             // @ts-ignore - these are config options supported by stargate-mongoose but not mongoose
             await mongooseInstance.connect(dbUri, options);
 
@@ -247,7 +247,7 @@ describe('Driver based tests', async () => {
             mongooseInstance.set('autoCreate', false);
             mongooseInstance.set('autoIndex', false);
 
-            const options = isAstra ? { isAstra: true } : { username: process.env.STARGATE_USERNAME, password: process.env.STARGATE_PASSWORD, authUrl: process.env.STARGATE_AUTH_URL };
+            const options = isAstra ? { isAstra: true } : { username: process.env.STARGATE_USERNAME, password: process.env.STARGATE_PASSWORD };
             // @ts-ignore - these are config options supported by stargate-mongoose but not mongoose
             await mongooseInstance.connect(dbUri, options);
 
@@ -260,7 +260,7 @@ describe('Driver based tests', async () => {
             mongooseInstance.setDriver(StargateMongooseDriver);
             mongooseInstance.set('autoCreate', true);
             mongooseInstance.set('autoIndex', false);
-            const options = isAstra ? { isAstra: true } : { username: process.env.STARGATE_USERNAME, password: process.env.STARGATE_PASSWORD, authUrl: process.env.STARGATE_AUTH_URL };
+            const options = isAstra ? { isAstra: true } : { username: process.env.STARGATE_USERNAME, password: process.env.STARGATE_PASSWORD };
             // @ts-ignore - these are config options supported by stargate-mongoose but not mongoose
             await mongooseInstance.connect(dbUri, options);
             if (isAstra) {
@@ -283,7 +283,7 @@ describe('Driver based tests', async () => {
             mongooseInstance.setDriver(StargateMongooseDriver);
             mongooseInstance.set('autoCreate', true);
             mongooseInstance.set('autoIndex', false);
-            const options = isAstra ? { isAstra: true } : { username: process.env.STARGATE_USERNAME, password: process.env.STARGATE_PASSWORD, authUrl: process.env.STARGATE_AUTH_URL };
+            const options = isAstra ? { isAstra: true } : { username: process.env.STARGATE_USERNAME, password: process.env.STARGATE_PASSWORD };
             //split dbUri by / and replace last element with newKeyspaceName
             const dbUriSplit = dbUri.split('/');
             const token = parseUri(dbUri).applicationToken;

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -22,8 +22,7 @@ export const getDataAPIClient = async () => {
         return null;
     }
     const options: ClientOptions = { authHeaderName: process.env.AUTH_HEADER_NAME };
-    if (process.env.STARGATE_AUTH_URL && process.env.STARGATE_USERNAME && process.env.STARGATE_PASSWORD) {
-        options.authUrl = process.env.STARGATE_AUTH_URL;
+    if (process.env.STARGATE_USERNAME && process.env.STARGATE_PASSWORD) {
         options.username = process.env.STARGATE_USERNAME;
         options.password = process.env.STARGATE_PASSWORD;
     }
@@ -36,8 +35,7 @@ export const getAstraClient = async () => {
         return null;
     }
     const options: ClientOptions = { authHeaderName: process.env.AUTH_HEADER_NAME };
-    if (process.env.STARGATE_AUTH_URL && process.env.STARGATE_USERNAME && process.env.STARGATE_PASSWORD) {
-        options.authUrl = process.env.STARGATE_AUTH_URL;
+    if (process.env.STARGATE_USERNAME && process.env.STARGATE_PASSWORD) {
         options.username = process.env.STARGATE_USERNAME;
         options.password = process.env.STARGATE_PASSWORD;
     }

--- a/tests/mongooseFixtures.ts
+++ b/tests/mongooseFixtures.ts
@@ -43,7 +43,6 @@ before(async function connectMongooseFixtures() {
         const options = {
             username: process.env.STARGATE_USERNAME,
             password: process.env.STARGATE_PASSWORD,
-            authUrl: process.env.STARGATE_AUTH_URL,
             logSkippedOptions: true
         };
         // @ts-ignore - these are config options supported by stargate-mongoose but not mongoose


### PR DESCRIPTION
**What this PR does**:
With the latest v1.0.6 version of Data API, the format of the token that is expected for local data-api instances testing has changed.
From, stargate-mongoose side, so far we have been sending the UUID token received from the coordiator auth end point as the token to the Data API calls. This no longer works. The token for local data-api/cassandra instances is expected to be of the format `Cassandra:base64(username):base64(password)`.

This change is compatible with v1.0.5 and prior versions as well for local testing. Since, during the local testing the token passed by the stargate-mongoose were not so far verified by Data API until v1.0.5, so change in the token works with the existing version of Data API as well.

Note: This fix has nothing to do with how stargate-mongoose connects with AstraDB cloud instance.

**Checklist**
- [X] Changes manually tested
- [X] Automated Tests added/updated
- [X] Documentation added/updated
- [X] CLA Signed: [DataStax CLA](https://cla.datastax.com/)