### PR TITLE
use find() with cursor for driver-layer countDocuments()

### DIFF
--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -66,8 +66,13 @@ export class Collection extends MongooseCollection {
      * Count documents in the collection that match the given filter.
      * @param filter
      */
-    countDocuments(filter: Record<string, any>) {
-        return this.collection.countDocuments(filter);
+    async countDocuments(filter: Record<string, any>) {
+        const cursor = this.collection.find(filter, { projection: { '*': 0 } });
+        let count = 0;
+        while (await cursor.next() != null) {
+            ++count;
+        }
+        return count;
     }
 
     /**

--- a/tests/driver/index.test.ts
+++ b/tests/driver/index.test.ts
@@ -110,6 +110,33 @@ describe('Driver based tests', async () => {
             assert.deepEqual(names.sort(), ['Bill', 'John']);
         });
 
+        it('handles countDocuments', async () => {
+            const Person = mongooseInstance!.model('Person');
+            await Person.deleteMany({});
+            for (let i = 0; i < 150; ++i) {
+                await Person.insertMany([
+                    { name: 'Bill' },
+                    { name: 'John' },
+                    { name: 'Michael' },
+                    { name: 'Jennifer' },
+                    { name: 'Christopher' },
+                    { name: 'Jessica' },
+                    { name: 'Matthew' },
+                    { name: 'Amanda' },
+                    { name: 'David' },
+                    { name: 'Ashley' }
+                ]);
+            }
+
+            const start = Date.now();
+            let count = await Person.countDocuments();
+            assert.strictEqual(count, 1500);
+            count = await Person.countDocuments({ name: 'John' });
+            assert.strictEqual(count, 150);
+            count = await Person.countDocuments({ name: { $in: ['John', 'David'] } });
+            assert.strictEqual(count, 300);
+        });
+
         it('handles document deleteOne() and updateOne()', async () => {
             const Person = mongooseInstance!.model('Person');
             await Person.deleteMany({});


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Given that `countDocuments()` has a limit on the number of documents it can count, I think it may be reasonable to implement `countDocuments()` using `find()` with a cursor in stargate-mongoose. I've confirmed this counts up to at least 15k documents. Performance is slower, on my laptop 12ms vs 60ms for 1000 documents, but I think the ability to count past 1k documents and not having to specify any sort of limit is more idiomatic for Mongoose.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)