### PR TITLE
add replaceOne as alias of findOneAndReplace similar to astra-db-ts

### DIFF
--- a/src/collections/options.ts
+++ b/src/collections/options.ts
@@ -151,6 +151,19 @@ export const updateOneInternalOptionsKeys: Set<string> = new Set(
     Object.keys(new _UpdateOneOptions)
 );
 
+class _ReplaceOneOptions {
+    upsert?: boolean = undefined;
+    sort?: SortOption;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface ReplaceOneOptions extends _ReplaceOneOptions {}
+export type ReplaceOneOptionsForDataAPI = Omit<UpdateOneOptions, 'sort'> & { sort?: SortOptionInternal };
+
+export const ReplaceOneInternalOptionsKeys: Set<string> = new Set(
+    Object.keys(new _ReplaceOneOptions)
+);
+
 export type IndexingOptions = { deny: string[], allow?: never } | { allow: string[], deny?: never };
 
 export interface DefaultIdOptions { type: 'objectId' | 'uuid' | 'uuid6' | 'uuid7' }

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -28,6 +28,8 @@ import {
     FindOptions,
     FindOptionsForDataAPI,
     InsertManyOptions,
+    ReplaceOneOptions,
+    ReplaceOneOptionsForDataAPI,
     SortOption,
     SortOptionInternal,
     UpdateManyOptions,
@@ -280,6 +282,24 @@ export class Collection extends MongooseCollection {
     }
 
     /**
+     * Update a single document in a collection that matches the given filter, replacing it with `replacement`.
+     * Converted to a `findOneAndReplace()` under the hood.
+     * @param filter
+     * @param replacement
+     * @param options
+     */
+    replaceOne(filter: Record<string, unknown>, replacement: Record<string, unknown>, options?: ReplaceOneOptions) {
+        let requestOptions: ReplaceOneOptionsForDataAPI | undefined = undefined;
+        if (options != null && options.sort != null) {
+            requestOptions = { ...options, sort: processSortOption(options.sort) };
+        } else if (options != null && options.sort == null) {
+            requestOptions = { ...options, sort: undefined };
+            delete requestOptions.sort;
+        }
+        return this.collection.replaceOne(filter, replacement, requestOptions);
+    }
+
+    /**
      * Update a single document in a collection that matches the given filter.
      * @param filter
      * @param update
@@ -396,13 +416,6 @@ export class Collection extends MongooseCollection {
      */
     distinct() {
         throw new OperationNotSupportedError('distinct() Not Implemented');
-    }
-
-    /**
-     * Replace one operation not supported.
-     */
-    replaceOne() {
-        throw new OperationNotSupportedError('replaceOne() Not Implemented');
     }
 }
 

--- a/tests/driver/api.test.ts
+++ b/tests/driver/api.test.ts
@@ -506,9 +506,12 @@ describe('Mongoose Model API level tests', async () => {
             const product2 = new Product({name: 'Product 2', price: 10, isCertified: true, category: 'cat 2'});
             const product3 = new Product({name: 'Product 3', price: 10, isCertified: true, category: 'cat 1'});
             await Product.insertMany([product1, product2, product3]);
-            const error: Error | null = await Product.replaceOne({category: 'cat 1'}, {name: 'Product 4'}).then(() => null, error => error);
-            assert.ok(error instanceof OperationNotSupportedError);
-            assert.strictEqual(error.message, 'replaceOne() Not Implemented');
+            const resp = await Product.replaceOne({category: 'cat 1'}, {name: 'Product 4'});
+            assert.equal(resp.modifiedCount, 1);
+
+            const doc = await Product.findOne({name: 'Product 4'});
+            assert.ok(doc);
+            assert.strictEqual(doc.category, undefined);
         });
         //Model.schema() is skipped since it doesn't make any database calls. More info here: https://mongoosejs.com/docs/api/model.html#Model.schema
         it('API ops tests Model.startSession()', async () => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

astra-db-ts has support for `replaceOne()` using `findOneAndReplace` under the hood, I think it is worth replicating this behavior for stargate-mongoose

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)