### PR TITLE
set isAstra to true by default and make README more Astra-focused in quickstart

### DIFF
--- a/DEVGUIDE.md
+++ b/DEVGUIDE.md
@@ -69,7 +69,6 @@ import { driver } from 'astra-mongoose';
 
 mongoose.setDriver(driver);
 mongoose.connect(process.env.ASTRA_URI, {
-  isAstra: true,
   logging: 'all' // astra-db-ts logging config
 });
 

--- a/README.md
+++ b/README.md
@@ -1,36 +1,20 @@
 # astra-mongoose ![ci-tests](https://github.com/stargate/stargate-mongoose/actions/workflows/ci-tests.yml/badge.svg)
 
-`astra-mongoose` is a Mongoose driver for [Data API](https://github.com/stargate/data-api) which runs on top of Apache Cassandra / DataStax Enterprise.
+`astra-mongoose` is a Mongoose driver for [Data API](https://github.com/stargate/data-api). It supports connecting to [DataStax Astra](https://astra.datastax.com/) as well as self-hosted Data API on top of Apache Cassandra / DataStax Enterprise.
 
 1. [Quickstart](#quickstart)
 2. [Architecture](#architecture)
 3. [Version compatibility](#version-compatibility)
-4. [Connecting to AstraDB](#connecting-to-astradb)
-5. [Sample Applications](#sample-applications)
-6. [Features Using Collections](#features-using-collections)
-7. [Features Using Tables](#features-using-tables)
-8. [API Reference](APIReference.md)
-9. [Developer Guide](DEVGUIDE.md)
+4. [Sample Applications](#sample-applications)
+5. [Features Using Collections](#features-using-collections)
+6. [Features Using Tables](#features-using-tables)
+7. [API Reference](APIReference.md)
+8. [Developer Guide](DEVGUIDE.md)
 
 ## Quickstart
 Prerequisites:
-node (>=20.0.0), npm/yarn, Docker (for testing locally using docker compose)
-- Start `Docker` on your local machine.
-- Clone this repository
-```shell
-git clone https://github.com/stargate/stargate-mongoose.git
-cd stargate-mongoose
-```
-- Execute below script and wait for it to complete, which starts a simple Data API on local with a DSE 6.8 (DataStax Enterprise) as database backend.
+node (>=20.0.0), npm/yarn
 
-For macOS/Linux
-```shell
-bin/start_data_api.sh
-```
-For Windows
-```shell
-bin\start_data_api.cmd
-```
 - Create a sample project called 'sample-app'
 ```shell
 mkdir sample-app
@@ -44,26 +28,30 @@ OR
 ```shell
 yarn init -y && yarn add express mongoose astra-mongoose
 ```
-
-
+- Set up an Astra database using the instructions here: https://docs.datastax.com/en/astra/astra-db-vector/api-reference/data-api-with-mongoosejs.html and get a `ASTRA_API_ENDPOINT` and `ASTRA_APPLICATION_TOKEN`.
 - Create a file called `index.js` under the 'sample-app' directory and copy below code into the file.
-```typescript
+```javascript
 //imports
 const express = require('express');
 const mongoose = require('mongoose');
-const { driver } = require('astra-mongoose');
+const { driver, createAstraUri } = require('@datastax/astra-mongoose');
 const Schema = mongoose.Schema;
 
-//override the default native driver
+// Override the default Mongoose driver
 mongoose.setDriver(driver);
 
-//Set up mongoose & end points definition
+// Create a connection string for Astra
+const uri = createAstraUri(
+  process.env.ASTRA_API_ENDPOINT,
+  process.env.ASTRA_APPLICATION_TOKEN
+);
+
+//Set up mongoose
+mongoose.connect(uri);
 const Product = mongoose.model('Product', new Schema({ name: String, price: Number }));
-mongoose.connect('http://localhost:8181/v1/inventory', {
-    username: 'cassandra',
-    password: 'cassandra'
-});
 Object.values(mongoose.connection.models).map(Model => Model.init());
+
+// Set up Express app with endpoints
 const app = express();
 app.get('/addproduct', (req, res) => {
     const newProduct = new Product(
@@ -88,14 +76,17 @@ app.listen(PORT, HOST, () => {
     console.log('http://localhost:' + PORT + '/getproducts');
 });
 ```
-- Execute below to run the app & navigate to the urls listed on the console
+- Execute below to run the app
 ```shell
 node index.js
 ```
-
-- Stop the Data API once the test is complete
+- Create a product
 ```shell
-docker compose -f bin/docker-compose.yml down -v
+curl http://localhost:8097/addproduct
+```
+- View the newly created product
+```shell
+curl http://localhost:8097/getproducts
 ```
 
 ## Architecture
@@ -120,31 +111,6 @@ The current implementation of the Data API uses DataStax Enterprise (DSE) as the
 | Astra                  | Current            |
 
 CI tests are run using the Stargate and Data API versions specified in the [api-compatibility.versions](api-compatibility.versions) file.
-
-## Connecting to AstraDB
-
-Here's a quick way to connect to AstraDB using `astra-mongoose` driver.
-
-```typescript
-const mongoose = require("mongoose");
-const { driver, createAstraUri } = require("astra-mongoose");
-
-const uri = createAstraUri(
-  process.env.ASTRA_DB_API_ENDPOINT,
-  process.env.ASTRA_DB_APPLICATION_TOKEN,
-  process.env.ASTRA_DB_NAMESPACE // optional
-);
-
-mongoose.setDriver(driver);
-
-await mongoose.connect(uri, {
-  isAstra: true,
-});
-```
-
-And the step-by-step instructions with a sample application can be found here in below guide.
-
-https://docs.datastax.com/en/astra/astra-db-vector/api-reference/data-api-with-mongoosejs.html
 
 ## Sample Applications
 

--- a/README.md
+++ b/README.md
@@ -6,14 +6,15 @@
 2. [Architecture](#architecture)
 3. [Version compatibility](#version-compatibility)
 4. [Sample Applications](#sample-applications)
-5. [Features Using Collections](#features-using-collections)
-6. [Features Using Tables](#features-using-tables)
-7. [API Reference](APIReference.md)
-8. [Developer Guide](DEVGUIDE.md)
+5. [Connecting to DSE/HCD](#connecting-to-dse-hcd)
+6. [Features Using Collections](#features-using-collections)
+7. [Features Using Tables](#features-using-tables)
+8. [API Reference](APIReference.md)
+9. [Developer Guide](DEVGUIDE.md)
 
 ## Quickstart
 Prerequisites:
-node (>=20.0.0), npm/yarn
+Node.js (>=20.0.0), npm/yarn
 
 - Create a sample project called 'sample-app'
 ```shell
@@ -28,7 +29,7 @@ OR
 ```shell
 yarn init -y && yarn add express mongoose astra-mongoose
 ```
-- Set up an Astra database using the instructions here: https://docs.datastax.com/en/astra/astra-db-vector/api-reference/data-api-with-mongoosejs.html and get a `ASTRA_API_ENDPOINT` and `ASTRA_APPLICATION_TOKEN`.
+- [Set up an Astra database using the instructions here](https://docs.datastax.com/en/astra-db-serverless/integrations/data-api-with-mongoosejs.html#quickstart). Save your `ASTRA_API_ENDPOINT` and `ASTRA_APPLICATION_TOKEN`.
 - Create a file called `index.js` under the 'sample-app' directory and copy below code into the file.
 ```javascript
 // Imports
@@ -117,6 +118,31 @@ CI tests are run using the Stargate and Data API versions specified in the [api-
 Sample applications developed using `astra-mongoose` driver are available in below repository.
 
 https://github.com/stargate/stargate-mongoose-sample-apps
+
+## Connecting to DSE/HCD
+
+Astra-mongoose also supports connecting to self-hosted Data API instances backed by DSE/HCD.
+Astra-mongoose has a `bin/start_data_api.sh` script that you can run to start a local Data API instance backed by DSE using docker-compose for testing and development purposes.
+
+```shell
+./bin/start_data_api.sh
+```
+
+You can then connect to your local Data API instance using `mongoose.connect()` with `isAstra: false` as follows.
+
+```javascript
+const mongoose = require('mongoose');
+const { driver } = require('@datastax/astra-mongoose');
+
+// Override the default Mongoose driver
+mongoose.setDriver(driver);
+
+await mongoose.connect('http://localhost:8181/v1/testks1', {
+  isAstra: false,
+  username: 'cassandra',
+  password: 'cassandra'
+});
+```
 
 ## Features Using Collections
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ const uri = createAstraUri(
   process.env.ASTRA_APPLICATION_TOKEN
 );
 
-//Set up mongoose
+// Set up mongoose
 mongoose.connect(uri);
 const Product = mongoose.model('Product', new Schema({ name: String, price: Number }));
 Object.values(mongoose.connection.models).map(Model => Model.init());

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ yarn init -y && yarn add express mongoose astra-mongoose
 - Set up an Astra database using the instructions here: https://docs.datastax.com/en/astra/astra-db-vector/api-reference/data-api-with-mongoosejs.html and get a `ASTRA_API_ENDPOINT` and `ASTRA_APPLICATION_TOKEN`.
 - Create a file called `index.js` under the 'sample-app' directory and copy below code into the file.
 ```javascript
-//imports
+// Imports
 const express = require('express');
 const mongoose = require('mongoose');
 const { driver, createAstraUri } = require('@datastax/astra-mongoose');

--- a/src/driver/connection.ts
+++ b/src/driver/connection.ts
@@ -240,7 +240,7 @@ export class Connection extends MongooseConnection {
      * @param uri the connection string
      * @param options
      */
-    async openUri(uri: string, options: ConnectOptionsInternal) {
+    async openUri(uri: string, options?: ConnectOptionsInternal) {
         let _fireAndForget: boolean | undefined = false;
         if (options && '_fireAndForget' in options) {
             _fireAndForget = !!options._fireAndForget;
@@ -282,7 +282,7 @@ export class Connection extends MongooseConnection {
      * @param uri the connection string
      * @param options
      */
-    async createClient(uri: string, options: ConnectOptionsInternal) {
+    async createClient(uri: string, options?: ConnectOptionsInternal) {
         this._connectionString = uri;
         this._closeCalled = false;
         this.readyState = STATES.connecting;
@@ -291,19 +291,19 @@ export class Connection extends MongooseConnection {
 
         const dbOptions = { dataApiPath: baseApiPath };
 
-        this._debug = options.debug;
+        this._debug = options?.debug;
 
-        const isAstra = options?.isAstra;
+        const isAstra = options?.isAstra ?? true;
         const { adminToken, environment } = isAstra
             ? { adminToken: applicationToken, environment: 'astra' as const }
             : {
                 adminToken: new UsernamePasswordTokenProvider(
-                    options.username || throwMissingUsernamePassword(),
-                    options.password || throwMissingUsernamePassword()
+                    options?.username || throwMissingUsernamePassword(),
+                    options?.password || throwMissingUsernamePassword()
                 ),
                 environment: 'dse' as const
             };
-        const client = new DataAPIClient(adminToken, { environment, logging: options.logging });
+        const client = new DataAPIClient(adminToken, { environment, logging: options?.logging });
         const db = options?.isTable
             ? new TablesDb(client.db(baseUrl, dbOptions), keyspaceName)
             : new CollectionsDb(client.db(baseUrl, dbOptions), keyspaceName);

--- a/tests/driver/collections.driver.test.ts
+++ b/tests/driver/collections.driver.test.ts
@@ -260,7 +260,9 @@ describe('COLLECTIONS: driver based tests', async () => {
             mongooseInstance.setDriver(AstraMongooseDriver);
             mongooseInstance.set('autoCreate', false);
             mongooseInstance.set('autoIndex', false);
-            const options = isAstra ? { isAstra: true } : { username: process.env.STARGATE_USERNAME, password: process.env.STARGATE_PASSWORD };
+            const options = isAstra
+                ? {}
+                : { isAstra: false, username: process.env.STARGATE_USERNAME, password: process.env.STARGATE_PASSWORD };
 
             await mongooseInstance.connect(dbUri, options);
 

--- a/tests/driver/tables.driver.test.ts
+++ b/tests/driver/tables.driver.test.ts
@@ -227,7 +227,9 @@ describe('TABLES: driver based tests', async () => {
             mongooseInstance.setDriver(AstraMongooseDriver);
             mongooseInstance.set('autoCreate', false);
             mongooseInstance.set('autoIndex', false);
-            const options = isAstra ? { isAstra: true } : { username: process.env.STARGATE_USERNAME, password: process.env.STARGATE_PASSWORD };
+            const options = isAstra
+                ? {}
+                : { isAstra: false, username: process.env.STARGATE_USERNAME, password: process.env.STARGATE_PASSWORD };
 
             await mongooseInstance.connect(dbUri, options);
 

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -27,6 +27,7 @@ export const isAstra = process.env.TEST_DOC_DB === 'astra' && !!process.env.ASTR
 export const testClient = process.env.TEST_DOC_DB === 'astra' ?
     (process.env.ASTRA_URI ?
         {
+            // Explicitly setting isAstra to true to align with the new default behavior.
             isAstra: true,
             uri: process.env.ASTRA_URI,
             options: {}

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -27,15 +27,16 @@ export const isAstra = process.env.TEST_DOC_DB === 'astra' && !!process.env.ASTR
 export const testClient = process.env.TEST_DOC_DB === 'astra' ?
     (process.env.ASTRA_URI ?
         {
-            isAstra,
+            isAstra: true,
             uri: process.env.ASTRA_URI,
-            options: {isAstra: true}
+            options: {}
         } : null)
     : (process.env.TEST_DOC_DB === 'dataapi' ? (process.env.DATA_API_URI ?
         {
-            isAstra,
+            isAstra: false,
             uri: process.env.DATA_API_URI,
             options: {
+                isAstra: false,
                 username: process.env.STARGATE_USERNAME,
                 password: process.env.STARGATE_PASSWORD
             }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

@toptobes made a good point in Slack - now that this project is called "astra-mongoose", we should make `isAstra` true by default. In addition, the current README emphasizes running Data API locally, but it is far more likely developers will be using this project with Astra. So I updated the quickstart in the README to use Astra over local Data API.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)