### PR TITLE
support returnDocumentResponses option

### DIFF
--- a/src/collections/collection.ts
+++ b/src/collections/collection.ts
@@ -35,26 +35,30 @@ import {
 } from './options';
 
 export interface DataAPIUpdateResult {
-  matchedCount: number;
-  modifiedCount: number;
-  acknowledged: boolean;
-  upsertedId?: any,
-  upsertedCount?: number
+    matchedCount: number;
+    modifiedCount: number;
+    acknowledged: boolean;
+    upsertedId?: any;
+    upsertedCount?: number;
 }
 
 export interface DataAPIDeleteResult {
-  acknowledged: boolean;
-  deletedCount: number;
+    acknowledged: boolean;
+    deletedCount: number;
 }
 
 export interface DataAPIInsertOneResult {
-  acknowledged: boolean;
-  insertedId: any;
+    acknowledged: boolean;
+    insertedId: any;
 }
 
 export interface DataAPIModifyResult {
-  ok: number;
-  value: Record<string, any> | null;
+    ok: number;
+    value: Record<string, any> | null;
+}
+
+export type DataAPIInsertManyResult = InsertManyResult<any> & {
+    documentResponses?: { _id: unknown, status: string, errorsIdx?: number }
 }
 
 export class Collection {
@@ -94,7 +98,7 @@ export class Collection {
     }
 
     async insertMany(documents: Record<string, any>[], options?: InsertManyOptions) {
-        return executeOperation(async (): Promise<InsertManyResult<any>> => {
+        return executeOperation(async (): Promise<DataAPIInsertManyResult> => {
             const command = {
                 insertMany: {
                     documents,
@@ -109,7 +113,8 @@ export class Collection {
             return {
                 acknowledged: true,
                 insertedCount: resp.status.insertedIds?.length || 0,
-                insertedIds: resp.status.insertedIds
+                insertedIds: resp.status.insertedIds,
+                documentResponses: resp.status.documentResponses
             };
         });
     }

--- a/src/collections/options.ts
+++ b/src/collections/options.ts
@@ -102,6 +102,7 @@ export const findOneAndUpdateInternalOptionsKeys: Set<string> = new Set(
 class _InsertManyOptions {
     ordered?: boolean = undefined;
     usePagination?: boolean = undefined;
+    returnDocumentResponses?: boolean = undefined;
 }
 
 export interface InsertManyOptions extends _InsertManyOptions {}

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -141,7 +141,7 @@ export class Collection extends MongooseCollection {
                         ret.documentResponses = ret.documentResponses?.concat(documentResponses ?? []);
                     } else {
                         ret.insertedCount += insertedCount;
-                        ret.insertedIds = ret!.insertedIds.concat(insertedIds);
+                        ret.insertedIds = ret.insertedIds!.concat(insertedIds);
                     }
                 } else {
                     ops.push(this.collection.insertMany(batch, options));
@@ -155,7 +155,7 @@ export class Collection extends MongooseCollection {
                         ret.documentResponses = ret.documentResponses?.concat(documentResponses ?? []);
                     } else {
                         ret.insertedCount += insertedCount;
-                        ret.insertedIds = ret!.insertedIds.concat(insertedIds);
+                        ret.insertedIds = ret.insertedIds!.concat(insertedIds);
                     }
                 }
             }

--- a/tests/collections/collection.test.ts
+++ b/tests/collections/collection.test.ts
@@ -242,6 +242,45 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
                 assert.strictEqual(error.status.insertedIds[index], doc._id);
             });
         });
+        it('should error out when one of the docs in insertMany is invalid with ordered true and returnDocumentResponses', async () => {
+            const docList: { _id?: string, username: string }[] = Array.from({ length: 20 }, () => ({ 'username': 'id' }));
+            docList.forEach((doc, index) => {
+                doc._id = 'docml' + (index + 1);
+                doc.username = doc.username + (index + 1);
+            });
+            docList[10] = docList[9];
+            let error: any;
+            try {
+                await collection.insertMany(docList, { ordered: true, returnDocumentResponses: true });
+            } catch (e: any) {
+                error = e;
+            }
+            assert.ok(error);
+            assert.strictEqual(error.errors[0].message, 'Document already exists with the given _id');
+            assert.strictEqual(error.errors[0].errorCode, 'DOCUMENT_ALREADY_EXISTS');
+            assert.deepStrictEqual(error.status.documentResponses, [
+                { _id: 'docml1', status: 'OK' },
+                { _id: 'docml2', status: 'OK' },
+                { _id: 'docml3', status: 'OK' },
+                { _id: 'docml4', status: 'OK' },
+                { _id: 'docml5', status: 'OK' },
+                { _id: 'docml6', status: 'OK' },
+                { _id: 'docml7', status: 'OK' },
+                { _id: 'docml8', status: 'OK' },
+                { _id: 'docml9', status: 'OK' },
+                { _id: 'docml10', status: 'OK' },
+                { _id: 'docml10', status: 'ERROR', errorsIdx: 0 },
+                { _id: 'docml12', status: 'SKIPPED' },
+                { _id: 'docml13', status: 'SKIPPED' },
+                { _id: 'docml14', status: 'SKIPPED' },
+                { _id: 'docml15', status: 'SKIPPED' },
+                { _id: 'docml16', status: 'SKIPPED' },
+                { _id: 'docml17', status: 'SKIPPED' },
+                { _id: 'docml18', status: 'SKIPPED' },
+                { _id: 'docml19', status: 'SKIPPED' },
+                { _id: 'docml20', status: 'SKIPPED' }
+            ]);
+        });
         it('should error out when one of the docs in insertMany is invalid with ordered false', async () => {
             const docList: { _id?: string, username: string }[] = Array.from({ length: 20 }, () => ({ 'username': 'id' }));
             docList.forEach((doc, index) => {

--- a/tests/collections/collection.test.ts
+++ b/tests/collections/collection.test.ts
@@ -295,6 +295,45 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
                 error = e;
             }
             assert.ok(error);
+            assert.strictEqual(error.errors[0].message, 'Document already exists with the given _id');
+            assert.strictEqual(error.errors[0].errorCode, 'DOCUMENT_ALREADY_EXISTS');
+            assert.deepStrictEqual(error.status.documentResponses, [
+                { _id: 'docml1', status: 'OK' },
+                { _id: 'docml2', status: 'OK' },
+                { _id: 'docml3', status: 'OK' },
+                { _id: 'docml4', status: 'OK' },
+                { _id: 'docml5', status: 'OK' },
+                { _id: 'docml6', status: 'OK' },
+                { _id: 'docml7', status: 'OK' },
+                { _id: 'docml8', status: 'OK' },
+                { _id: 'docml9', status: 'OK' },
+                { _id: 'docml10', status: 'OK' },
+                { _id: 'docml10', status: 'ERROR', errorsIdx: 0 },
+                { _id: 'docml12', status: 'SKIPPED' },
+                { _id: 'docml13', status: 'SKIPPED' },
+                { _id: 'docml14', status: 'SKIPPED' },
+                { _id: 'docml15', status: 'SKIPPED' },
+                { _id: 'docml16', status: 'SKIPPED' },
+                { _id: 'docml17', status: 'SKIPPED' },
+                { _id: 'docml18', status: 'SKIPPED' },
+                { _id: 'docml19', status: 'SKIPPED' },
+                { _id: 'docml20', status: 'SKIPPED' }
+            ]);
+        });
+        it('should error out when one of the docs in insertMany is invalid with ordered false and returnDocumentResponses', async () => {
+            const docList: { _id?: string, username: string }[] = Array.from({ length: 20 }, () => ({ 'username': 'id' }));
+            docList.forEach((doc, index) => {
+                doc._id = 'docml' + (index + 1);
+                doc.username = doc.username + (index + 1);
+            });
+            docList[10] = docList[9];
+            let error: any;
+            try {
+                await collection.insertMany(docList, { ordered: false });
+            } catch (e: any) {
+                error = e;
+            }
+            assert.ok(error);
             assert.strictEqual(error.errors[0].message, 'Failed to insert document with _id \'docml10\': Document already exists with the given _id');
             assert.strictEqual(error.errors[0].errorCode, 'DOCUMENT_ALREADY_EXISTS');
             assert.strictEqual(error.status.insertedIds.length, 19);

--- a/tests/collections/collection.test.ts
+++ b/tests/collections/collection.test.ts
@@ -281,7 +281,7 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
                 { _id: 'docml20', status: 'SKIPPED' }
             ]);
         });
-        it('should error out when one of the docs in insertMany is invalid with ordered false', async () => {
+        it('should error out when one of the docs in insertMany is invalid with ordered false and returnDocumentResponses', async () => {
             const docList: { _id?: string, username: string }[] = Array.from({ length: 20 }, () => ({ 'username': 'id' }));
             docList.forEach((doc, index) => {
                 doc._id = 'docml' + (index + 1);
@@ -290,7 +290,7 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
             docList[10] = docList[9];
             let error: any;
             try {
-                await collection.insertMany(docList, { ordered: false });
+                await collection.insertMany(docList, { ordered: false, returnDocumentResponses: true });
             } catch (e: any) {
                 error = e;
             }
@@ -307,20 +307,20 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
                 { _id: 'docml7', status: 'OK' },
                 { _id: 'docml8', status: 'OK' },
                 { _id: 'docml9', status: 'OK' },
-                { _id: 'docml10', status: 'OK' },
                 { _id: 'docml10', status: 'ERROR', errorsIdx: 0 },
-                { _id: 'docml12', status: 'SKIPPED' },
-                { _id: 'docml13', status: 'SKIPPED' },
-                { _id: 'docml14', status: 'SKIPPED' },
-                { _id: 'docml15', status: 'SKIPPED' },
-                { _id: 'docml16', status: 'SKIPPED' },
-                { _id: 'docml17', status: 'SKIPPED' },
-                { _id: 'docml18', status: 'SKIPPED' },
-                { _id: 'docml19', status: 'SKIPPED' },
-                { _id: 'docml20', status: 'SKIPPED' }
+                { _id: 'docml10', status: 'OK' },
+                { _id: 'docml12', status: 'OK' },
+                { _id: 'docml13', status: 'OK' },
+                { _id: 'docml14', status: 'OK' },
+                { _id: 'docml15', status: 'OK' },
+                { _id: 'docml16', status: 'OK' },
+                { _id: 'docml17', status: 'OK' },
+                { _id: 'docml18', status: 'OK' },
+                { _id: 'docml19', status: 'OK' },
+                { _id: 'docml20', status: 'OK' }
             ]);
         });
-        it('should error out when one of the docs in insertMany is invalid with ordered false and returnDocumentResponses', async () => {
+        it('should error out when one of the docs in insertMany is invalid with ordered false', async () => {
             const docList: { _id?: string, username: string }[] = Array.from({ length: 20 }, () => ({ 'username': 'id' }));
             docList.forEach((doc, index) => {
                 doc._id = 'docml' + (index + 1);

--- a/tests/driver/api.test.ts
+++ b/tests/driver/api.test.ts
@@ -462,7 +462,6 @@ describe('Mongoose Model API level tests', async () => {
             const insertResp: InsertManyResult<any> = await Product.insertMany([product1, product2, product3] , {ordered: true, rawResult: true});
             assert.ok(insertResp.acknowledged);
             assert.strictEqual(insertResp.insertedCount, 3);
-            await Product.deleteMany({});
 
             let docs = [];
             for (let i = 0; i < 21; ++i) {
@@ -479,7 +478,14 @@ describe('Mongoose Model API level tests', async () => {
             const respUnordered: InsertManyResult<any> = await Product.insertMany(docs, { usePagination: true, ordered: false, rawResult: true });
             assert.ok(respUnordered.acknowledged);
             assert.strictEqual(respUnordered.insertedCount, 21);
-
+        });
+        it('API ops tests Model.insertMany() with returnDocumentResponses', async () => {
+            const product1Id = new mongoose.Types.ObjectId('0'.repeat(24));
+            const product2Id = new mongoose.Types.ObjectId('1'.repeat(24));
+            const product3Id = new mongoose.Types.ObjectId('2'.repeat(24));
+            const product1 = {_id: product1Id, name: 'Product 1', price: 10, isCertified: true, category: 'cat 2'};
+            const product2 = {_id: product2Id, name: 'Product 2', price: 10, isCertified: true, category: 'cat 2'};
+            const product3 = {_id: product3Id, name: 'Product 3', price: 10, isCertified: true, category: 'cat 1'};
             const respWithResponses = await Product.insertMany(
                 [product1, product2, product3],
                 {returnDocumentResponses: true, rawResult: true}
@@ -489,6 +495,16 @@ describe('Mongoose Model API level tests', async () => {
                 { _id: '0'.repeat(24), status: 'OK' },
                 { _id: '1'.repeat(24), status: 'OK' },
                 { _id: '2'.repeat(24), status: 'OK' }
+            ]);
+
+            const err = await Product.insertMany(
+                [product1, product2, product3],
+                {returnDocumentResponses: true}
+            ).then(() => null, err => err);
+            assert.deepStrictEqual(err.status.documentResponses, [
+                { _id: '0'.repeat(24), status: 'ERROR', errorsIdx: 0 },
+                { _id: '1'.repeat(24), status: 'ERROR', errorsIdx: 0 },
+                { _id: '2'.repeat(24), status: 'ERROR', errorsIdx: 0 }
             ]);
         });
         //Model.inspect can not be tested since it is a helper for console logging. More info here: https://mongoosejs.com/docs/api/model.html#Model.inspect()

--- a/tests/driver/api.test.ts
+++ b/tests/driver/api.test.ts
@@ -453,12 +453,16 @@ describe('Mongoose Model API level tests', async () => {
             assert.strictEqual(findOneResp?.name, 'Product 4');
         });
         it('API ops tests Model.insertMany()', async () => {
-            const product1 = {name: 'Product 1', price: 10, isCertified: true, category: 'cat 2'};
-            const product2 = {name: 'Product 2', price: 10, isCertified: true, category: 'cat 2'};
-            const product3 = {name: 'Product 3', price: 10, isCertified: true, category: 'cat 1'};
+            const product1Id = new mongoose.Types.ObjectId('0'.repeat(24));
+            const product2Id = new mongoose.Types.ObjectId('1'.repeat(24));
+            const product3Id = new mongoose.Types.ObjectId('2'.repeat(24));
+            const product1 = {_id: product1Id, name: 'Product 1', price: 10, isCertified: true, category: 'cat 2'};
+            const product2 = {_id: product2Id, name: 'Product 2', price: 10, isCertified: true, category: 'cat 2'};
+            const product3 = {_id: product3Id, name: 'Product 3', price: 10, isCertified: true, category: 'cat 1'};
             const insertResp: InsertManyResult<any> = await Product.insertMany([product1, product2, product3] , {ordered: true, rawResult: true});
             assert.ok(insertResp.acknowledged);
             assert.strictEqual(insertResp.insertedCount, 3);
+            await Product.deleteMany({});
 
             let docs = [];
             for (let i = 0; i < 21; ++i) {
@@ -475,6 +479,17 @@ describe('Mongoose Model API level tests', async () => {
             const respUnordered: InsertManyResult<any> = await Product.insertMany(docs, { usePagination: true, ordered: false, rawResult: true });
             assert.ok(respUnordered.acknowledged);
             assert.strictEqual(respUnordered.insertedCount, 21);
+
+            const respWithResponses = await Product.insertMany(
+                [product1, product2, product3],
+                {returnDocumentResponses: true, rawResult: true}
+            );
+            assert.ok(respWithResponses.acknowledged);
+            assert.deepStrictEqual(respWithResponses.documentResponses, [
+                { _id: '0'.repeat(24), status: 'OK' },
+                { _id: '1'.repeat(24), status: 'OK' },
+                { _id: '2'.repeat(24), status: 'OK' }
+            ]);
         });
         //Model.inspect can not be tested since it is a helper for console logging. More info here: https://mongoosejs.com/docs/api/model.html#Model.inspect()
         it('API ops tests Model.listIndexes()', async () => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Adds support for `insertMany`'s new `returnDocumentResponses` option

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)