### PR TITLE
avoid stripping out options if no options passed

### DIFF
--- a/src/client/httpClient.ts
+++ b/src/client/httpClient.ts
@@ -435,7 +435,7 @@ export const handleIfErrorResponse = (response: any, data: Record<string, unknow
 function cleanupOptions(commandName: string, command: Record<string, any>, optionsToRetain: Set<string> | null, logSkippedOptions: boolean) {
     if (command.options != null) {
         Object.keys(command.options).forEach((key) => {
-            if (optionsToRetain !== null && !optionsToRetain.has(key)) {
+            if (optionsToRetain != null && !optionsToRetain.has(key)) {
                 if (logSkippedOptions) {
                     logger.warn(`'${commandName}' does not support option '${key}'`);
                 }

--- a/src/client/httpClient.ts
+++ b/src/client/httpClient.ts
@@ -435,7 +435,7 @@ export const handleIfErrorResponse = (response: any, data: Record<string, unknow
 function cleanupOptions(commandName: string, command: Record<string, any>, optionsToRetain: Set<string> | null, logSkippedOptions: boolean) {
     if (command.options != null) {
         Object.keys(command.options).forEach((key) => {
-            if (optionsToRetain === null || !optionsToRetain.has(key)) {
+            if (optionsToRetain !== null && !optionsToRetain.has(key)) {
                 if (logSkippedOptions) {
                     logger.warn(`'${commandName}' does not support option '${key}'`);
                 }

--- a/src/collections/client.ts
+++ b/src/collections/client.ts
@@ -17,6 +17,7 @@ import { createNamespace, executeOperation, parseUri } from './utils';
 import { HTTPClient } from '@/src/client';
 import { logger } from '@/src/logger';
 import {OperationNotSupportedError} from '@/src/driver';
+import { retainNoOptions } from './options';
 
 export interface ClientOptions {
   applicationToken?: string;
@@ -143,7 +144,7 @@ export class Client {
             return await this.httpClient.executeCommandWithUrl(
                 '/',
                 command,
-                null
+                retainNoOptions
             );
         });
     }

--- a/src/collections/collection.ts
+++ b/src/collections/collection.ts
@@ -32,7 +32,8 @@ import {
     updateOneInternalOptionsKeys,
     UpdateOneOptions,
     FindOptions,
-    findOneInternalOptionsKeys
+    findOneInternalOptionsKeys,
+    retainNoOptions
 } from './options';
 
 export interface DataAPIUpdateResult {
@@ -89,7 +90,7 @@ export class Collection {
             const resp = await this.httpClient.executeCommandWithUrl(
                 this.httpBasePath,
                 command,
-                null
+                retainNoOptions
             );
             return {
                 acknowledged: true,
@@ -223,7 +224,7 @@ export class Collection {
             const deleteOneResp = await this.httpClient.executeCommandWithUrl(
                 this.httpBasePath,
                 command,
-                null
+                retainNoOptions
             );
             return {
                 acknowledged: true,
@@ -242,7 +243,7 @@ export class Collection {
             const deleteManyResp = await this.httpClient.executeCommandWithUrl(
                 this.httpBasePath,
                 command,
-                null
+                retainNoOptions
             );
             if (deleteManyResp.status.moreData) {
                 throw new StargateMongooseError(`More records found to be deleted even after deleting ${deleteManyResp.status.deletedCount} records`, command);
@@ -319,7 +320,7 @@ export class Collection {
             const resp = await this.httpClient.executeCommandWithUrl(
                 this.httpBasePath,
                 command,
-                null
+                retainNoOptions
             );
             return resp.status.count;
         });
@@ -331,7 +332,7 @@ export class Collection {
             const resp = await this.httpClient.executeCommandWithUrl(
                 this.httpBasePath,
                 command,
-                null
+                retainNoOptions
             );
             return resp.status.count;
         });
@@ -349,7 +350,7 @@ export class Collection {
         const resp = await this.httpClient.executeCommandWithUrl(
             this.httpBasePath,
             command,
-            null
+            retainNoOptions
         );
         return {
             value : resp.data?.document,

--- a/src/collections/db.ts
+++ b/src/collections/db.ts
@@ -17,7 +17,8 @@ import {
     CreateCollectionOptions,
     createCollectionOptionsKeys,
     ListCollectionOptions,
-    listCollectionOptionsKeys
+    listCollectionOptionsKeys,
+    retainNoOptions
 } from './options';
 import { Collection } from './collection';
 import { executeOperation, createNamespace, dropNamespace } from './utils';
@@ -101,7 +102,7 @@ export class Db {
         return await this.httpClient.executeCommandWithUrl(
             this.httpBasePath,
             command,
-            null
+            retainNoOptions
         );
     }
 
@@ -142,7 +143,7 @@ export class Db {
             return await this.httpClient.executeCommandWithUrl(
                 '/' + this.name,
                 command,
-                null
+                retainNoOptions
             );
         });
     }

--- a/src/collections/options.ts
+++ b/src/collections/options.ts
@@ -172,3 +172,5 @@ export interface ListCollectionOptions extends _ListCollectionOptions {}
 export const listCollectionOptionsKeys: Set<string> = new Set(
     Object.keys(new _ListCollectionOptions)
 );
+
+export const retainNoOptions: Set<string> = new Set();


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

`cleanupOptions()` is meant to strip out unsupported options, but right now with `runCommand()` it will always strip out all options by default. This really tripped me up when testing `listIndexes()` because `runCommand({ listIndexes: { options: { explain: true } } })` would end up as `listIndexes: { options: {} }`. Now that we support `runCommand()`, I think only stripping out options for known operations is better.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)