### PR TITLE
upgrade data-api to 1.0.7

### DIFF
--- a/api-compatibility.versions
+++ b/api-compatibility.versions
@@ -1,2 +1,2 @@
-stargate_version=v2.1.0-BETA-10
-data_api_version=v1.0.5
+stargate_version=v2.1.0-BETA-11
+data_api_version=v1.0.7

--- a/src/collections/utils.ts
+++ b/src/collections/utils.ts
@@ -49,9 +49,9 @@ export const parseUri = (uri: string): ParsedUri => {
 };
 
 // Removes the last part of the api path (which is assumed as the keyspace name). for example below are the sample input => output from this function
-// /v1/testks1 => v1
-// /apis/v1/testks1 => apis/v1
-// /testks1 => '' (empty string)
+//  /v1/testks1 => v1
+//  /apis/v1/testks1 => apis/v1
+//  /testks1 => '' (empty string)
 function getBaseAPIPath(pathFromUrl?: string | null) {
     if (!pathFromUrl) {
         return '';

--- a/src/collections/utils.ts
+++ b/src/collections/utils.ts
@@ -15,7 +15,6 @@
 import { Types } from 'mongoose';
 import url from 'url';
 import { logger } from '@/src/logger';
-import axios from 'axios';
 import { HTTPClient, handleIfErrorResponse } from '@/src/client/httpClient';
 
 interface ParsedUri {

--- a/tests/collections/collection.test.ts
+++ b/tests/collections/collection.test.ts
@@ -187,20 +187,13 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
             assert.strictEqual(Object.keys(res.insertedIds).length, 3);
         });
         it('should not insert more than allowed number of documents in one insertMany call', async () => {
-            const docList = Array.from({ length: 21 }, () => ({ 'username': 'id' }));
+            const docList = Array.from({ length: 101 }, () => ({ 'username': 'id' }));
             docList.forEach((doc, index) => {
                 doc.username = doc.username + (index + 1);
             });
-            let error: any;
-            try {
-                await collection.insertMany(docList);
-            } catch (e: any) {
-                error = e;
-            }
-            assert.ok(error);
-            assert.strictEqual(
-                error.errors[0].message,
-                'Request invalid: field \'command.documents\' value "[{"username":"id1"}, {"username":"id2"}, {"username":"id3"}, {"username":"id4"}, {"username":"id5"}, {"username":"id6"}, {"username":"id7"}, {"username":"id8"}, {"username":"id9"}, {"username":"id10"}, {"username":"id11"}, {"username":"id12"}, {"username":"id13"}, {"username":"id14"}, {"username":"id15"}, {"username":"id16"}, {"username":"id17"}, {"username":"id18"}, {"username":"id19"}, {"username":"id20"}, {"username":"id21"}]" not valid. Problem: amount of documents to insert is over the max limit (21 vs 20).'
+            await assert.rejects(
+              () => collection.insertMany(docList),
+              /Problem: amount of documents to insert is over the max limit \(101 vs 100\)/
             );
         });
         it('should error out when docs list is empty in insertMany', async () => {

--- a/tests/collections/collection.test.ts
+++ b/tests/collections/collection.test.ts
@@ -192,8 +192,8 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
                 doc.username = doc.username + (index + 1);
             });
             await assert.rejects(
-              () => collection.insertMany(docList),
-              /Problem: amount of documents to insert is over the max limit \(101 vs 100\)/
+                () => collection.insertMany(docList),
+                /Problem: amount of documents to insert is over the max limit \(101 vs 100\)/
             );
         });
         it('should error out when docs list is empty in insertMany', async () => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Use latest version of data-api. Requires a minor test change because data-api now allows up to 100 docs in `insertMany()`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)