### PR TITLE
support estimatedDocumentCount()

### DIFF
--- a/src/collections/collection.ts
+++ b/src/collections/collection.ts
@@ -315,6 +315,18 @@ export class Collection {
         });
     }
 
+    async estimatedDocumentCount(): Promise<number> {
+        return executeOperation(async (): Promise<number> => {
+            const command = { estimatedDocumentCount: {} };
+            const resp = await this.httpClient.executeCommandWithUrl(
+                this.httpBasePath,
+                command,
+                null
+            );
+            return resp.status.count;
+        });
+    }
+
     async findOneAndDelete(filter: Record<string, any>, options?: FindOneAndDeleteOptions): Promise<DataAPIModifyResult> {
         const command = {
             findOneAndDelete: {

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -263,6 +263,13 @@ export class Collection extends MongooseCollection {
     }
 
     /**
+     * Get the estimated number of documents in a collection based on collection metadata
+     */
+    estimatedDocumentCount() {
+        return this.collection.estimatedDocumentCount();
+    }
+
+    /**
      * Bulk write not supported.
      * @param ops
      * @param options
@@ -333,13 +340,6 @@ export class Collection extends MongooseCollection {
      */
     distinct() {
         throw new OperationNotSupportedError('distinct() Not Implemented');
-    }
-
-    /**
-     * Estimated document count operation not supported.
-     */
-    estimatedDocumentCount() {
-        throw new OperationNotSupportedError('estimatedDocumentCount() Not Implemented');
     }
 
     /**

--- a/tests/driver/api.test.ts
+++ b/tests/driver/api.test.ts
@@ -370,19 +370,15 @@ describe('Mongoose Model API level tests', async () => {
             assert.strictEqual(err?.message, 'distinct() Not Implemented');
         });
         
-        it('API ops tests Model.estimatedDocumentCount()', async () => {
-            let error: OperationNotSupportedError | null = null;
-            try {
-                const product1 = new Product({name: 'Product 1', price: 10, isCertified: true, category: 'cat 1'});
-                const product2 = new Product({name: 'Product 2', price: 10, isCertified: true, category: 'cat 2'});
-                const product3 = new Product({name: 'Product 3', price: 10, isCertified: true, category: 'cat 1'});
-                await Product.insertMany([product1, product2, product3]);
-                await Product.estimatedDocumentCount();
-            } catch (err: any) {
-                error = err;
-            }
-            assert.ok(error);
-            assert.strictEqual(error?.message, 'estimatedDocumentCount() Not Implemented');
+        it('API ops tests Model.estimatedDocumentCount()', async function() {
+            const product1 = new Product({name: 'Product 1', price: 10, isCertified: true, category: 'cat 1'});
+            const product2 = new Product({name: 'Product 2', price: 10, isCertified: true, category: 'cat 2'});
+            const product3 = new Product({name: 'Product 3', price: 10, isCertified: true, category: 'cat 1'});
+            await Product.create([product1, product2, product3]);
+            
+            const count = await Product.estimatedDocumentCount();
+            assert.equal(typeof count, 'number');
+            assert.ok(count >= 0);
         });
         //skipping Model.events() as it is not making any database calls
         it('API ops tests Model.exists()', async () => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Adds support for `estimatedDocumentCount()`, which was introduced in data-api v1.0.3. Testing is a bit tricky, I haven't been able to get `estimatedDocumentCount()` to return anything other than 0 locally. However, it looks like [astra-db-ts ran into a similar issue](https://github.com/datastax/astra-db-ts/blob/b10da81f62a0ef72d9b8923bc035b7e7dd6289b5/tests/integration/data-api/collection/estimated-document-count.test.ts#L28), so I borrowed the testing pattern they used - just assert that `estimatedDocumentCount()` returns a non-negative number.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)