### PR TITLE
add support for includeSortVector by decorating docs with $sortVector property

### DIFF
--- a/src/collections/collection.ts
+++ b/src/collections/collection.ts
@@ -268,6 +268,9 @@ export class Collection {
                 command,
                 findOneInternalOptionsKeys
             );
+            if (options != null && options.includeSortVector) {
+                resp.data.document.$sortVector = resp.status.sortVector;
+            }
             return resp.data.document;
         });
     }

--- a/src/collections/cursor.ts
+++ b/src/collections/cursor.ts
@@ -114,6 +114,9 @@ export class FindCursor {
         if (this.options.includeSimilarity) {
             options.includeSimilarity = this.options.includeSimilarity;
         }
+        if (this.options?.includeSortVector) {
+            options.includeSortVector = this.options.includeSortVector;
+        }
 
         const cleanOptions = omit(options, ['sort', 'projection']) ?? {};
 
@@ -135,7 +138,12 @@ export class FindCursor {
         if (this.nextPageState == null) {
             this.exhausted = true;
         }
-        this.page = Object.keys(resp.data.documents).map(i => resp.data.documents[i]);
+        this.page = resp.data.documents;
+        if (options != null && options.includeSortVector) {
+            this.page.forEach(doc => {
+                doc.$sortVector = resp.status.sortVector;
+            });
+        }
         this.pageIndex = 0;    
     }
 

--- a/src/collections/options.ts
+++ b/src/collections/options.ts
@@ -35,6 +35,7 @@ export interface FindOptions {
     sort?: SortOption;
     projection?: ProjectionOption;
     includeSimilarity?: boolean;
+    includeSortVector?: boolean;
 }
 
 class _FindOptionsInternal {
@@ -42,6 +43,7 @@ class _FindOptionsInternal {
     skip?: number = undefined;
     pagingState?: string = undefined;
     includeSimilarity?: boolean = undefined;
+    includeSortVector?: boolean = undefined;
 }
 
 export interface FindOptionsInternal extends _FindOptionsInternal {}
@@ -54,10 +56,12 @@ export interface FindOneOptions {
     sort?: Record<string, 1 | -1>;
     projection?: ProjectionOption;
     includeSimilarity?: boolean;
+    includeSortVector?: boolean;
 }
 
 class _FindOneOptionsInternal {
     includeSimilarity?: boolean = undefined;
+    includeSortVector?: boolean = undefined;
 }
 
 export const findOneInternalOptionsKeys: Set<string> = new Set(

--- a/tests/driver/api.test.ts
+++ b/tests/driver/api.test.ts
@@ -20,6 +20,7 @@ import {
     TEST_COLLECTION_NAME
 } from '@/tests/fixtures';
 import mongoose, { Schema, InferSchemaType, InsertManyResult } from 'mongoose';
+import { once } from 'events';
 import * as StargateMongooseDriver from '@/src/driver';
 import {randomUUID} from 'crypto';
 import {OperationNotSupportedError} from '@/src/driver';
@@ -747,13 +748,13 @@ describe('Mongoose Model API level tests', async () => {
         });
 
         it('supports sort() with includeSortVector in find()', async function() {
-            const docs = await Vector
+            const cursor = await Vector
                 .find({}, null, { includeSortVector: true })
-                .sort({ $vector: { $meta: [1, 99] } });
-            const doc = docs[0];
-            assert.deepStrictEqual(doc.name, 'Test vector 1');
-            assert.deepStrictEqual(doc.$sortVector, [1, 99]);
-            assert.deepStrictEqual(doc.get('$sortVector'), [1, 99]);
+                .sort({ $vector: { $meta: [1, 99] } })
+                .cursor();
+            
+            await once(cursor, 'cursor');
+            assert.deepStrictEqual(await cursor.cursor.getSortVector(), [1, 99]);            
         });
 
         it('supports sort() and similarity score with $meta with findOne()', async function() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Right now stargate-mongoose doesn't support includeSortVector option. This PR adds that option. Given that Mongoose always returns just the `response.data.document` and `response.data.documents` properties when calling `findOne()` and `find()`, we need some alternative syntax to support `includeSortVector`. I supported that by just adding `$sortVector` as a property on the result documents.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)