### PR TITLE
improve error when calling `createCollection()` and `dropCollection()` with no args

### DIFF
--- a/src/collections/db.ts
+++ b/src/collections/db.ts
@@ -66,6 +66,9 @@ export class Db {
    * @returns Promise
    */
     async createCollection(collectionName: string, options?: CreateCollectionOptions) {
+        if (collectionName == null) {
+            throw new TypeError(`Must specify a collection name when calling createCollection, got ${collectionName}`);
+        }
         return executeOperation(async () => {
             const command = {
                 createCollection: {
@@ -87,6 +90,9 @@ export class Db {
    * @returns APIResponse
    */
     async dropCollection(collectionName: string) {
+        if (collectionName == null) {
+            throw new TypeError(`Must specify a collection name when calling dropCollection, got ${collectionName}`);
+        }
         const command = {
             deleteCollection: {
                 name: collectionName

--- a/src/collections/utils.ts
+++ b/src/collections/utils.ts
@@ -15,7 +15,6 @@
 import { Types } from 'mongoose';
 import url from 'url';
 import { logger } from '@/src/logger';
-import axios from 'axios';
 import { HTTPClient, handleIfErrorResponse } from '@/src/client/httpClient';
 
 interface ParsedUri {

--- a/tests/collections/db.test.ts
+++ b/tests/collections/db.test.ts
@@ -109,6 +109,16 @@ describe('StargateMongoose - collections.Db', async () => {
             }
         });
 
+        it('throws helpful error if calling createCollection with no args', async () => {
+            const db = new Db(httpClient, parseUri(dbUri).keyspaceName);
+
+            await assert.rejects(
+                // @ts-ignore
+                () => db.createCollection(),
+                /Must specify a collection name when calling createCollection/
+            );
+        });
+
         it('should create a Collection with allow indexing options', async () => {
             const collectionName = TEST_COLLECTION_NAME + '_allow';
             const db = new Db(httpClient, parseUri(dbUri).keyspaceName);
@@ -178,6 +188,16 @@ describe('StargateMongoose - collections.Db', async () => {
             const res = await db.dropCollection(`test_db_collection_${suffix}`);
             assert.strictEqual(res.status?.ok, 1);
             assert.strictEqual(res.errors, undefined);
+        });
+
+        it('throws helpful error if calling dropCollection with no args', async () => {
+            const db = new Db(httpClient, parseUri(dbUri).keyspaceName);
+
+            await assert.rejects(
+                // @ts-ignore
+                () => db.dropCollection(),
+                /Must specify a collection name when calling dropCollection/
+            );
         });
     });
 

--- a/tests/driver/api.test.ts
+++ b/tests/driver/api.test.ts
@@ -489,7 +489,7 @@ describe('Mongoose Model API level tests', async () => {
             const product1 = new Product({name: 'Product 1', price: 10, isCertified: true, category: 'cat 1'});
             await product1.save();
             const docSaved = await Product.findOne({name: 'Product 1'});
-            assert.strictEqual(docSaved.name, 'Product 1');
+            assert.strictEqual(docSaved!.name, 'Product 1');
             await product1.deleteOne();
             const findDeletedDoc = await Product.findOne({name: 'Product 1'});
             assert.strictEqual(findDeletedDoc, null);


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Quick fix for an issue I ran into: if you call `createCollection()` on a connection with no arguments, you get a somewhat confusing error message:

```
    {
      message: "Request invalid: field 'command.name' value `null` not valid. Problem: must not be null.",
      errorCode: 'COMMAND_FIELD_INVALID'
    }
```

Just a quick fix to improve that error message

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)