### PR TITLE
improve http2 connection error handling

### DIFF
--- a/APIReference.md
+++ b/APIReference.md
@@ -361,7 +361,7 @@
 
 <a name="getStargateAccessToken"></a>
 
-## getStargateAccessToken(authUrl, username, password) ⇒
+## getStargateAccessToken(username, password) ⇒
 <p>Get an access token from Stargate (this is useful while connecting to open source Data API)</p>
 
 **Kind**: global function  
@@ -369,7 +369,6 @@
 
 | Param | Description |
 | --- | --- |
-| authUrl | <p>the base URL of the Data API auth (this is generally the Stargate Coordinator auth URL)</p> |
 | username | <p>Username</p> |
 | password | <p>Password</p> |
 

--- a/src/client/httpClient.ts
+++ b/src/client/httpClient.ts
@@ -338,7 +338,7 @@ export class HTTPClient {
                     errors: response.data?.errors
                 };
             } else {
-                return response;
+                return { errors: response.data?.errors };
             }
         } catch (e: any) {
             logger.error(requestInfo.url + ': ' + e.message);

--- a/src/collections/client.ts
+++ b/src/collections/client.ts
@@ -81,7 +81,13 @@ export class Client {
             logSkippedOptions: options?.logSkippedOptions,
             useHTTP2: options?.useHTTP2
         });
-        await client.connect();
+        await client.connect().catch(err => {
+            // If `connect()` throws an error, there's no way for the calling code to
+            // get a reference to `client()`. So make sure to close client in case we
+            // have an open HTTP2 socket, otherwise there's no way to close the socket.
+            client.close();
+            throw err;
+        });
         return client;
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Fixes for a couple of issues I ran into while debugging test failures in stargate-mongoose-sample-apps (https://github.com/stargate/stargate-mongoose-sample-apps/pull/319) due to credential issues. With http2, we have a few issues with handling incorrect credentials that cause the process to hang.

1. In `src/connections/client.ts`, if `Client.connect()` throws an error, we don't return a reference to the newly created `client` and don't close the client's http2 session. That means the client's http2 session may stay open, and there's no way for the calling code to close it.
2. We don't surface http2 errors correctly. `axiosAgent()` throws an error if request status is `>= 400`, which means http1 logic never executes the `else { return response; }` block in `src/client/httpClient.ts`. But http2 only goes through that block because `makeHTTP2Request()` does not throw an error if request status is `>= 400`. And that code path leaves the `errors` property in `data.errors` rather than promoting `errors` to a top-level property, which means `handleIfErrorResponse` doesn't see the server errors.

I also fixed a minor docs issue where `getStargateAccessToken()` description was out of date.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)