### PR TITLE
add usePagination option to insertMany() to allow inserting arbitrarily many docs in batch

### DIFF
--- a/src/collections/options.ts
+++ b/src/collections/options.ts
@@ -94,6 +94,7 @@ export const findOneAndUpdateInternalOptionsKeys: Set<string> = new Set(
 
 class _InsertManyOptions {
     ordered?: boolean = undefined;
+    usePagination?: boolean = undefined;
 }
 
 export interface InsertManyOptions extends _InsertManyOptions {}

--- a/src/collections/utils.ts
+++ b/src/collections/utils.ts
@@ -15,7 +15,6 @@
 import { Types } from 'mongoose';
 import url from 'url';
 import { logger } from '@/src/logger';
-import axios from 'axios';
 import { HTTPClient, handleIfErrorResponse } from '@/src/client/httpClient';
 
 interface ParsedUri {

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -112,8 +112,47 @@ export class Collection extends MongooseCollection {
      * @param documents
      * @param options
      */
-    insertMany(documents: Record<string, any>[], options?: InsertManyOptions) {
-        return this.collection.insertMany(documents, options);
+    async insertMany(documents: Record<string, any>[], options?: InsertManyOptions) {
+        const usePagination = options?.usePagination ?? false;
+        if (options != null && 'usePagination' in options) {
+            options = { ...options };
+            delete options.usePagination;
+        }
+
+        const ordered = options?.ordered ?? true;
+
+        if (usePagination) {
+            const batchSize = 20;
+            const ops = [];
+            const ret = { acknowledged: true, insertedCount: 0, insertedIds: [] };
+            for (let i = 0; i < documents.length; i += batchSize) {
+                const batch = documents.slice(i, i + batchSize);
+                if (ordered) {
+                    const {
+                        acknowledged,
+                        insertedCount,
+                        insertedIds
+                    } = await this.collection.insertMany(batch, options);
+                    ret.acknowledged = ret.acknowledged && acknowledged;
+                    ret.insertedCount += insertedCount;
+                    ret.insertedIds = ret.insertedIds.concat(insertedIds);
+                } else {
+                    ops.push(this.collection.insertMany(batch, options));
+                }
+            }
+            if (ordered) {
+                const results = await Promise.all(ops);
+                for (const { acknowledged, insertedCount, insertedIds } of results) {
+                    ret.acknowledged = ret.acknowledged && acknowledged;
+                    ret.insertedCount += insertedCount;
+                    ret.insertedIds = ret.insertedIds.concat(insertedIds);
+                }
+            }
+
+            return ret;
+        } else {
+            return this.collection.insertMany(documents, options);
+        }
     }
 
     /**

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -140,7 +140,7 @@ export class Collection extends MongooseCollection {
                     ops.push(this.collection.insertMany(batch, options));
                 }
             }
-            if (ordered) {
+            if (!ordered) {
                 const results = await Promise.all(ops);
                 for (const { acknowledged, insertedCount, insertedIds } of results) {
                     ret.acknowledged = ret.acknowledged && acknowledged;

--- a/tests/driver/api.test.ts
+++ b/tests/driver/api.test.ts
@@ -461,6 +461,13 @@ describe('Mongoose Model API level tests', async () => {
             assert.strictEqual(insertResp[0].name, 'Product 1');
             assert.strictEqual(insertResp[1].name, 'Product 2');
             assert.strictEqual(insertResp[2].name, 'Product 3');
+
+            const docs = [];
+            for (let i = 0; i < 21; ++i) {
+                docs.push({ name: 'Test product ' + i, price: 10, isCertified: true });
+            }
+            const resp = await Product.insertMany(docs, { usePagination: true });
+            assert.strictEqual(resp.length, 21);
         });
         //Model.inspect can not be tested since it is a helper for console logging. More info here: https://mongoosejs.com/docs/api/model.html#Model.inspect()
         it('API ops tests Model.listIndexes()', async () => {

--- a/tests/driver/api.test.ts
+++ b/tests/driver/api.test.ts
@@ -19,7 +19,7 @@ import {
     testClient,
     TEST_COLLECTION_NAME
 } from '@/tests/fixtures';
-import mongoose, {Schema, InferSchemaType} from 'mongoose';
+import mongoose, { Schema, InferSchemaType, InsertManyResult } from 'mongoose';
 import * as StargateMongooseDriver from '@/src/driver';
 import {randomUUID} from 'crypto';
 import {OperationNotSupportedError} from '@/src/driver';
@@ -456,18 +456,25 @@ describe('Mongoose Model API level tests', async () => {
             const product1 = {name: 'Product 1', price: 10, isCertified: true, category: 'cat 2'};
             const product2 = {name: 'Product 2', price: 10, isCertified: true, category: 'cat 2'};
             const product3 = {name: 'Product 3', price: 10, isCertified: true, category: 'cat 1'};
-            const insertResp = await Product.insertMany([product1, product2, product3] , {ordered: true});
-            assert.strictEqual(insertResp.length, 3);
-            assert.strictEqual(insertResp[0].name, 'Product 1');
-            assert.strictEqual(insertResp[1].name, 'Product 2');
-            assert.strictEqual(insertResp[2].name, 'Product 3');
+            const insertResp: InsertManyResult<any> = await Product.insertMany([product1, product2, product3] , {ordered: true, rawResult: true});
+            assert.ok(insertResp.acknowledged);
+            assert.strictEqual(insertResp.insertedCount, 3);
 
-            const docs = [];
+            let docs = [];
             for (let i = 0; i < 21; ++i) {
                 docs.push({ name: 'Test product ' + i, price: 10, isCertified: true });
             }
-            const resp = await Product.insertMany(docs, { usePagination: true });
-            assert.strictEqual(resp.length, 21);
+            const respOrdered: InsertManyResult<any> = await Product.insertMany(docs, { usePagination: true, rawResult: true  });
+            assert.ok(respOrdered.acknowledged);
+            assert.strictEqual(respOrdered.insertedCount, 21);
+
+            docs = [];
+            for (let i = 0; i < 21; ++i) {
+                docs.push({ name: 'Test product ' + i, price: 10, isCertified: true });
+            }
+            const respUnordered: InsertManyResult<any> = await Product.insertMany(docs, { usePagination: true, ordered: false, rawResult: true });
+            assert.ok(respUnordered.acknowledged);
+            assert.strictEqual(respUnordered.insertedCount, 21);
         });
         //Model.inspect can not be tested since it is a helper for console logging. More info here: https://mongoosejs.com/docs/api/model.html#Model.inspect()
         it('API ops tests Model.listIndexes()', async () => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Similar to how `updateMany()` now has a `usePagination` option to allow updating more than 20 docs at a time, this PR adds batching for `insertMany()`. Re: discussion with Aaron last week.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)