### PR TITLE
serialize Mongoose subdocs and arrays using toBSON() to avoid errors on $push with document array

### DIFF
--- a/src/client/serialize.ts
+++ b/src/client/serialize.ts
@@ -3,12 +3,12 @@ import mongoose from 'mongoose';
 
 export function serialize(data: Record<string, any>, pretty?: boolean): string {
     return data != null
-      ? EJSON.stringify(
-        applyToBSONTransform(data),
-        (key, value) => serializeValue(value),
-        pretty ? '  ' : ''
-      )
-      : data;
+        ? EJSON.stringify(
+            applyToBSONTransform(data),
+            (key, value) => serializeValue(value),
+            pretty ? '  ' : ''
+        )
+        : data;
 }
 
 // Mongoose relies on certain values getting transformed into their BSON equivalents,
@@ -19,8 +19,8 @@ function applyToBSONTransform(data: Record<string, any> | any[]): Record<string,
     }
     // @ts-ignore
     if (shouldApplyToBSON(data) && typeof data.toBSON === 'function') {
-      // @ts-ignore
-      data = data.toBSON();
+        // @ts-ignore
+        data = data.toBSON();
     }
     if (Array.isArray(data)) {
         return data.map(el => applyToBSONTransform(el));
@@ -36,31 +36,31 @@ function applyToBSONTransform(data: Record<string, any> | any[]): Record<string,
 }
 
 function shouldApplyToBSON(value: any) {
-  return value?.isMongooseArrayProxy || value instanceof mongoose.Types.Subdocument;
+    return value?.isMongooseArrayProxy || value instanceof mongoose.Types.Subdocument;
 }
 
 function serializeValue(value: any): any {
-  if (value != null && typeof value === 'bigint') {
-      //BigInt handling
-      return Number(value);
-  } else if (value != null && typeof value === 'object') {
-      // ObjectId to strings
-      if (value.$oid) {
-          return value.$oid;
-      } else if (value.$numberDecimal) {
-          //Decimal128 handling
-          return Number(value.$numberDecimal);
-      } else if (value.$binary && (value.$binary.subType === '03' || value.$binary.subType === '04')) {
-          //UUID handling. Subtype 03 or 04 is UUID. Refer spec : https://bsonspec.org/spec.html
-          return Buffer.from(value.$binary.base64, 'base64').toString('hex')
-              .replace(/(.{8})(.{4})(.{4})(.{4})(.{12})/, '$1-$2-$3-$4-$5');
-      }
-      //Date handling
-      else if (value.$date) {
-          // Use numbers instead of strings for dates
-          value.$date = new Date(value.$date).valueOf();
-      }
-  }
-  //all other values
-  return value;
+    if (value != null && typeof value === 'bigint') {
+        //BigInt handling
+        return Number(value);
+    } else if (value != null && typeof value === 'object') {
+        // ObjectId to strings
+        if (value.$oid) {
+            return value.$oid;
+        } else if (value.$numberDecimal) {
+            //Decimal128 handling
+            return Number(value.$numberDecimal);
+        } else if (value.$binary && (value.$binary.subType === '03' || value.$binary.subType === '04')) {
+            //UUID handling. Subtype 03 or 04 is UUID. Refer spec : https://bsonspec.org/spec.html
+            return Buffer.from(value.$binary.base64, 'base64').toString('hex')
+                .replace(/(.{8})(.{4})(.{4})(.{4})(.{12})/, '$1-$2-$3-$4-$5');
+        }
+        //Date handling
+        else if (value.$date) {
+            // Use numbers instead of strings for dates
+            value.$date = new Date(value.$date).valueOf();
+        }
+    }
+    //all other values
+    return value;
 }

--- a/src/client/serialize.ts
+++ b/src/client/serialize.ts
@@ -1,0 +1,66 @@
+import { EJSON } from 'bson';
+import mongoose from 'mongoose';
+
+export function serialize(data: Record<string, any>, pretty?: boolean): string {
+    return data != null
+      ? EJSON.stringify(
+        applyToBSONTransform(data),
+        (key, value) => serializeValue(value),
+        pretty ? '  ' : ''
+      )
+      : data;
+}
+
+// Mongoose relies on certain values getting transformed into their BSON equivalents,
+// most notably subdocuments and document arrays. Otherwise `$push` on a document array fails.
+function applyToBSONTransform(data: Record<string, any> | any[]): Record<string, any> {
+    if (data == null) {
+        return data;
+    }
+    // @ts-ignore
+    if (shouldApplyToBSON(data) && typeof data.toBSON === 'function') {
+      // @ts-ignore
+      data = data.toBSON();
+    }
+    if (Array.isArray(data)) {
+        return data.map(el => applyToBSONTransform(el));
+    }
+    for (const key of Object.keys(data)) {
+        if (data[key] == null) {
+            continue;
+        } else if (typeof data[key] === 'object') {
+            data[key] = applyToBSONTransform(data[key]);
+        }
+    }
+    return data;
+}
+
+function shouldApplyToBSON(value: any) {
+  return value?.isMongooseArrayProxy || value instanceof mongoose.Types.Subdocument;
+}
+
+function serializeValue(value: any): any {
+  if (value != null && typeof value === 'bigint') {
+      //BigInt handling
+      return Number(value);
+  } else if (value != null && typeof value === 'object') {
+      // ObjectId to strings
+      if (value.$oid) {
+          return value.$oid;
+      } else if (value.$numberDecimal) {
+          //Decimal128 handling
+          return Number(value.$numberDecimal);
+      } else if (value.$binary && (value.$binary.subType === '03' || value.$binary.subType === '04')) {
+          //UUID handling. Subtype 03 or 04 is UUID. Refer spec : https://bsonspec.org/spec.html
+          return Buffer.from(value.$binary.base64, 'base64').toString('hex')
+              .replace(/(.{8})(.{4})(.{4})(.{4})(.{12})/, '$1-$2-$3-$4-$5');
+      }
+      //Date handling
+      else if (value.$date) {
+          // Use numbers instead of strings for dates
+          value.$date = new Date(value.$date).valueOf();
+      }
+  }
+  //all other values
+  return value;
+}

--- a/tests/driver/api.test.ts
+++ b/tests/driver/api.test.ts
@@ -593,18 +593,18 @@ describe('Mongoose Model API level tests', async () => {
             assert.deepStrictEqual(tags.toObject(), [{ name: 'Electronics' }, { name: 'Home & Garden' }]);
         });
         it('API ops tests Model.updateOne() $set subdocument', async () => {
-          const cart = new Cart({
-              user: {
-                  name: 'test set subdocument'
-              }
-          });
-          await cart.save();
-          //UpdateOne
-          await Cart.updateOne({ _id: cart._id }, { $set: { user: { name: 'test updated subdoc' } } });
+            const cart = new Cart({
+                user: {
+                    name: 'test set subdocument'
+                }
+            });
+            await cart.save();
+            //UpdateOne
+            await Cart.updateOne({ _id: cart._id }, { $set: { user: { name: 'test updated subdoc' } } });
           
-          const { user } = await Cart.findById(cart._id).orFail();
-          assert.deepStrictEqual(user.toObject(), { name: 'test updated subdoc' });
-      });
+            const { user } = await Cart.findById(cart._id).orFail();
+            assert.deepStrictEqual(user.toObject(), { name: 'test updated subdoc' });
+        });
         //Model.validate is skipped since it doesn't make any database calls. More info here: https://mongoosejs.com/docs/api/model.html#Model.validate
         it('API ops tests Model.watch()', async () => {
             let error: OperationNotSupportedError | null = null;

--- a/tests/mongooseFixtures.ts
+++ b/tests/mongooseFixtures.ts
@@ -8,7 +8,7 @@ const cartSchema = new Schema({
     cartName: {type: String, lowercase: true, unique: true, index: true},
     products: [{type: Schema.Types.ObjectId, ref: 'Product'}],
     user: new Schema({
-      name: String
+        name: String
     }, { _id: false })
 });
 

--- a/tests/mongooseFixtures.ts
+++ b/tests/mongooseFixtures.ts
@@ -6,7 +6,10 @@ import { parseUri, createNamespace } from '@/src/collections/utils';
 const cartSchema = new Schema({
     name: String,
     cartName: {type: String, lowercase: true, unique: true, index: true},
-    products: [{type: Schema.Types.ObjectId, ref: 'Product'}]
+    products: [{type: Schema.Types.ObjectId, ref: 'Product'}],
+    user: new Schema({
+      name: String
+    }, { _id: false })
 });
 
 const productSchema = new Schema({
@@ -14,7 +17,8 @@ const productSchema = new Schema({
     price: Number,
     expiryDate: Date,
     isCertified: Boolean,
-    category: String
+    category: String,
+    tags: [{ _id: false, name: String }]
 });
 
 export const mongooseInstance = new Mongoose();


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Without this PR, the `API ops tests Model.updateOne() $push document array` test added in this PR would fail with the following error:

```
Error: Command "updateOne" failed with the following errors: [{"message":"Converting circular structure to EJSON: (root) -> updateOne -> update -> $push -> tags -> __parentArray -> ...
```

I ran into this issue when working on vkarpov15/notion-clone#3: notice the `RateLimit.collection.findOneAndUpdate()` to avoid this issue.

The root cause is that Mongoose casts the `$push.tags` property in `{ $push: { tags: { name: 'Home & Garden' } } }` to a Mongoose ArraySubdocument, which is a circular object that `EJSON.serialize()` crashes on. With this PR, stargate-mongoose will convert any Mongoose arrays and Mongoose subdocuments (both circular objects) to POJOs before calling `EJSON.serialize()` to avoid this circular structure error.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)