### PR TITLE
upgrade to data-api v1.0.11, support projections in findOneAndX, fix tests

### DIFF
--- a/api-compatibility.versions
+++ b/api-compatibility.versions
@@ -1,2 +1,2 @@
 stargate_version=v2.1.0-BETA-12
-data_api_version=v1.0.10
+data_api_version=v1.0.11

--- a/api-compatibility.versions
+++ b/api-compatibility.versions
@@ -1,2 +1,2 @@
 stargate_version=v2.1.0-BETA-12
-data_api_version=v1.0.11
+data_api_version=v1.0.12

--- a/src/collections/collection.ts
+++ b/src/collections/collection.ts
@@ -259,7 +259,7 @@ export class Collection {
                     filter,
                     options,
                     ...(options?.sort != null ? { sort: options?.sort } : {}),
-                    ...(options?.projection != null ? { sort: options?.projection } : {}),
+                    ...(options?.projection != null ? { projection: options?.projection } : {}),
                 }
             };
 
@@ -279,7 +279,8 @@ export class Collection {
                     filter,
                     replacement,
                     options: omit(options, ['sort']),
-                    ...(options?.sort != null ? { sort: options?.sort } : {})
+                    ...(options?.sort != null ? { sort: options?.sort } : {}),
+                    ...(options?.projection != null ? { projection: options?.projection } : {}),
                 }
             };
             setDefaultIdForUpsert(command.findOneAndReplace, true);
@@ -319,7 +320,8 @@ export class Collection {
         const command = {
             findOneAndDelete: {
                 filter,
-                ...(options?.sort != null ? { sort: options?.sort } : {})
+                ...(options?.sort != null ? { sort: options?.sort } : {}),
+                ...(options?.projection != null ? { projection: options?.projection } : {}),
             }
         };
 
@@ -348,7 +350,8 @@ export class Collection {
                     filter,
                     update,
                     options: omit(options, ['sort']),
-                    ...(options?.sort != null ? { sort: options?.sort } : {})
+                    ...(options?.sort != null ? { sort: options?.sort } : {}),
+                    ...(options?.projection != null ? { projection: options?.projection } : {}),
                 }
             };
             setDefaultIdForUpsert(command.findOneAndUpdate);

--- a/src/collections/options.ts
+++ b/src/collections/options.ts
@@ -66,6 +66,7 @@ export const findOneInternalOptionsKeys: Set<string> = new Set(
 
 export interface FindOneAndDeleteOptions {
     sort?: SortOption;
+    projection?: ProjectionOption;
     includeResultMetadata?: boolean;
 }
 
@@ -74,6 +75,7 @@ class _FindOneAndReplaceOptions {
     upsert?: boolean = undefined;
     returnDocument?: 'before' | 'after' = undefined;
     sort?: SortOption;
+    projection?: ProjectionOption;
     includeResultMetadata?: boolean;
 }
 
@@ -87,6 +89,7 @@ class _FindOneAndUpdateOptions {
     upsert?: boolean = undefined;
     returnDocument?: 'before' | 'after' = undefined;
     sort?: SortOption;
+    projection?: ProjectionOption;
     includeResultMetadata?: boolean;
 }
 

--- a/tests/driver/api.test.ts
+++ b/tests/driver/api.test.ts
@@ -725,7 +725,9 @@ describe('Mongoose Model API level tests', async () => {
             vector.$vector = [1, 101];
             await vector.save();
 
-            const { $vector } = await Vector.findOne({ name: 'Test vector 1' }).orFail();
+            const { $vector } = await Vector
+                .findOne({ name: 'Test vector 1' }, { '*': 1 })
+                .orFail();
             assert.deepStrictEqual($vector, [1, 101]);
         });
 
@@ -782,7 +784,7 @@ describe('Mongoose Model API level tests', async () => {
                     { name: 'found vector', $vector: [990, 1] }
                 ).
                 sort({ $vector: { $meta: [99, 1] } });
-            const vectors = await Vector.find().limit(20).sort({ name: 1 });
+            const vectors = await Vector.find().select({ '*': 1 }).limit(20).sort({ name: 1 });
             assert.deepStrictEqual(vectors.map(v => v.name), ['Test vector 1', 'found vector']);
             assert.deepStrictEqual(vectors.map(v => v.$vector), [[1, 100], [990, 1]]);
         });
@@ -794,12 +796,13 @@ describe('Mongoose Model API level tests', async () => {
                     { name: 'found vector', $vector: [990, 1] },
                     { returnDocument: 'before' }
                 ).
+                select({ '*': 1 }).
                 orFail().
                 sort({ $vector: { $meta: [99, 1] } });
             assert.deepStrictEqual(res.$vector, [100, 1]);
             assert.strictEqual(res.name, 'Test vector 2');
 
-            const doc = await Vector.findById(res._id).orFail();
+            const doc = await Vector.findById(res._id).select({ '*': 1 }).orFail();
             assert.strictEqual(doc.name, 'found vector');
             assert.deepStrictEqual(doc.$vector, [990, 1]);
         });
@@ -810,7 +813,9 @@ describe('Mongoose Model API level tests', async () => {
                     { name: 'Test vector 2' },
                     { $setOnInsert: { $vector: [990, 1] } },
                     { returnDocument: 'after', upsert: true }
-                );
+                ).
+                select({ '*': 1 }).
+                orFail();
             assert.deepStrictEqual(res.$vector, [100, 1]);
             assert.strictEqual(res.name, 'Test vector 2');
 
@@ -818,8 +823,10 @@ describe('Mongoose Model API level tests', async () => {
                 findOneAndUpdate(
                     { name: 'Test vector 3' },
                     { $setOnInsert: { $vector: [990, 1] } },
-                    { returnDocument: 'after', upsert: true }
-                );
+                    { returnDocument: 'after', upsert: true, projection: { '*': 1 } }
+                ).
+                select({ '*': 1 }).
+                orFail();
             assert.deepStrictEqual(res.$vector, [990, 1]);
             assert.strictEqual(res.name, 'Test vector 3');
         });
@@ -831,6 +838,7 @@ describe('Mongoose Model API level tests', async () => {
                     { $unset: { $vector: 1 } },
                     { returnDocument: 'after' }
                 ).
+                select({ '*': 1 }).
                 orFail();
             assert.deepStrictEqual(res.$vector, undefined);
             assert.strictEqual(res.name, 'Test vector 2');
@@ -844,11 +852,12 @@ describe('Mongoose Model API level tests', async () => {
                     { returnDocument: 'before' }
                 ).
                 orFail().
+                select({ '*': 1 }).
                 sort({ $vector: { $meta: [99, 1] } });
             assert.deepStrictEqual(res.$vector, [100, 1]);
             assert.strictEqual(res.name, 'Test vector 2');
 
-            const doc = await Vector.findById(res._id).orFail();
+            const doc = await Vector.findById(res._id, { '*': 1 }).orFail();
             assert.strictEqual(doc.name, 'found vector');
             assert.deepStrictEqual(doc.$vector, [990, 1]);
         });
@@ -860,6 +869,7 @@ describe('Mongoose Model API level tests', async () => {
                     { returnDocument: 'before' }
                 ).
                 orFail().
+                select({ '*': 1 }).
                 sort({ $vector: { $meta: [1, 99] } });
             assert.deepStrictEqual(res.$vector, [1, 100]);
             assert.strictEqual(res.name, 'Test vector 1');


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

The new behavior of "`$vector` is projected out by default" in data-api v1.0.11 caused some test failures, which surfaced a couple of issues in our handling of projections:

1. findOneAndX don't support projection, stargate-mongoose doesn't currently set `projection` option on those
2. `findOne()` sets `projection` option as `sort` option

This PR fixes the above issues

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)