### PR TITLE
correct driver re-export for VS code

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,9 @@ import {
     TableSerDesConfig
 } from '@datastax/astra-db-ts';
 
-export * as driver from './driver';
+import * as driver from './driver';
+export { driver };
+
 export { default as createAstraUri } from './createAstraUri';
 export { default as tableDefinitionFromSchema } from './tableDefinitionFromSchema';
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

I spotted an issue where VS code wouldn't recognize `driver` as an export, leading it to flag `import { driver } from '@datastax/astra-mongoose'` as importing a non-existent export. 

Explanation from ChatGPT:

Yes — this is a known TypeScript + export * as quirk that especially shows up in d.ts files.

Here’s the problem:

export * as driver from './driver';

This syntactically exports a namespace named driver, but in .d.ts files, VSCode's language server sometimes doesn't properly recognize these synthetic namespace exports, especially if the imported file (./driver) doesn’t have a corresponding export = or namespace-style structure.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)