### PR TITLE
add runCommand() to allow running arbitrary commands against db

### DIFF
--- a/src/collections/collection.ts
+++ b/src/collections/collection.ts
@@ -386,6 +386,16 @@ export class Collection {
             };
         });
     }
+
+    async runCommand(command: Record<string, any>) {
+        return executeOperation(async () => {
+            return await this.httpClient.executeCommandWithUrl(
+                this.httpBasePath,
+                command,
+                null
+            );
+        });
+    }
 }
 
 export class StargateMongooseError extends Error {

--- a/src/collections/db.ts
+++ b/src/collections/db.ts
@@ -136,6 +136,16 @@ export class Db {
             );
         });
     }
+
+    async runCommand(command: Record<string, any>) {
+        return executeOperation(async () => {
+            return await this.httpClient.executeCommandWithUrl(
+                '/' + this.name,
+                command,
+                null
+            );
+        });
+    }
 }
 
 export class StargateAstraError extends Error {

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -281,6 +281,14 @@ export class Collection extends MongooseCollection {
     }
 
     /**
+     * Run an arbitrary command against this collection's http client
+     * @param command
+     */
+    runCommand(command: Record<string, any>) {
+        return this.collection.runCommand(command);
+    }
+
+    /**
      * Bulk write not supported.
      * @param ops
      * @param options

--- a/src/driver/connection.ts
+++ b/src/driver/connection.ts
@@ -99,6 +99,14 @@ export class Connection extends MongooseConnection {
         });
     }
 
+    async runCommand(command: Record<string, any>): Promise<unknown> {
+        return executeOperation(async () => {
+            await this._waitForClient();
+            const db = this.client.db();
+            return db.runCommand(command);
+        });
+    }
+
     async openUri(uri: string, options: any) {
         let _fireAndForget = false;
         if (options && '_fireAndForget' in options) {

--- a/tests/driver/api.test.ts
+++ b/tests/driver/api.test.ts
@@ -706,6 +706,10 @@ describe('Mongoose Model API level tests', async () => {
             // @ts-ignore
             assert.ok(databases.includes(mongooseInstance.connection.db.name));
         });
+        it('API ops tests connection.runCommand()', async () => {
+            const res = await mongooseInstance!.connection.runCommand({ findCollections: {} })
+            assert.ok(res.status.collections.includes('carts'));
+        });
     });
 
     describe('vector search', function() {

--- a/tests/driver/api.test.ts
+++ b/tests/driver/api.test.ts
@@ -707,8 +707,12 @@ describe('Mongoose Model API level tests', async () => {
             assert.ok(databases.includes(mongooseInstance.connection.db.name));
         });
         it('API ops tests connection.runCommand()', async () => {
-            const res = await mongooseInstance!.connection.runCommand({ findCollections: {} })
+            const res = await mongooseInstance!.connection.runCommand({ findCollections: {} });
             assert.ok(res.status.collections.includes('carts'));
+        });
+        it('API ops tests collection.runCommand()', async () => {
+            const res = await mongooseInstance!.connection.db.collection('carts').runCommand({ find: {} });
+            assert.ok(Array.isArray(res.data.documents));
         });
     });
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Per discussion with Aaron, we should use `runCommand()` for now to create tables instead of table-specific functions in #244 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)