### PR TITLE
log db-level events in tests, bubble collection and db level events to connection

### DIFF
--- a/DEVGUIDE.md
+++ b/DEVGUIDE.md
@@ -74,13 +74,18 @@ mongoose.connect(process.env.ASTRA_URI, {
 
 const TestModel = mongoose.model('Test', mongoose.Schema({ name: String }), 'test');
 
-// Listen to astra-db-ts events directly on the astra-db-ts collection or table.
-mongoose.connection.collection('test').collection.on('commandStarted', ev => {
+// Astra-mongoose bubbles up events from astra-mongoose collections and dbs to the connection object
+mongoose.connection.on('commandStarted', ev => {
   console.log(ev);
 });
 
 
 await TestModel.findOne(); // Prints "CommandStartedEvent { ... }"
+
+// Alternatively, can listen to astra-db-ts events directly on the raw astra-db-ts collection
+mongoose.connection.collection('test').collection.on('commandStarted', ev => {
+  console.log(ev);
+});
 ```
 
 Astra-mongoose's tests use the above pattern to log requests sent to Data API.

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -133,6 +133,12 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
         const collection = this.connection.db!.collection<DocType>(this.name, collectionOptions);
         this._collection = collection;
 
+        // Bubble up collection-level events from astra-db-ts to the main connection
+        collection.on('commandStarted', ev => this.connection.emit('commandStarted', ev));
+        collection.on('commandFailed', ev => this.connection.emit('commandFailed', ev));
+        collection.on('commandSucceeded', ev => this.connection.emit('commandSucceeded', ev));
+        collection.on('commandWarnings', ev => this.connection.emit('commandWarnings', ev));
+
         return collection;
     }
 

--- a/tests/e2e/index.js
+++ b/tests/e2e/index.js
@@ -1,1 +1,15 @@
+// Copyright DataStax, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 require('@datastax/astra-mongoose');

--- a/tests/mongooseFixtures.ts
+++ b/tests/mongooseFixtures.ts
@@ -1,4 +1,18 @@
-import { TEST_COLLECTION_NAME, testClient } from './fixtures';
+// Copyright DataStax, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { testClient } from './fixtures';
 import { Schema, Mongoose, Model, InferSchemaType, SubdocsToPOJOs } from 'mongoose';
 import * as AstraMongooseDriver from '../src/driver';
 import assert from 'assert';
@@ -108,13 +122,7 @@ export async function createMongooseCollections(isTable: boolean) {
         }
 
         if (testDebug) {
-            mongooseInstanceTables.connection.collection(ProductTablesModel.collection.collectionName).collection.on('commandStarted', ev => {
-                console.log(ev.target.url, JSON.stringify(ev.command, null, '    '));
-            });
-            mongooseInstanceTables.connection.collection(CartTablesModel.collection.collectionName).collection.on('commandStarted', ev => {
-                console.log(ev.target.url, JSON.stringify(ev.command, null, '    '));
-            });
-            mongooseInstanceTables.connection.collection(TEST_COLLECTION_NAME).collection.on('commandStarted', ev => {
+            mongooseInstanceTables.connection.on('commandStarted', ev => {
                 console.log(ev.target.url, JSON.stringify(ev.command, null, '    '));
             });
         }
@@ -143,13 +151,7 @@ export async function createMongooseCollections(isTable: boolean) {
         }
 
         if (testDebug) {
-            mongooseInstance.connection.collection(Product.collection.collectionName).collection.on('commandStarted', ev => {
-                console.log(ev.target.url, JSON.stringify(ev.command, null, '    '));
-            });
-            mongooseInstance.connection.collection(Cart.collection.collectionName).collection.on('commandStarted', ev => {
-                console.log(ev.target.url, JSON.stringify(ev.command, null, '    '));
-            });
-            mongooseInstance.connection.collection(TEST_COLLECTION_NAME).collection.on('commandStarted', ev => {
+            mongooseInstance.connection.db!.astraDb.on('commandStarted', ev => {
                 console.log(ev.target.url, JSON.stringify(ev.command, null, '    '));
             });
         }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Issue https://github.com/datastax/astra-db-ts/issues/115 caused me a lot of headache when working on $match + $lexical, it would have been easier to find if I had been logging db-level events to the console in tests. But I wasn't logging db-level events because that was tricky to do. So, in addition, with this PR I'm bubbling up collection-level and db-level events to the connection to make it easier to log all events. Bubbling events to the connection is more idiomatic with how Mongoose works (for example, Mongoose emits any errors that occur on individual documents to the model instance)

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)