### PR TITLE
allow setting astra-db-ts custom fetch option

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "jsdoc-to-markdown": "^9.1.1",
     "mongoose": "^8.14.0",
     "nyc": "^17.1.0",
+    "sinon": "^15.0.1",
     "ts-mocha": "^11.1.0",
     "typescript": "5.x",
     "typescript-eslint": "~8.28"

--- a/src/driver/connection.ts
+++ b/src/driver/connection.ts
@@ -304,10 +304,7 @@ export class Connection extends MongooseConnection {
                 ),
                 environment: 'dse' as const
             };
-        const clientOptions: DataAPIClientOptions = { environment, logging: options?.logging };
-        if (options?.httpOptions != null) {
-            clientOptions.httpOptions = options.httpOptions;
-        }
+        const clientOptions: DataAPIClientOptions = { environment, logging: options?.logging, ...(options?.httpOptions ?? {}) };
         const client = new DataAPIClient(adminToken, clientOptions);
         const db = options?.isTable
             ? new TablesDb(client.db(baseUrl, dbOptions), keyspaceName)

--- a/src/driver/connection.ts
+++ b/src/driver/connection.ts
@@ -304,7 +304,11 @@ export class Connection extends MongooseConnection {
                 ),
                 environment: 'dse' as const
             };
-        const clientOptions: DataAPIClientOptions = { environment, logging: options?.logging, ...(options?.httpOptions ?? {}) };
+
+        const clientOptions: DataAPIClientOptions = { environment, logging: options?.logging };
+        if (options?.httpOptions != null) {
+            clientOptions.httpOptions = options.httpOptions;
+        }
         const client = new DataAPIClient(adminToken, clientOptions);
         const db = options?.isTable
             ? new TablesDb(client.db(baseUrl, dbOptions), keyspaceName)

--- a/src/driver/connection.ts
+++ b/src/driver/connection.ts
@@ -16,20 +16,21 @@ import { Collection, MongooseCollectionOptions } from './collection';
 import {
     AstraDbAdmin,
     CollectionDescriptor,
+    CreateAstraKeyspaceOptions,
+    CreateCollectionOptions,
+    CreateDataAPIKeyspaceOptions,
     CreateTableDefinition,
+    CreateTableOptions,
+    DataAPIClientOptions,
     DataAPIDbAdmin,
-    LoggingEvent,
+    DropCollectionOptions,
+    DropTableOptions,
     ListCollectionsOptions,
     ListTablesOptions,
+    LoggingEvent,
     RawDataAPIResponse,
     TableDescriptor,
-    DropCollectionOptions,
-    CreateTableOptions,
-    DropTableOptions,
-    CreateAstraKeyspaceOptions,
-    CreateDataAPIKeyspaceOptions,
-    CreateCollectionOptions,
-    WithTimeout
+    WithTimeout,
 } from '@datastax/astra-db-ts';
 import { CollectionsDb, TablesDb } from './db';
 import { default as MongooseConnection } from 'mongoose/lib/connection';
@@ -303,7 +304,11 @@ export class Connection extends MongooseConnection {
                 ),
                 environment: 'dse' as const
             };
-        const client = new DataAPIClient(adminToken, { environment, logging: options?.logging });
+        const clientOptions: DataAPIClientOptions = { environment, logging: options?.logging };
+        if (options?.httpOptions != null) {
+            clientOptions.httpOptions = options.httpOptions;
+        }
+        const client = new DataAPIClient(adminToken, clientOptions);
         const db = options?.isTable
             ? new TablesDb(client.db(baseUrl, dbOptions), keyspaceName)
             : new CollectionsDb(client.db(baseUrl, dbOptions), keyspaceName);

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,8 @@ import {
     CollectionSerDesConfig,
     CollectionVectorOptions,
     RerankedResult,
-    TableSerDesConfig
+    TableSerDesConfig,
+    HttpOptions,
 } from '@datastax/astra-db-ts';
 
 export * as driver from './driver';
@@ -49,6 +50,7 @@ declare module 'mongoose' {
         sanitizeFilter?: boolean;
         username?: string;
         password?: string;
+        httpOptions?: HttpOptions
     }
 
     interface InsertManyOptions {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

I've been working on an obsidian plugin using astra-mongoose. Since Obsidian runs on Electron, default `fetch()` suffers from CORS restrictions, so the easiest workaround is to import node-fetch and use that. This PR makes it possible to set `httpOptions`, including custom `fetch()` wrapper, in `mongoose.connect()` and `mongoose.createConnection()`

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)