### PR TITLE
enable tables when running start_data_api.sh

### DIFF
--- a/bin/docker-compose.yml
+++ b/bin/docker-compose.yml
@@ -41,6 +41,7 @@ services:
       - QUARKUS_HTTP_ACCESS_LOG_ENABLED=${REQUESTLOG}
       - QUARKUS_LOG_LEVEL=${LOGLEVEL}
       - STARGATE_JSONAPI_OPERATIONS_DATABASE_CONFIG_CASSANDRA_END_POINTS=coordinator
+      - STARGATE_TABLES_ENABLED=true
     healthcheck:
       test: curl -f http://localhost:8181/stargate/health || exit 1
       interval: 5s


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Turn on tables when running using `bin/start_data_api.sh`, which will be helpful for tests

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)