### PR TITLE
handle docker-compose v2 in start_data_api.sh

### DIFF
--- a/bin/start_data_api.sh
+++ b/bin/start_data_api.sh
@@ -64,7 +64,7 @@ export JSONTAG
 
 echo "Running with Stargate $SGTAG, JSON API $JSONTAG"
 
-if command -v docker-compose &> /dev/null
+if which docker-compose
 then
   docker-compose -f $SCRIPTS_HOME/docker-compose.yml up -d
 else

--- a/bin/start_data_api.sh
+++ b/bin/start_data_api.sh
@@ -64,4 +64,9 @@ export JSONTAG
 
 echo "Running with Stargate $SGTAG, JSON API $JSONTAG"
 
-docker-compose -f $SCRIPTS_HOME/docker-compose.yml up -d
+if command -v docker-compose &> /dev/null
+then
+  docker-compose -f $SCRIPTS_HOME/docker-compose.yml up -d
+else
+  docker compose -f $SCRIPTS_HOME/docker-compose.yml up -d
+fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

I had some issues in stargate-mongoose-sample-apps in https://github.com/stargate/stargate-mongoose-sample-apps/pull/382 because GitHub Actions has moved fully to docker-compose v2, so my tests started failing with following error:

```
Run chmod +x bin/start_data_api.sh
Loading versions from bin/../api-compatibility.versions
bin/start_data_api.sh: [6](https://github.com/stargate/stargate-mongoose-sample-apps/actions/runs/10219524448/job/28277951536#step:4:7)7: docker-compose: not found
Running with Stargate v2.1.0-BETA-13, JSON API v1.0.14
Error: Process completed with exit code 12[7](https://github.com/stargate/stargate-mongoose-sample-apps/actions/runs/10219524448/job/28277951536#step:4:8).
```

Example: https://github.com/stargate/stargate-mongoose-sample-apps/actions/runs/10219524448/job/28277951536

This commit: https://github.com/stargate/stargate-mongoose-sample-apps/pull/382/commits/8997ec5f9ac62026c5aafacdde8e9be40ed2817f fixed most of it by just changing `docker-compose` to `docker compose`, no dash.

With this PR, start_data_api.sh will use `docker-compose` if available, and fall back to `docker compose` if not.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)