### PR TITLE
Upgrade to data-api 1.0.27, tests for $lexical

### DIFF
--- a/api-compatibility.versions
+++ b/api-compatibility.versions
@@ -1,2 +1,2 @@
-stargate_version=v2.1.0-BETA-23
-data_api_version=v1.0.25
+stargate_version=v2.1.0-BETA-25
+data_api_version=v1.0.27

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@babel/preset-typescript": "^7.17.12",
     "@types/mocha": "^10.0.10",
     "@types/node": "^18.19.67",
+    "@types/sinon": "^17.0.4",
     "eslint": "^9.23.0",
     "jsdoc-babel": "^0.5.0",
     "jsdoc-to-markdown": "^9.1.1",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "eslint": "^9.23.0",
     "jsdoc-babel": "^0.5.0",
     "jsdoc-to-markdown": "^9.1.1",
-    "mongoose": "^8.14.0",
+    "mongoose": "^8.16.1",
     "nyc": "^17.1.0",
     "sinon": "^15.0.1",
     "ts-mocha": "^11.1.0",
@@ -82,7 +82,7 @@
     "@datastax/astra-db-ts": "2.0.1"
   },
   "peerDependencies": {
-    "mongoose": "^8.14.0"
+    "mongoose": "^8.16.1"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/src/driver/index.ts
+++ b/src/driver/index.ts
@@ -17,8 +17,12 @@ export { Collection, OperationNotSupportedError } from './collection';
 export { Vectorize, VectorizeOptions } from './vectorize';
 
 import { Connection } from './connection';
-import { Mongoose } from 'mongoose';
+import { Mongoose, Schema } from 'mongoose';
 import { handleVectorFieldsProjection, addVectorDimensionValidator, findAndRerankStatic } from './plugins';
+
+// @ts-expect-error workaround to allow Mongoose to handle $match, this syntax isn't part
+// of Mongoose's public API
+Schema.Types.String.prototype.$conditionalHandlers.$match = v => v;
 
 export const plugins = [handleVectorFieldsProjection, addVectorDimensionValidator, findAndRerankStatic];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import {
     RerankedResult,
     TableSerDesConfig,
     HttpOptions,
+    CollectionLexicalOptions,
 } from '@datastax/astra-db-ts';
 
 import * as driver from './driver';
@@ -42,6 +43,7 @@ declare module 'mongodb' {
         vector?: CollectionVectorOptions;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         indexing?: CollectionIndexingOptions<any>;
+        lexical?: CollectionLexicalOptions;
     }
 }
 

--- a/tests/driver/collections.api.test.ts
+++ b/tests/driver/collections.api.test.ts
@@ -1248,28 +1248,32 @@ describe('COLLECTIONS: mongoose Model API level tests with collections', async (
     });
 
     describe('$match', function () {
-        it('works on $lexical field', async function () {
-            this.timeout(120_000);
-
-            const lexicalSchema = new Schema(
-                {
-                    $lexical: { type: String },
-                    name: 'String'
+        const lexicalSchema = new Schema(
+            {
+                $lexical: { type: String },
+                name: 'String'
+            },
+            {
+                collectionOptions: {
+                    lexical: {
+                        enabled: true,
+                        analyzer: 'STANDARD',
+                    }
                 },
-                {
-                    collectionOptions: {
-                        lexical: {
-                            enabled: true,
-                            analyzer: 'STANDARD',
-                        }
-                    },
-                    autoCreate: false
-                }
-            );
-            const LexicalModel = mongooseInstance.model('Lexical', lexicalSchema, TEST_COLLECTION_NAME);
-            await mongooseInstance.connection.dropCollection(TEST_COLLECTION_NAME);
-            await LexicalModel.createCollection();
+                autoCreate: false
+            }
+        );
+        let LexicalModel: Model<InferSchemaType<typeof lexicalSchema>>;
 
+        before(async function () {
+            this.timeout(120_000);
+            await mongooseInstance.connection.dropCollection(TEST_COLLECTION_NAME);
+            LexicalModel = mongooseInstance.model('Lexical', lexicalSchema, TEST_COLLECTION_NAME);
+            await LexicalModel.createCollection();
+        });
+
+        it('works on $lexical field', async function () {
+            await LexicalModel.deleteMany({});
             await LexicalModel.create([
                 { name: 'test 1', $lexical: 'the quick brown fox jumped over the lazy dog' },
                 { name: 'test 2', $lexical: 'the lazy red hen sat beside the sleepy dog' }
@@ -1281,14 +1285,17 @@ describe('COLLECTIONS: mongoose Model API level tests with collections', async (
             docs = await LexicalModel.find({ $lexical: { $match: 'sat' } });
             assert.strictEqual(docs.length, 1);
             assert.strictEqual(docs[0].name, 'test 2');
+        });
 
+        it.skip('sorts results by $lexical field', async function () {
+            // Ensure collection is clean and has the right docs
             await LexicalModel.deleteMany({});
             await LexicalModel.create([
                 { name: 'test A1', $lexical: 'the badger is a small, burrowing mammal known for its bold behavior and distinctive striped face.' },
                 { name: 'test A2', $lexical: 'badger badger badger mushroom mushroom' },
                 { name: 'test A3', $lexical: 'the quick brown fox jumped over the lazy dog' }
             ]);
-            docs = await LexicalModel.find({ $lexical: { $match: 'badger' } }).sort({ $lexical: { $meta: 'badger' } });
+            const docs = await LexicalModel.find({ $lexical: { $match: 'badger' } }).sort({ $lexical: { $meta: 'badger' } });
             assert.strictEqual(docs.length, 2);
             assert.strictEqual(docs[0].name, 'test A1');
             assert.strictEqual(docs[1].name, 'test A2');

--- a/tests/driver/collections.api.test.ts
+++ b/tests/driver/collections.api.test.ts
@@ -1282,16 +1282,16 @@ describe('COLLECTIONS: mongoose Model API level tests with collections', async (
             assert.strictEqual(docs.length, 1);
             assert.strictEqual(docs[0].name, 'test 2');
 
-            /*await LexicalModel.deleteMany({});
+            await LexicalModel.deleteMany({});
             await LexicalModel.create([
-                { name: 'test A1', $lexical: 'badgers are small, burrowing mammals known for their bold behavior and distinctive striped faces.' },
+                { name: 'test A1', $lexical: 'the badger is a small, burrowing mammal known for its bold behavior and distinctive striped face.' },
                 { name: 'test A2', $lexical: 'badger badger badger mushroom mushroom' },
                 { name: 'test A3', $lexical: 'the quick brown fox jumped over the lazy dog' }
             ]);
-            docs = await LexicalModel.find({ $lexical: { $match: 'badger' } }).sort({ $lexical: 'badger' });
+            docs = await LexicalModel.find({ $lexical: { $match: 'badger' } }).sort({ $lexical: { $meta: 'badger' } });
             assert.strictEqual(docs.length, 2);
             assert.strictEqual(docs[0].name, 'test A1');
-            assert.strictEqual(docs[1].name, 'test A2');*/
+            assert.strictEqual(docs[1].name, 'test A2');
         });
     });
 });

--- a/tests/driver/collections.api.test.ts
+++ b/tests/driver/collections.api.test.ts
@@ -1246,4 +1246,52 @@ describe('COLLECTIONS: mongoose Model API level tests with collections', async (
             assert.ok(!doc.$vector);
         });
     });
+
+    describe('$match', function () {
+        it('works on $lexical field', async function () {
+            this.timeout(120_000);
+
+            const lexicalSchema = new Schema(
+                {
+                    $lexical: { type: String },
+                    name: 'String'
+                },
+                {
+                    collectionOptions: {
+                        lexical: {
+                            enabled: true,
+                            analyzer: 'STANDARD',
+                        }
+                    },
+                    autoCreate: false
+                }
+            );
+            const LexicalModel = mongooseInstance.model('Lexical', lexicalSchema, TEST_COLLECTION_NAME);
+            await mongooseInstance.connection.dropCollection(TEST_COLLECTION_NAME);
+            await LexicalModel.createCollection();
+
+            await LexicalModel.create([
+                { name: 'test 1', $lexical: 'the quick brown fox jumped over the lazy dog' },
+                { name: 'test 2', $lexical: 'the lazy red hen sat beside the sleepy dog' }
+            ]);
+            let docs = await LexicalModel.find({ $lexical: { $match: 'jumped' } });
+            assert.strictEqual(docs.length, 1);
+            assert.strictEqual(docs[0].name, 'test 1');
+
+            docs = await LexicalModel.find({ $lexical: { $match: 'sat' } });
+            assert.strictEqual(docs.length, 1);
+            assert.strictEqual(docs[0].name, 'test 2');
+
+            /*await LexicalModel.deleteMany({});
+            await LexicalModel.create([
+                { name: 'test A1', $lexical: 'badgers are small, burrowing mammals known for their bold behavior and distinctive striped faces.' },
+                { name: 'test A2', $lexical: 'badger badger badger mushroom mushroom' },
+                { name: 'test A3', $lexical: 'the quick brown fox jumped over the lazy dog' }
+            ]);
+            docs = await LexicalModel.find({ $lexical: { $match: 'badger' } }).sort({ $lexical: 'badger' });
+            assert.strictEqual(docs.length, 2);
+            assert.strictEqual(docs[0].name, 'test A1');
+            assert.strictEqual(docs[1].name, 'test A2');*/
+        });
+    });
 });

--- a/tests/driver/collections.api.test.ts
+++ b/tests/driver/collections.api.test.ts
@@ -1297,8 +1297,8 @@ describe('COLLECTIONS: mongoose Model API level tests with collections', async (
             ]);
             const docs = await LexicalModel.find({ $lexical: { $match: 'badger' } }).sort({ $lexical: { $meta: 'badger' } });
             assert.strictEqual(docs.length, 2);
-            assert.strictEqual(docs[0].name, 'test A1');
-            assert.strictEqual(docs[1].name, 'test A2');
+            assert.strictEqual(docs[0].name, 'test A2');
+            assert.strictEqual(docs[1].name, 'test A1');
         });
     });
 });

--- a/tests/driver/collections.api.test.ts
+++ b/tests/driver/collections.api.test.ts
@@ -1251,7 +1251,7 @@ describe('COLLECTIONS: mongoose Model API level tests with collections', async (
         const lexicalSchema = new Schema(
             {
                 $lexical: { type: String },
-                name: 'String'
+                name: { type: String }
             },
             {
                 collectionOptions: {

--- a/tests/driver/tables.api.test.ts
+++ b/tests/driver/tables.api.test.ts
@@ -101,7 +101,10 @@ describe('TABLES: Mongoose Model API level tests', async () => {
             await product1.save();
             const error: Error | null = await Product.$where('this.name === "Product 1"').exec().then(() => null, error => error);
             assert.ok(error instanceof DataAPIResponseError);
-            assert.strictEqual(error.errorDescriptors[0].message, 'Invalid filter expression: filter clause path (\'$where\') cannot start with `$`');
+            assert.ok(
+                error.errorDescriptors[0].message.startsWith('Only columns defined in the table schema can be filtered on.'),
+                error.errorDescriptors[0].message
+            );
         });
         it('API ops tests Model.aggregate()', async () => {
             //Model.aggregate()

--- a/tests/mongooseFixtures.ts
+++ b/tests/mongooseFixtures.ts
@@ -114,7 +114,7 @@ export async function createMongooseCollections(isTable: boolean) {
             mongooseInstanceTables.connection.collection(CartTablesModel.collection.collectionName).collection.on('commandStarted', ev => {
                 console.log(ev.target.url, JSON.stringify(ev.command, null, '    '));
             });
-            mongooseInstance.connection.collection(TEST_COLLECTION_NAME).collection.on('commandStarted', ev => {
+            mongooseInstanceTables.connection.collection(TEST_COLLECTION_NAME).collection.on('commandStarted', ev => {
                 console.log(ev.target.url, JSON.stringify(ev.command, null, '    '));
             });
         }

--- a/tests/mongooseFixtures.ts
+++ b/tests/mongooseFixtures.ts
@@ -1,4 +1,4 @@
-import { testClient } from './fixtures';
+import { TEST_COLLECTION_NAME, testClient } from './fixtures';
 import { Schema, Mongoose, Model, InferSchemaType, SubdocsToPOJOs } from 'mongoose';
 import * as AstraMongooseDriver from '../src/driver';
 import assert from 'assert';
@@ -114,6 +114,9 @@ export async function createMongooseCollections(isTable: boolean) {
             mongooseInstanceTables.connection.collection(CartTablesModel.collection.collectionName).collection.on('commandStarted', ev => {
                 console.log(ev.target.url, JSON.stringify(ev.command, null, '    '));
             });
+            mongooseInstance.connection.collection(TEST_COLLECTION_NAME).collection.on('commandStarted', ev => {
+                console.log(ev.target.url, JSON.stringify(ev.command, null, '    '));
+            });
         }
 
         return { mongooseInstance: mongooseInstanceTables, Product: ProductTablesModel, Cart: CartTablesModel };
@@ -144,6 +147,9 @@ export async function createMongooseCollections(isTable: boolean) {
                 console.log(ev.target.url, JSON.stringify(ev.command, null, '    '));
             });
             mongooseInstance.connection.collection(Cart.collection.collectionName).collection.on('commandStarted', ev => {
+                console.log(ev.target.url, JSON.stringify(ev.command, null, '    '));
+            });
+            mongooseInstance.connection.collection(TEST_COLLECTION_NAME).collection.on('commandStarted', ev => {
                 console.log(ev.target.url, JSON.stringify(ev.command, null, '    '));
             });
         }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Tests for $lexical + $match, upgrade to data-api v1.0.27, and a small workaround to let `$match` work with Mongoose. Still pending a Mongoose bug fix to allow $match to work.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)