### PR TITLE
add support for createTable(), listTables(), dropTable(), createIndex(), dropIndex()

### DIFF
--- a/api-compatibility.versions
+++ b/api-compatibility.versions
@@ -1,2 +1,2 @@
-stargate_version=v2.1.0-BETA-13
-data_api_version=v1.0.14
+stargate_version=v2.1.0-BETA-14
+data_api_version=v1.0.15

--- a/api-compatibility.versions
+++ b/api-compatibility.versions
@@ -1,2 +1,2 @@
-stargate_version=v2.1.0-BETA-14
-data_api_version=v1.0.16
+stargate_version=v2.1.0-BETA-18
+data_api_version=v1.0.17

--- a/src/collections/collection.ts
+++ b/src/collections/collection.ts
@@ -431,9 +431,14 @@ export class Collection {
                     indexName
                 }
             };
+            return await this.httpClient.executeCommandWithUrl(
+                this.httpBasePath,
+                command,
+                null
+            );
         });
     }
-    
+
     async runCommand(command: Record<string, any>) {
         return executeOperation(async () => {
             return await this.httpClient.executeCommandWithUrl(

--- a/src/collections/collection.ts
+++ b/src/collections/collection.ts
@@ -386,6 +386,58 @@ export class Collection {
             };
         });
     }
+
+    /**
+     *
+     * @param column
+     * @param indexName
+     * @returns Promise
+     */
+    async createIndex(column: string, indexName: string) {
+        if (column == null) {
+            throw new TypeError(`Must specify a column when calling createIndex, got ${column}`);
+        }
+        if (indexName == null) {
+            throw new TypeError(`Must specify an indexName when calling createIndex, got ${indexName}`);
+        }
+        return executeOperation(async () => {
+            const command = {
+                addIndex: {
+                    column,
+                    indexName
+                }
+            };
+            return await this.httpClient.executeCommandWithUrl(
+                this.httpBasePath,
+                command,
+                null
+            );
+        });
+    }
+
+    /**
+     *
+     * @param column
+     * @param indexName
+     * @returns Promise
+     */
+    async dropIndex(indexName: string) {
+        if (indexName == null) {
+            throw new TypeError(`Must specify an indexName when calling dropIndex, got ${indexName}`);
+        }
+        return executeOperation(async () => {
+            const command = {
+                dropIndex: {
+                    indexName
+                }
+            };
+            return await this.httpClient.executeCommandWithUrl(
+                this.httpBasePath,
+                command,
+                null
+            );
+        });
+    }
 }
 
 export class StargateMongooseError extends Error {

--- a/src/collections/db.ts
+++ b/src/collections/db.ts
@@ -110,6 +110,19 @@ export class Db {
         });
     }
 
+    async listTables() {
+        return executeOperation(async () => {
+            const command = {
+                listTables: {}
+            };
+            return await this.httpClient.executeCommandWithUrl(
+                this.httpBasePath,
+                command,
+                null
+            );
+        });
+    }
+
     /**
      *
      * @param name

--- a/src/collections/db.ts
+++ b/src/collections/db.ts
@@ -16,6 +16,7 @@ import { HTTPClient } from '@/src/client';
 import {
     CreateCollectionOptions,
     createCollectionOptionsKeys,
+    CreateTableDefinition,
     ListCollectionOptions,
     listCollectionOptionsKeys
 } from './options';
@@ -80,6 +81,54 @@ export class Db {
                 this.httpBasePath,
                 command,
                 createCollectionOptionsKeys
+            );
+        });
+    }
+
+    /**
+     *
+     * @param name
+     * @param options
+     * @returns Promise
+     */
+    async createTable(name: string, definition: CreateTableDefinition) {
+        if (name == null) {
+            throw new TypeError(`Must specify a name when calling createTable, got ${name}`);
+        }
+        return executeOperation(async () => {
+            const command = {
+                createTable: {
+                    name,
+                    definition
+                }
+            };
+            return await this.httpClient.executeCommandWithUrl(
+                this.httpBasePath,
+                command,
+                null
+            );
+        });
+    }
+
+    /**
+     *
+     * @param name
+     * @returns Promise
+     */
+    async dropTable(name: string) {
+        if (name == null) {
+            throw new TypeError(`Must specify a name when calling dropTable, got ${name}`);
+        }
+        return executeOperation(async () => {
+            const command = {
+                dropTable: {
+                    name
+                }
+            };
+            return await this.httpClient.executeCommandWithUrl(
+                this.httpBasePath,
+                command,
+                null
             );
         });
     }

--- a/src/collections/options.ts
+++ b/src/collections/options.ts
@@ -155,6 +155,13 @@ export const createCollectionOptionsKeys: Set<string> = new Set(
     Object.keys(new _CreateCollectionOptions)
 );
 
+type TableDataTypes = 'text' | 'int' | 'boolean' | 'bigint' | 'decimal' | 'double' | 'float' | 'smallint' | 'tinyint' | 'varint' | 'ascii';
+
+export interface CreateTableDefinition {
+    columns: Record<string, { type: TableDataTypes }>,
+    primaryKey: string
+}
+
 class _ListCollectionOptions {
     explain?: boolean = undefined;
 }

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -274,6 +274,25 @@ export class Collection extends MongooseCollection {
     }
 
     /**
+     *
+     * @param fieldOrSpec
+     * @param options
+     */
+    createIndex(fieldOrSpec: Record<string, any> | string, options: { name: string, [other: string]: any }) {
+        if (fieldOrSpec != null && typeof fieldOrSpec === 'object' && Object.keys(fieldOrSpec).length > 1) {
+            throw new TypeError('Can only index one key');
+        }
+        const field: string = typeof fieldOrSpec === 'string' ? fieldOrSpec : Object.keys(fieldOrSpec)[0];
+        if (typeof fieldOrSpec !== 'string') {
+            throw new TypeError('Invalid index specification');
+        }
+        if (typeof options?.name !== 'string') {
+            throw new TypeError('Must provide `name` option to `createIndex()`');
+        }
+        return this.collection.createIndex(field, options.name);
+    }
+
+    /**
      * Get the estimated number of documents in a collection based on collection metadata
      */
     estimatedDocumentCount() {
@@ -321,15 +340,6 @@ export class Collection extends MongooseCollection {
      */
     listIndexes(options?: any) {
         throw new OperationNotSupportedError('listIndexes() Not Implemented');
-    }
-
-    /**
-     * Create index not supported.
-     * @param fieldOrSpec
-     * @param options
-     */
-    createIndex(fieldOrSpec: any, options?: any) {
-        throw new OperationNotSupportedError('createIndex() Not Implemented');
     }
 
     /**

--- a/src/driver/connection.ts
+++ b/src/driver/connection.ts
@@ -17,7 +17,7 @@ import { Collection } from './collection';
 import { default as MongooseConnection } from 'mongoose/lib/connection';
 import { STATES } from 'mongoose';
 import { executeOperation } from '../collections/utils';
-import { CreateCollectionOptions } from '../collections/options';
+import { CreateCollectionOptions, CreateTableDefinition } from '../collections/options';
 
 export class Connection extends MongooseConnection {
     debugType = 'StargateMongooseConnection';
@@ -58,11 +58,43 @@ export class Connection extends MongooseConnection {
         });
     }
 
+    async createTable(name: string, definition: CreateTableDefinition) {
+        return executeOperation(async () => {
+            await this._waitForClient();
+            const db = this.client.db();
+            return db.createTable(name, definition);
+        });
+    }
+
+    async createIndex(column: string, indexName: string) {
+        return executeOperation(async () => {
+            await this._waitForClient();
+            const db = this.client.db();
+            return db.createIndex(column, indexName);
+        });
+    }
+
     async dropCollection(name: string) {
         return executeOperation(async () => {
             await this._waitForClient();
             const db = this.client.db();
             return db.dropCollection(name);
+        });
+    }
+
+    async dropTable(name: string) {
+        return executeOperation(async () => {
+            await this._waitForClient();
+            const db = this.client.db();
+            return db.dropTable(name);
+        });
+    }
+
+    async dropIndex(name: string) {
+        return executeOperation(async () => {
+            await this._waitForClient();
+            const db = this.client.db();
+            return db.dropTable(name);
         });
     }
 

--- a/src/driver/connection.ts
+++ b/src/driver/connection.ts
@@ -66,6 +66,15 @@ export class Connection extends MongooseConnection {
         });
     }
 
+    async listTables(): Promise<string[]> {
+        return executeOperation(async () => {
+            await this._waitForClient();
+            const db = this.client.db();
+            const res: { status: { tables: string[] } } = await db.listTables();
+            return res.status.tables;
+        });
+    }
+
     async createIndex(column: string, indexName: string) {
         return executeOperation(async () => {
             await this._waitForClient();

--- a/tests/collections/collection.test.ts
+++ b/tests/collections/collection.test.ts
@@ -2829,6 +2829,9 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
         });
 
         after(async () => {
+            if (isAstra || !process.env.TABLES_ENABLED) {
+                return;
+            }
             await db.dropTable(tableName);
         });
 

--- a/tests/collections/collection.test.ts
+++ b/tests/collections/collection.test.ts
@@ -235,7 +235,7 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
                 error = e;
             }
             assert.ok(error);
-            assert.strictEqual(error.errors[0].message, 'Failed to insert document with _id \'docml10\': Document already exists with the given _id');
+            assert.strictEqual(error.errors[0].message, 'Failed to insert document with _id docml10: Document already exists with the given _id');
             assert.strictEqual(error.errors[0].errorCode, 'DOCUMENT_ALREADY_EXISTS');
             assert.strictEqual(error.status.insertedIds.length, 10);
             docList.slice(0, 10).forEach((doc, index) => {
@@ -315,7 +315,7 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
                 error = e;
             }
             assert.ok(error);
-            assert.strictEqual(error.errors[0].message, 'Failed to insert document with _id \'docml10\': Document already exists with the given _id');
+            assert.strictEqual(error.errors[0].message, 'Failed to insert document with _id docml10: Document already exists with the given _id');
             assert.strictEqual(error.errors[0].errorCode, 'DOCUMENT_ALREADY_EXISTS');
             assert.strictEqual(error.status.insertedIds.length, 19);
             //check if response insertedIds contains all the docs except the one that failed

--- a/tests/collections/db.test.ts
+++ b/tests/collections/db.test.ts
@@ -255,7 +255,7 @@ describe('StargateMongoose - collections.Db', async () => {
                 assert.strictEqual(err.errors.length, 1);
                 assert.strictEqual(
                     err.errors[0].message,
-                    'INVALID_ARGUMENT: Unknown namespace \'' + keyspaceName + '\', you must create it first.'
+                    'The provided namespace does not exist: Unknown namespace \'' + keyspaceName + '\', you must create it first'
                 );
             }
         });
@@ -296,7 +296,7 @@ describe('StargateMongoose - collections.Db', async () => {
                     assert.strictEqual(err.errors.length, 1);
                     assert.strictEqual(
                         err.errors[0].message,
-                        'INVALID_ARGUMENT: Unknown namespace \'' + keyspaceName + '\', you must create it first.'
+                        'The provided namespace does not exist: Unknown namespace \'' + keyspaceName + '\', you must create it first'
                     );
                 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Add support for new table operations `createTable()`, `dropTable()`, `createIndex()`, `dropIndex()`. `createIndex()` still uses `addIndex` command under the hood, will have to change when https://github.com/stargate/data-api/pull/1358/files is merged.

Tests are behind a `TABLES_ENABLED` flag, so tests shouldn't error in CI because these commands aren't in a data-api release yet.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)