### PR TITLE
upgrade to data-api@1.0.21 + more robust way to stop mono service in ci

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -14,11 +14,7 @@ jobs:
       STARGATE_AUTH_URL: http://localhost:8081/v1/auth
       STARGATE_USERNAME: cassandra
       STARGATE_PASSWORD: cassandra
-    steps:      
-      - name: disable and stop mono-xsp4.service
-        run: |
-          sudo systemctl stop mono-xsp4.service || true
-          sudo systemctl disable mono-xsp4.service || true
+    steps:
       - uses: actions/checkout@v3
       - name: Set up Data API
         run: |
@@ -33,25 +29,21 @@ jobs:
         with:
           node-version: 16.15.0
       - name: setup project
-        run: npm i      
+        run: npm i
       - name: run tests
         run: |
           npm run test
   e2e:
     runs-on: ubuntu-latest
     needs: tests
-    steps:      
-      - name: disable and stop mono-xsp4.service
-        run: |
-          sudo systemctl stop mono-xsp4.service || true
-          sudo systemctl disable mono-xsp4.service || true
+    steps:
       - uses: actions/checkout@v3
       - name: Setting up the node version
         uses: actions/setup-node@v3
         with:
           node-version: 16.15.0
       - name: setup project
-        run: npm i   
+        run: npm i
       - name: build
         run: npm run build
       - name: pack

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -43,7 +43,8 @@ jobs:
     steps:      
       - name: disable and stop mono-xsp4.service
         run: |
-          sudo kill -9 $(sudo lsof -t -i:8084)
+          sudo systemctl stop mono-xsp4.service || true
+          sudo systemctl disable mono-xsp4.service || true
       - uses: actions/checkout@v3
       - name: Setting up the node version
         uses: actions/setup-node@v3

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -17,7 +17,8 @@ jobs:
     steps:      
       - name: disable and stop mono-xsp4.service
         run: |
-          sudo kill -9 $(sudo lsof -t -i:8084)
+          sudo systemctl stop mono-xsp4.service || true
+          sudo systemctl disable mono-xsp4.service || true
       - uses: actions/checkout@v3
       - name: Set up Data API
         run: |

--- a/api-compatibility.versions
+++ b/api-compatibility.versions
@@ -1,2 +1,2 @@
 stargate_version=v2.1.0-BETA-19
-data_api_version=v1.0.20
+data_api_version=v1.0.21

--- a/api-compatibility.versions
+++ b/api-compatibility.versions
@@ -1,2 +1,2 @@
 stargate_version=v2.1.0-BETA-19
-data_api_version=v1.0.21
+data_api_version=v1.0.22

--- a/tests/collections/collection.test.ts
+++ b/tests/collections/collection.test.ts
@@ -93,7 +93,7 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
             } else {
                 assert.strictEqual(
                     error.errors[0].message,
-                    'Document size limitation violated: indexed String value (property \'username\') length (1048576 bytes) exceeds maximum allowed (8000 bytes)'
+                    'Document size limitation violated: indexed String value (field \'username\') length (1048576 bytes) exceeds maximum allowed (8000 bytes)'
                 );
             }
         });
@@ -102,7 +102,7 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
             const docToInsert = { [fieldName]: 'value' };
             const error: Error | null = await collection.insertOne(docToInsert).then(() => null, error => error);
             assert.ok(error instanceof StargateServerError);
-            assert.strictEqual(error.errors[0].message, 'Document size limitation violated: property path length (1001) exceeds maximum allowed (1000) (path ends with \''+ fieldName +'\')');
+            assert.strictEqual(error.errors[0].message, 'Document size limitation violated: field path length (1001) exceeds maximum allowed (1000) (path ends with \''+ fieldName +'\')');
         });
         it('Should fail if the string field value is > 16000', async () => {
             const _string16klength = new Array(16001).fill('a').join('');
@@ -111,7 +111,7 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
             assert.ok(error instanceof StargateServerError);
             assert.strictEqual(
                 error.errors[0].message,
-                'Document size limitation violated: indexed String value (property \'username\') length (16001 bytes) exceeds maximum allowed (8000 bytes)'
+                'Document size limitation violated: indexed String value (field \'username\') length (16001 bytes) exceeds maximum allowed (8000 bytes)'
             );
         });
         it('Should fail if an array field size is > 10000', async () => {
@@ -120,7 +120,7 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
             assert.ok(error instanceof StargateServerError);
             assert.strictEqual(
                 error.errors[0].message,
-                'Document size limitation violated: number of elements an indexable Array (property \'tags\') has (10001) exceeds maximum allowed (1000)'
+                'Document size limitation violated: number of elements an indexable Array (field \'tags\') has (10001) exceeds maximum allowed (1000)'
             );
         });
         it('Should fail if a doc contains more than 1000 properties', async () => {
@@ -132,7 +132,7 @@ describe(`StargateMongoose - ${testClientName} Connection - collections.collecti
             assert.ok(error instanceof StargateServerError);
             assert.strictEqual(
                 error.errors[0].message,
-                'Document size limitation violated: number of properties an indexable Object (property \'null\') has (1002) exceeds maximum allowed (1000)'
+                'Document size limitation violated: number of properties an indexable Object (field \'null\') has (1002) exceeds maximum allowed (1000)'
             );
         });
     });

--- a/tests/collections/db.test.ts
+++ b/tests/collections/db.test.ts
@@ -246,9 +246,10 @@ describe('StargateMongoose - collections.Db', async () => {
     });
 
     describe('createDatabase', () => {
-        after(async () => {
+        after(async function () {
+            this.timeout(120_000);
             if (isAstra) {
-                return;
+                return this.skip();
             }
             const keyspaceName = parseUri(dbUri).keyspaceName;
             await createNamespace(httpClient, keyspaceName);

--- a/tests/driver/api.test.ts
+++ b/tests/driver/api.test.ts
@@ -202,7 +202,7 @@ describe('Mongoose Model API level tests', async () => {
             const error: Error | null = await Product.$where('this.name === "Product 1"').exec().then(() => null, error => error);
             assert.ok(error);
             assert.ok(error instanceof StargateServerError);
-            assert.strictEqual(error.errors[0].message, 'Invalid filter expression: filter clause path (\'$where\') contains character(s) not allowed');
+            assert.strictEqual(error.errors[0].message, 'Invalid filter expression: filter clause path (\'$where\') cannot start with `$`');
         });
         it('API ops tests Model.aggregate()', async () => {
             //Model.aggregate()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Tests currently failing on main branch because of https://github.com/actions/runner-images/issues/2821. I already made a similar fix in #240: https://github.com/stargate/stargate-mongoose/commit/39f1f92bec0316d910dc2522a05327a37bb507f2

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)