### PR TITLE
add handle$vectorProjection plugin

### DIFF
--- a/src/driver/index.ts
+++ b/src/driver/index.ts
@@ -17,8 +17,8 @@ export { Collection, OperationNotSupportedError } from './collection';
 
 import { Connection } from './connection';
 import { Mongoose } from 'mongoose';
-import { handle$vectorProjection } from './plugins';
+import { handleVectorFieldsProjection } from './plugins';
 
-export const plugins = [handle$vectorProjection];
+export const plugins = [handleVectorFieldsProjection];
 
 export type StargateMongoose = Mongoose & { connection: Connection, connections: Connection[] };

--- a/src/driver/index.ts
+++ b/src/driver/index.ts
@@ -17,5 +17,8 @@ export { Collection, OperationNotSupportedError } from './collection';
 
 import { Connection } from './connection';
 import { Mongoose } from 'mongoose';
+import { handle$vectorProjection } from './plugins';
+
+export const plugins = [handle$vectorProjection];
 
 export type StargateMongoose = Mongoose & { connection: Connection, connections: Connection[] };

--- a/src/driver/plugins.ts
+++ b/src/driver/plugins.ts
@@ -1,0 +1,20 @@
+import type { Schema, Query } from 'mongoose';
+
+export function handle$vectorProjection(this: Query<unknown, unknown>, schema: Schema) {
+    schema.pre(['find', 'findOne', 'findOneAndUpdate', 'findOneAndReplace', 'findOneAndDelete'], function() {
+        const projection = this.projection();
+        if (projection != null) {
+            if (Object.keys(projection).length === 1 && projection['*']) {
+                return;
+            }
+        }
+        const $vector = this.model.schema.paths['$vector'];
+        const $vectorize = this.model.schema.paths['$vectorize'];
+        if ($vector?.options?.select && (projection == null || !('$vector' in projection))) {
+            this.projection({ ...projection, $vector: 1 });
+        }
+        if ($vectorize?.options?.select && (projection == null || !('$vectorize' in projection))) {
+            this.projection({ ...projection, $vectorize: 1 });
+        }
+    });
+}

--- a/src/driver/plugins.ts
+++ b/src/driver/plugins.ts
@@ -1,6 +1,6 @@
 import type { Schema, Query } from 'mongoose';
 
-export function handle$vectorProjection(this: Query<unknown, unknown>, schema: Schema) {
+export function handleVectorFieldsProjection(this: Query<unknown, unknown>, schema: Schema) {
     schema.pre(['find', 'findOne', 'findOneAndUpdate', 'findOneAndReplace', 'findOneAndDelete'], function() {
         const projection = this.projection();
         if (projection != null) {

--- a/tests/driver/api.test.ts
+++ b/tests/driver/api.test.ts
@@ -726,7 +726,14 @@ describe('Mongoose Model API level tests', async () => {
                 .orFail();
             assert.deepStrictEqual($vector, [1, 101]);
 
-            const doc = await Vector
+            let doc = await Vector
+                .findOne({ name: 'Test vector 1' })
+                .select({ name: 0 })
+                .orFail();
+            assert.deepStrictEqual(doc.$vector, [1, 101]);
+            assert.strictEqual(doc.name, undefined);
+
+            doc = await Vector
                 .findOne({ name: 'Test vector 1' })
                 .select({ $vector: 0 })
                 .orFail();

--- a/tests/driver/api.test.ts
+++ b/tests/driver/api.test.ts
@@ -679,7 +679,7 @@ describe('Mongoose Model API level tests', async () => {
     describe('vector search', function() {
         const vectorSchema = new Schema(
             {
-                $vector: { type: [Number], default: () => void 0 },
+                $vector: { type: [Number], default: () => void 0, select: true },
                 name: 'String'
             },
             {
@@ -722,9 +722,16 @@ describe('Mongoose Model API level tests', async () => {
             await vector.save();
 
             const { $vector } = await Vector
-                .findOne({ name: 'Test vector 1' }, { '*': 1 })
+                .findOne({ name: 'Test vector 1' })
                 .orFail();
             assert.deepStrictEqual($vector, [1, 101]);
+
+            const doc = await Vector
+                .findOne({ name: 'Test vector 1' })
+                .select({ $vector: 0 })
+                .orFail();
+            assert.strictEqual(doc.$vector, undefined);
+            assert.strictEqual(doc.name, 'Test vector 1');
         });
 
         it('supports sort() and similarity score with $meta with find()', async function() {
@@ -780,7 +787,7 @@ describe('Mongoose Model API level tests', async () => {
                     { name: 'found vector', $vector: [990, 1] }
                 ).
                 sort({ $vector: { $meta: [99, 1] } });
-            const vectors = await Vector.find().select({ '*': 1 }).limit(20).sort({ name: 1 });
+            const vectors = await Vector.find().limit(20).sort({ name: 1 });
             assert.deepStrictEqual(vectors.map(v => v.name), ['Test vector 1', 'found vector']);
             assert.deepStrictEqual(vectors.map(v => v.$vector), [[1, 100], [990, 1]]);
         });
@@ -792,13 +799,12 @@ describe('Mongoose Model API level tests', async () => {
                     { name: 'found vector', $vector: [990, 1] },
                     { returnDocument: 'before' }
                 ).
-                select({ '*': 1 }).
                 orFail().
                 sort({ $vector: { $meta: [99, 1] } });
             assert.deepStrictEqual(res.$vector, [100, 1]);
             assert.strictEqual(res.name, 'Test vector 2');
 
-            const doc = await Vector.findById(res._id).select({ '*': 1 }).orFail();
+            const doc = await Vector.findById(res._id).orFail();
             assert.strictEqual(doc.name, 'found vector');
             assert.deepStrictEqual(doc.$vector, [990, 1]);
         });
@@ -810,7 +816,6 @@ describe('Mongoose Model API level tests', async () => {
                     { $setOnInsert: { $vector: [990, 1] } },
                     { returnDocument: 'after', upsert: true }
                 ).
-                select({ '*': 1 }).
                 orFail();
             assert.deepStrictEqual(res.$vector, [100, 1]);
             assert.strictEqual(res.name, 'Test vector 2');
@@ -819,9 +824,8 @@ describe('Mongoose Model API level tests', async () => {
                 findOneAndUpdate(
                     { name: 'Test vector 3' },
                     { $setOnInsert: { $vector: [990, 1] } },
-                    { returnDocument: 'after', upsert: true, projection: { '*': 1 } }
+                    { returnDocument: 'after', upsert: true }
                 ).
-                select({ '*': 1 }).
                 orFail();
             assert.deepStrictEqual(res.$vector, [990, 1]);
             assert.strictEqual(res.name, 'Test vector 3');
@@ -834,7 +838,6 @@ describe('Mongoose Model API level tests', async () => {
                     { $unset: { $vector: 1 } },
                     { returnDocument: 'after' }
                 ).
-                select({ '*': 1 }).
                 orFail();
             assert.deepStrictEqual(res.$vector, undefined);
             assert.strictEqual(res.name, 'Test vector 2');
@@ -848,12 +851,11 @@ describe('Mongoose Model API level tests', async () => {
                     { returnDocument: 'before' }
                 ).
                 orFail().
-                select({ '*': 1 }).
                 sort({ $vector: { $meta: [99, 1] } });
             assert.deepStrictEqual(res.$vector, [100, 1]);
             assert.strictEqual(res.name, 'Test vector 2');
 
-            const doc = await Vector.findById(res._id, { '*': 1 }).orFail();
+            const doc = await Vector.findById(res._id).orFail();
             assert.strictEqual(doc.name, 'found vector');
             assert.deepStrictEqual(doc.$vector, [990, 1]);
         });
@@ -865,7 +867,6 @@ describe('Mongoose Model API level tests', async () => {
                     { returnDocument: 'before' }
                 ).
                 orFail().
-                select({ '*': 1 }).
                 sort({ $vector: { $meta: [1, 99] } });
             assert.deepStrictEqual(res.$vector, [1, 100]);
             assert.strictEqual(res.name, 'Test vector 1');

--- a/tests/mongooseFixtures.ts
+++ b/tests/mongooseFixtures.ts
@@ -28,7 +28,7 @@ mongooseInstance.set('autoCreate', false);
 mongooseInstance.set('autoIndex', false);
 
 for (const plugin of plugins) {
-  mongooseInstance.plugin(plugin);
+    mongooseInstance.plugin(plugin);
 }
 
 export const Cart = mongooseInstance.model('Cart', cartSchema);

--- a/tests/mongooseFixtures.ts
+++ b/tests/mongooseFixtures.ts
@@ -2,6 +2,7 @@ import { isAstra, testClient } from './fixtures';
 import { Schema, Mongoose } from 'mongoose';
 import * as StargateMongooseDriver from '@/src/driver';
 import { parseUri, createNamespace } from '@/src/collections/utils';
+import { plugins } from '@/src/driver';
 
 const cartSchema = new Schema({
     name: String,
@@ -25,6 +26,11 @@ export const mongooseInstance = new Mongoose();
 mongooseInstance.setDriver(StargateMongooseDriver);
 mongooseInstance.set('autoCreate', false);
 mongooseInstance.set('autoIndex', false);
+
+for (const plugin of plugins) {
+  mongooseInstance.plugin(plugin);
+}
+
 export const Cart = mongooseInstance.model('Cart', cartSchema);
 export const Product = mongooseInstance.model('Product', productSchema);
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

I ran into some hard-to-debug errors with the recent change to deselect $vector and $vectorize by default, so I think it's worth adding some functionality to make it easier for $vector to be included by default in the stargate-mongoose layer using Mongoose's schema-level `select` syntax.

```javascript
const vectorSchema = new Schema({
  $vector: { type: [Number], select: true } // <-- `select: true` will mean `$vector` is projected in by default
});
```

Mongoose's `select: true` syntax is currently used to project fields in by default when they are excluded by the projection. Without a plugin, Mongoose would only add `$vector: 1` if there's an inclusive projection with other fields, like `Vector.find().select({ name: 1 })`.

This PR adds a plugin which will add `$vector: 1` to any projection if `$vector` has `select: true` in the schema.

I'll also add a quick PR to Mongoose to allow drivers to specify plugins. Right now, Mongoose supports global plugins, but scoped to the particular Mongoose instance. So if you use `const mongoose = require('mongoose')`, you get global plugins. But if you use `const mongoose = new Mongoose()`, you don't.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)