### PR TITLE
fix typescript types for Mongoose 8.17 and upgrade to data-api v1.0.29

### DIFF
--- a/api-compatibility.versions
+++ b/api-compatibility.versions
@@ -1,2 +1,2 @@
 stargate_version=v2.1.0-BETA-25
-data_api_version=v1.0.27
+data_api_version=v1.0.29

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "eslint": "^9.23.0",
     "jsdoc-babel": "^0.5.0",
     "jsdoc-to-markdown": "^9.1.1",
-    "mongoose": "^8.16.1",
+    "mongoose": "^8.17.0",
     "nyc": "^17.1.0",
     "sinon": "^16.1.1",
     "ts-mocha": "^11.1.0",
@@ -84,7 +84,7 @@
     "@datastax/astra-db-ts": "^2.0.2"
   },
   "peerDependencies": {
-    "mongoose": "^8.16.1"
+    "mongoose": "^8.17.0"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/src/driver/index.ts
+++ b/src/driver/index.ts
@@ -20,8 +20,6 @@ import { Connection } from './connection';
 import { Mongoose, Schema } from 'mongoose';
 import { handleVectorFieldsProjection, addVectorDimensionValidator, findAndRerankStatic } from './plugins';
 
-// @ts-expect-error workaround to allow Mongoose to handle $match, this syntax isn't part
-// of Mongoose's public API
 Schema.Types.String.prototype.$conditionalHandlers.$match = v => v;
 
 export const plugins = [handleVectorFieldsProjection, addVectorDimensionValidator, findAndRerankStatic];

--- a/tests/driver/tables.vector.test.ts
+++ b/tests/driver/tables.vector.test.ts
@@ -39,19 +39,17 @@ describe('TABLES: vector search', function() {
             versionKey: false
         }
     );
-    let Vector: Model<InferSchemaType<typeof vectorSchema>>;
+    const Vector = mongooseInstance.model(
+        'VectorTable',
+        vectorSchema,
+        'vector_table'
+    );
 
     before(async () => {
         await createMongooseCollections(true);
     });
 
     before(async function() {
-        Vector = mongooseInstance.model(
-            'VectorTable',
-            vectorSchema,
-            'vector_table'
-        );
-
         const existingTables = await mongooseInstance.connection.listTables();
         const vectorTable = existingTables.find(t => t.name === 'vector_table');
         const hasValidVectorDefinition = vectorTable?.definition.columns.vector?.type === 'vector' &&

--- a/tests/mongooseFixtures.ts
+++ b/tests/mongooseFixtures.ts
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { TEST_COLLECTION_NAME, testClient } from './fixtures';
-import { Schema, Mongoose, Model, InferSchemaType, SubdocsToPOJOs } from 'mongoose';
+import { testClient } from './fixtures';
+import { Schema, Mongoose, InferSchemaType, SubdocsToPOJOs } from 'mongoose';
 import * as AstraMongooseDriver from '../src/driver';
 import assert from 'assert';
 import { plugins } from '../src/driver';

--- a/tests/mongooseFixtures.ts
+++ b/tests/mongooseFixtures.ts
@@ -1,5 +1,5 @@
 import { TEST_COLLECTION_NAME, testClient } from './fixtures';
-import { Schema, Mongoose, Model, InferSchemaType, SubdocsToPOJOs } from 'mongoose';
+import { Schema, Mongoose, InferSchemaType, SubdocsToPOJOs } from 'mongoose';
 import * as AstraMongooseDriver from '../src/driver';
 import assert from 'assert';
 import { plugins } from '../src/driver';
@@ -34,10 +34,10 @@ for (const plugin of plugins) {
     mongooseInstance.plugin(plugin);
 }
 
-export type CartModelType = Model<InferSchemaType<typeof cartSchema>>;
-export type ProductModelType = Model<InferSchemaType<typeof productSchema>>;
 export const Cart = mongooseInstance.model('Cart', cartSchema);
 export const Product = mongooseInstance.model('Product', productSchema);
+export type CartModelType = typeof Cart;
+export type ProductModelType = typeof Product;
 export type ProductHydratedDoc = ReturnType<(typeof Product)['hydrate']>;
 export type ProductRawDoc = SubdocsToPOJOs<InferSchemaType<typeof productSchema>>;
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Fixed build for Mongoose 8.17, which includes some changes for making `__v` not required that isn't quite compatible with stargate-mongoose's TypeScript types.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)