### PR TITLE
reuse collections where possible in tests

### DIFF
--- a/tests/collections/options.test.ts
+++ b/tests/collections/options.test.ts
@@ -17,6 +17,10 @@ import mongoose from 'mongoose';
 import { Product } from '@/tests/mongooseFixtures';
 
 describe('Options tests', async () => {
+    beforeEach(async function() {
+        await Product.deleteMany({});
+    });
+
     afterEach(async function() {
         await Product.deleteMany({});
     });

--- a/tests/mongooseFixtures.ts
+++ b/tests/mongooseFixtures.ts
@@ -65,11 +65,6 @@ before(async function connectMongooseFixtures() {
 
 before(createMongooseCollections);
 
-after(async function cleanupMongooseCollections() {
-    await Cart.db.dropCollection(Cart.collection.collectionName);
-    await Product.db.dropCollection(Product.collection.collectionName);
-});
-
 after(async function disconnectMongooseFixtures() {
     await mongooseInstance.disconnect();
 });


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Tests currently run very slowly, including when you're just rerunning a single test repeatedly, because the tests currently drop all collections and recreate them on each test run. With this PR, the tests will only create 4 collections in the main namespace and not drop the collections after every run. Similarly, when starting up, tests will double check for existing compatible collections before recreating. This takes nearly 1 minute off of test startup time on my local machine.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)