### PR TITLE
add support for `$vectorize` in `sort()` using `$meta` syntax

### DIFF
--- a/src/client/httpClient.ts
+++ b/src/client/httpClient.ts
@@ -18,7 +18,6 @@ import { logger, setLevel } from '@/src/logger';
 import { inspect } from 'util';
 import { LIB_NAME, LIB_VERSION } from '../version';
 import { getStargateAccessToken } from '../collections/utils';
-import { EJSON } from 'bson';
 import http2 from 'http2';
 import { StargateMongooseError } from '../collections/collection';
 import { deserialize } from './deserialize'; 

--- a/src/collections/cursor.ts
+++ b/src/collections/cursor.ts
@@ -36,6 +36,7 @@ export class FindCursor {
 
         const isOverPageSizeLimit = this.options.sort &&
             !('$vector' in this.options.sort) &&
+            !('$vectorize' in this.options.sort) &&
             (this.options.limit == null || this.options.limit > 20);
         if (isOverPageSizeLimit) {
             throw new Error('Cannot set sort option without limit <= 20, JSON API can currently only return 20 documents with sort');

--- a/src/collections/cursor.ts
+++ b/src/collections/cursor.ts
@@ -35,7 +35,7 @@ export class FindCursor {
         this.options = options ?? {};
 
         const isOverPageSizeLimit = this.options.sort &&
-            this.options.sort.$vector == null &&
+            !('$vector' in this.options.sort) &&
             (this.options.limit == null || this.options.limit > 20);
         if (isOverPageSizeLimit) {
             throw new Error('Cannot set sort option without limit <= 20, JSON API can currently only return 20 documents with sort');

--- a/src/collections/options.ts
+++ b/src/collections/options.ts
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export type SortOption = Record<string, 1 | -1> | { $vector: { $meta: Array<number> } } | { $vector: Array<number> };
+export type SortOption = Record<string, 1 | -1> |
+  { $vector: { $meta: Array<number> } } |
+  { $vector: Array<number> } |
+  { $vectorize: { $meta: string } } |
+  { $vectorize: string };
 
 export type ProjectionOption = Record<string, 1 | 0 | true | false | { $slice: number }>;
 

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -354,10 +354,16 @@ function processSortOption(options: { sort?: SortOption }) {
     if (options.sort == null) {
         return;
     }
-    if (typeof options.sort.$vector !== 'object' || Array.isArray(options.sort.$vector)) {
-        return;
+    if ('$vector' in options.sort &&
+        typeof options.sort.$vector === 'object' &&
+        !Array.isArray(options.sort.$vector)) {
+        options.sort.$vector = options.sort.$vector.$meta;
     }
-    options.sort.$vector = options.sort.$vector.$meta;
+    if ('$vectorize' in options.sort &&
+        typeof options.sort.$vectorize === 'object' &&
+        !Array.isArray(options.sort.$vectorize)) {
+        options.sort.$vectorize = options.sort.$vectorize.$meta;
+    }
 }
 
 export class OperationNotSupportedError extends Error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

The following now works:

```
  await Email.create({
    title: 'foo',
    $vectorize: 'taco tuesday'
  });

  console.log(await Email.findOne().sort({ $vectorize: { $meta: 'mexican food' } }));
```

Like `$vector`, we need `$meta` sort `sort()` because 1) Mongoose is fairly strict with what values are allowed for `sort()` and doesn't allow arbitrary strings; 2) Even if Mongoose did allow arbitrary strings, Mongoose has special handling for `sort('descending')` and a couple of other alternative syntaxes for sort. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)