### PR TITLE
misc bug fixes: nested maps, negative dimensions, remove unused authHeaderName

### DIFF
--- a/src/createAstraUri.ts
+++ b/src/createAstraUri.ts
@@ -22,7 +22,6 @@ export default function createAstraUri (
     apiToken: string,
     namespace?: string,
     baseApiPath?: string,
-    authHeaderName?: string,
 ) {
     const uri = new url.URL(apiEndpoint);
     let contextPath = '';
@@ -31,9 +30,6 @@ export default function createAstraUri (
     uri.pathname = contextPath;
     if (apiToken) {
         uri.searchParams.append('applicationToken', apiToken);
-    }
-    if (authHeaderName) {
-        uri.searchParams.append('authHeaderName', authHeaderName);
     }
     return uri.toString();
 }

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -536,7 +536,9 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
         if (this.collection instanceof AstraTable) {
             throw new OperationNotSupportedError('Cannot use findAndRerank() with tables');
         }
-        return this.collection.findAndRerank(filter, options);
+        filter = serialize(filter, false);
+        return this.collection.findAndRerank(filter, options)
+            .map(result => ({ ...result, document: deserializeDoc(result.document) }));
     }
 
     /**

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -55,6 +55,7 @@ import {
     TableUpdateOneOptions,
     TableVectorIndexOptions,
 } from '@datastax/astra-db-ts';
+import { OperationNotSupportedError } from '../operationNotSupportedError';
 import { SchemaOptions } from 'mongoose';
 import deserializeDoc from '../deserializeDoc';
 import { inspect } from 'util';
@@ -580,13 +581,6 @@ function processSortOption(sort: MongooseSortOption): SortOptionInternal {
     }
 
     return result;
-}
-
-export class OperationNotSupportedError extends Error {
-    constructor(message: string) {
-        super(message);
-        this.name = 'OperationNotSupportedError';
-    }
 }
 
 /*!

--- a/src/driver/connection.ts
+++ b/src/driver/connection.ts
@@ -469,6 +469,10 @@ export const parseUri = (uri: string): ParsedUri => {
 
 
     // Remove trailing slash from pathname before use
+    //  /v1/testks1/ => /v1/testks1
+    //  /apis/v1/testks1/ => /apis/v1/testks1
+    //  /testks1/ => /testks1
+    //  / => '' (empty string)
     const pathname = parsedUrl.pathname.replace(/\/$/, '');
     const keyspaceName = pathname.substring(pathname.lastIndexOf('/') + 1);
     // Remove the last part of the api path (which is assumed as the keyspace name). For example:

--- a/src/driver/connection.ts
+++ b/src/driver/connection.ts
@@ -88,24 +88,32 @@ export class Connection extends MongooseConnection {
     models: Record<string, Model<unknown>> = {};
     _debug?: boolean | ((name: string, fn: string, ...args: unknown[]) => void) | null;
 
+    // Store references to event listener functions for cleanup
+    private _dbEventListeners?: {
+         commandStarted: (ev: CommandStartedEvent) => void;
+         commandFailed: (ev: CommandFailedEvent) => void;
+         commandSucceeded: (ev: CommandSucceededEvent) => void;
+         commandWarnings: (ev: CommandWarningsEvent) => void;
+     };
+
     constructor(base: Mongoose) {
         super(base);
     }
 
     /**
-     * Helper borrowed from Mongoose to wait for the connection to finish connecting. Because Mongoose
-     * supports creating a new connection, registering some models, and connecting to the database later.
-     * This method is private and should not be called by clients.
-     *
-     * #### Example:
-     *     const conn = mongoose.createConnection();
-     *     // This may call `createCollection()` internally depending on `autoCreate` option, even though
-     *     // this connection hasn't connected to the database yet.
-     *     conn.model('Test', mongoose.Schema({ name: String }));
-     *     await conn.openUri(uri);
-     *
-     * @ignore
-     */
+      * Helper borrowed from Mongoose to wait for the connection to finish connecting. Because Mongoose
+      * supports creating a new connection, registering some models, and connecting to the database later.
+      * This method is private and should not be called by clients.
+      *
+      * #### Example:
+      *     const conn = mongoose.createConnection();
+      *     // This may call `createCollection()` internally depending on `autoCreate` option, even though
+      *     // this connection hasn't connected to the database yet.
+      *     conn.model('Test', mongoose.Schema({ name: String }));
+      *     await conn.openUri(uri);
+      *
+      * @ignore
+      */
     async _waitForClient() {
         const shouldWaitForClient = (this.readyState === STATES.connecting || this.readyState === STATES.disconnected) && this._shouldBufferCommands();
         if (shouldWaitForClient) {
@@ -116,10 +124,10 @@ export class Connection extends MongooseConnection {
     }
 
     /**
-     * Get a collection by name. Cached in `this.collections`.
-     * @param name
-     * @param options
-     */
+      * Get a collection by name. Cached in `this.collections`.
+      * @param name
+      * @param options
+      */
     collection<DocType extends Record<string, unknown> = Record<string, unknown>>(name: string, options?: MongooseCollectionOptions): Collection<DocType> {
         if (!(name in this.collections)) {
             this.collections[name] = new Collection<DocType>(name, this, options);
@@ -128,10 +136,10 @@ export class Connection extends MongooseConnection {
     }
 
     /**
-     * Create a new collection in the database
-     * @param name The name of the collection to create
-     * @param options
-     */
+      * Create a new collection in the database
+      * @param name The name of the collection to create
+      * @param options
+      */
     async createCollection<DocType extends Record<string, unknown> = Record<string, unknown>>(
         name: string,
         options?: CreateCollectionOptions<DocType>
@@ -141,17 +149,17 @@ export class Connection extends MongooseConnection {
     }
 
     /**
-     * Get current debug setting, accounting for potential changes to global debug config (`mongoose.set('debug', true | false)`)
-     */
+      * Get current debug setting, accounting for potential changes to global debug config (`mongoose.set('debug', true | false)`)
+      */
     get debug(): boolean | ((name: string, fn: string, ...args: unknown[]) => void) | null | undefined {
         return this._debug ?? this.base?.options?.debug;
     }
 
     /**
-     * Create a new table in the database
-     * @param name
-     * @param definition
-     */
+      * Create a new table in the database
+      * @param name
+      * @param definition
+      */
     async createTable<DocType extends Record<string, unknown> = Record<string, unknown>>(
         name: string,
         definition: CreateTableDefinition,
@@ -162,45 +170,45 @@ export class Connection extends MongooseConnection {
     }
 
     /**
-     * Drop a collection from the database
-     * @param name
-     */
+      * Drop a collection from the database
+      * @param name
+      */
     async dropCollection(name: string, options?: DropCollectionOptions) {
         await this._waitForClient();
         return this.db!.dropCollection(name, options);
     }
 
     /**
-     * Drop a table from the database
-     * @param name The name of the table to drop
-     */
+      * Drop a table from the database
+      * @param name The name of the table to drop
+      */
     async dropTable(name: string, options?: DropTableOptions) {
         await this._waitForClient();
         return this.db!.dropTable(name, options);
     }
 
     /**
-     * Create a new keyspace.
-     *
-     * @param name The name of the keyspace to create
-     */
+      * Create a new keyspace.
+      *
+      * @param name The name of the keyspace to create
+      */
     async createKeyspace(name: string, options?: CreateAstraKeyspaceOptions & CreateDataAPIKeyspaceOptions) {
         await this._waitForClient();
         return await this.admin!.createKeyspace(name, options);
     }
 
     /**
-     * Not implemented.
-     *
-     * @ignore
-     */
+      * Not implemented.
+      *
+      * @ignore
+      */
     async dropDatabase() {
         throw new OperationNotSupportedError('dropDatabase() Not Implemented');
     }
 
     /**
-     * List all collections in the database
-     */
+      * List all collections in the database
+      */
 
     async listCollections(options: ListCollectionsOptions & { nameOnly: true }): Promise<string[]>;
     async listCollections(options?: ListCollectionsOptions & { nameOnly?: false }): Promise<CollectionDescriptor[]>;
@@ -214,8 +222,8 @@ export class Connection extends MongooseConnection {
     }
 
     /**
-     * List all tables in the database
-     */
+      * List all tables in the database
+      */
 
     async listTables(options: ListTablesOptions & { nameOnly: true }): Promise<string[]>;
     async listTables(options?: ListTablesOptions & { nameOnly?: false }): Promise<TableDescriptor[]>;
@@ -229,17 +237,17 @@ export class Connection extends MongooseConnection {
     }
 
     /**
-     * Run an arbitrary Data API command on the database
-     * @param command The command to run
-     */
+      * Run an arbitrary Data API command on the database
+      * @param command The command to run
+      */
     async runCommand(command: Record<string, unknown>): Promise<RawDataAPIResponse> {
         await this._waitForClient();
         return this.db!.command(command);
     }
 
     /**
-     * List all keyspaces. Called "listDatabases" for Mongoose compatibility
-     */
+      * List all keyspaces. Called "listDatabases" for Mongoose compatibility
+      */
 
     async listDatabases(options?: WithTimeout<'keyspaceAdminTimeoutMs'>): Promise<{ databases: { name: string }[] }> {
         await this._waitForClient();
@@ -247,12 +255,12 @@ export class Connection extends MongooseConnection {
     }
 
     /**
-     * Logic for creating a connection to Data API. Mongoose calls `openUri()` internally when the
-     * user calls `mongoose.create()` or `mongoose.createConnection(uri)`
-     *
-     * @param uri the connection string
-     * @param options
-     */
+      * Logic for creating a connection to Data API. Mongoose calls `openUri()` internally when the
+      * user calls `mongoose.create()` or `mongoose.createConnection(uri)`
+      *
+      * @param uri the connection string
+      * @param options
+      */
     async openUri(uri: string, options?: ConnectOptionsInternal) {
         let _fireAndForget: boolean | undefined = false;
         if (options && '_fireAndForget' in options) {
@@ -291,10 +299,10 @@ export class Connection extends MongooseConnection {
     }
 
     /**
-     * Create an astra-db-ts client and corresponding objects: client, db, admin.
-     * @param uri the connection string
-     * @param options
-     */
+      * Create an astra-db-ts client and corresponding objects: client, db, admin.
+      * @param uri the connection string
+      * @param options
+      */
     async createClient(uri: string, options?: ConnectOptionsInternal) {
         this._connectionString = uri;
         this._closeCalled = false;
@@ -345,10 +353,17 @@ export class Connection extends MongooseConnection {
         this.onOpen();
 
         // Bubble up db-level events from astra-db-ts to the main connection
-        db.astraDb.on('commandStarted', ev => this.emit('commandStarted', ev));
-        db.astraDb.on('commandFailed', ev => this.emit('commandFailed', ev));
-        db.astraDb.on('commandSucceeded', ev => this.emit('commandSucceeded', ev));
-        db.astraDb.on('commandWarnings', ev => this.emit('commandWarnings', ev));
+        // Store listener references for later removal
+        this._dbEventListeners = {
+            commandStarted: (ev: CommandStartedEvent) => this.emit('commandStarted', ev),
+            commandFailed: (ev: CommandFailedEvent) => this.emit('commandFailed', ev),
+            commandSucceeded: (ev: CommandSucceededEvent) => this.emit('commandSucceeded', ev),
+            commandWarnings: (ev: CommandWarningsEvent) => this.emit('commandWarnings', ev),
+        };
+        db.astraDb.on('commandStarted', this._dbEventListeners.commandStarted);
+        db.astraDb.on('commandFailed', this._dbEventListeners.commandFailed);
+        db.astraDb.on('commandSucceeded', this._dbEventListeners.commandSucceeded);
+        db.astraDb.on('commandWarnings', this._dbEventListeners.commandWarnings);
 
         return this;
 
@@ -361,47 +376,56 @@ export class Connection extends MongooseConnection {
     }
 
     /**
-     * Not supported
-     *
-     * @param _client
-     * @ignore
-     */
+      * Not supported
+      *
+      * @param _client
+      * @ignore
+      */
 
     setClient() {
         throw new AstraMongooseError('SetClient not supported');
     }
 
     /**
-     * For consistency with Mongoose's API. `mongoose.createConnection(uri)` returns the connection, **not** a promise,
-     * so the Mongoose pattern to call `createConnection()` and wait for connection to succeed is
-     * `await createConnection(uri).asPromise()`
-     */
+      * For consistency with Mongoose's API. `mongoose.createConnection(uri)` returns the connection, **not** a promise,
+      * so the Mongoose pattern to call `createConnection()` and wait for connection to succeed is
+      * `await createConnection(uri).asPromise()`
+      */
     asPromise() {
         return this.initialConnection;
     }
 
     /**
-     * Not supported
-     *
-     * @ignore
-     */
+      * Not supported
+      *
+      * @ignore
+      */
 
     startSession() {
         throw new AstraMongooseError('startSession() Not Implemented');
     }
 
     /**
-     * Mongoose calls `doClose()` to close the connection when the user calls `mongoose.disconnect()` or `conn.close()`.
-     * Handles closing the astra-db-ts client.
-     * This method is private and should not be called by clients directly. Mongoose will call this method internally when
-     * the user calls `mongoose.disconnect()` or `conn.close()`.
-     *
-     * @returns Client
-     * @ignore
-     */
-    doClose() {
+      * Mongoose calls `doClose()` to close the connection when the user calls `mongoose.disconnect()` or `conn.close()`.
+      * Handles closing the astra-db-ts client.
+      * This method is private and should not be called by clients directly. Mongoose will call this method internally when
+      * the user calls `mongoose.disconnect()` or `conn.close()`.
+      *
+      * @returns Client
+      * @ignore
+      */
+    async doClose() {
+        // Remove db-level event listeners if present
+        if (this.db && this._dbEventListeners) {
+            const dbEmitter = this.db.astraDb;
+            dbEmitter.off('commandStarted', this._dbEventListeners.commandStarted);
+            dbEmitter.off('commandFailed', this._dbEventListeners.commandFailed);
+            dbEmitter.off('commandSucceeded', this._dbEventListeners.commandSucceeded);
+            dbEmitter.off('commandWarnings', this._dbEventListeners.commandWarnings);
+            this._dbEventListeners = undefined;
+        }
         if (this.client != null) {
-            this.client.close();
+            await this.client.close();
         }
         return this;
     }
@@ -431,12 +455,12 @@ export class Connection extends MongooseConnection {
     }
 }
 
-interface ParsedUri {
-    baseUrl: string;
-    baseApiPath: string;
-    keyspaceName: string;
-    applicationToken?: string;
-}
+ interface ParsedUri {
+     baseUrl: string;
+     baseApiPath: string;
+     keyspaceName: string;
+     applicationToken?: string;
+ }
 
 // Parse a connection URI in the format of: https://${baseUrl}/${baseAPIPath}/${keyspace}?applicationToken=${applicationToken}
 export const parseUri = (uri: string): ParsedUri => {

--- a/src/driver/index.ts
+++ b/src/driver/index.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 export { Connection } from './connection';
-export { Collection, OperationNotSupportedError } from './collection';
+export { Collection } from './collection';
 export { Vectorize, VectorizeOptions } from './vectorize';
 
 import { Connection } from './connection';

--- a/src/driver/plugins.ts
+++ b/src/driver/plugins.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import type { Schema, SchemaType } from 'mongoose';
+import { AstraMongooseError } from '../astraMongooseError';
 import { CollectionFindAndRerankOptions } from '@datastax/astra-db-ts';
 import { Collection } from './collection';
 
@@ -67,6 +68,12 @@ export function addVectorDimensionValidator(schema: Schema) {
         const isValidArray = schemaType.instance === 'Array' || schemaType.instance === 'Vectorize';
         if (isValidArray && schemaType.getEmbeddedSchemaType()?.instance === 'Number' && typeof schemaType.options?.dimension === 'number') {
             const dimension = schemaType.options?.dimension;
+            if (dimension <= 0) {
+                throw new AstraMongooseError('`dimension` option for vectorize paths must be a positive integer, got: ' + dimension, {
+                    options: schemaType.options,
+                    path: schemaType.path,
+                });
+            }
             schemaType.validate((value: number[] | string | null) => {
                 if (value == null) {
                     return true;

--- a/src/driver/vectorize.ts
+++ b/src/driver/vectorize.ts
@@ -36,6 +36,11 @@ export class Vectorize extends Schema.Types.Array {
     constructor(key: string, options: VectorizeOptions) {
         super(key, { type: 'Number' });
         this.options = options;
+        if (typeof options?.dimension === 'number' && options.dimension <= 0) {
+            throw new AstraMongooseError('`dimension` option for vectorize paths must be a positive integer, got: ' + options?.dimension, {
+                options
+            });
+        }
         this.instance = 'Vectorize';
         if (options?.index) {
             this.index.call(this, options.index);
@@ -62,7 +67,10 @@ export class Vectorize extends Schema.Types.Array {
      * Overwritten to account for Mongoose SchemaArray constructor taking different arguments than Vectorize
      */
     clone(): Vectorize {
-        const options = Object.assign({}, this.options) as VectorizeOptions;
+        const options = { ...this.options } as VectorizeOptions;
+        if (options?.service) {
+            options.service = { ...options.service };
+        }
         const schematype = new Vectorize(this.path, options);
         schematype.validators = this.validators.slice();
         // @ts-expect-error Mongoose doesn't expose the type of `requiredValidator`

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ import type { Mongoose } from 'mongoose';
 export { Vectorize, VectorizeOptions } from './driver';
 
 export { AstraMongooseError } from './astraMongooseError';
+export { OperationNotSupportedError } from './operationNotSupportedError';
 
 export type AstraMongoose = Omit<Mongoose, 'connection'> & { connection: AstraMongooseDriver.Connection };
 

--- a/src/operationNotSupportedError.ts
+++ b/src/operationNotSupportedError.ts
@@ -1,0 +1,20 @@
+// Copyright DataStax, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export class OperationNotSupportedError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'OperationNotSupportedError';
+    }
+}

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -54,7 +54,9 @@ function serializeValue(data: any, isTable?: boolean): any {
         // Rely on astra driver to serialize dates
         return data;
     } else if (data instanceof Map && !isTable) {
-        return Object.fromEntries(data.entries());
+        return Object.fromEntries(
+            [...data.entries()].map(([key, value]) => [key, serializeValue(value, isTable)])
+        );
     } else if (data instanceof Binary) {
         if (data.sub_type === 3 || data.sub_type === 4) {
             // UUIDs, no need for explicit `instanceof UUID` check because bson UUID extends Binary

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -46,8 +46,8 @@ function serializeValue(data: any, isTable?: boolean): any {
     if (data instanceof ObjectId) {
         return data.toHexString();
     } else if (data instanceof mongoose.Types.Decimal128) {
-        //Decimal128 handling
-        return Number(data.toString());
+        // Decimal128 handling: for collections, store as string to avoid loss of precision
+        return isTable ? Number(data.toString()) : data.toString();
     } else if (data instanceof Double) {
         return Number(data.valueOf());
     } else if (data instanceof Date) {

--- a/src/tableDefinitionFromSchema.ts
+++ b/src/tableDefinitionFromSchema.ts
@@ -22,13 +22,16 @@ type AllowedDataAPITypes = 'text' | 'double' | 'timestamp' | 'boolean' | 'decima
  * Given a Mongoose schema, create an equivalent Data API table definition for use with `createTable()`
  */
 export default function tableDefinitionFromSchema(schema: Schema): CreateTableDefinition {
+    const versionKey = schema.options.versionKey;
     const tableDefinition: CreateTableDefinition = {
         primaryKey: '_id',
         columns: {
-            _id: { type: 'text' },
-            __v: { type: 'int' }
+            _id: { type: 'text' }
         }
     };
+    if (typeof versionKey === 'string') {
+        tableDefinition.columns[versionKey] = { type: 'int' };
+    }
     const schemaTypesForNestedPath: Record<string, SchemaType[]> = {};
     for (const path of Object.keys(schema.paths)) {
         const schemaType = schema.paths[path];

--- a/tests/createAstraUri.test.ts
+++ b/tests/createAstraUri.test.ts
@@ -42,10 +42,4 @@ describe('Utils test', () => {
         const uri: string = createAstraUri(apiEndpoint,'myToken','testks1','apis');
         assert.strictEqual(uri, 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com/apis/testks1?applicationToken=myToken');
     });
-
-    it('with authHeaderName', () => {
-        const apiEndpoint = 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com';
-        const uri: string = createAstraUri(apiEndpoint,'myToken','testks1','apis','x-authn');
-        assert.strictEqual(uri, 'https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com/apis/testks1?applicationToken=myToken&authHeaderName=x-authn');
-    });
 });

--- a/tests/driver/collections.api.test.ts
+++ b/tests/driver/collections.api.test.ts
@@ -21,10 +21,10 @@ import mongoose, { Schema, InferSchemaType, InsertManyResult, Model } from 'mong
 import { once } from 'events';
 import * as AstraMongooseDriver from '../../src/driver';
 import {randomUUID} from 'crypto';
-import {OperationNotSupportedError} from '../../src/driver';
+import { OperationNotSupportedError } from '../../src/operationNotSupportedError';
 import { CartModelType, ProductModelType, productSchema, ProductRawDoc, createMongooseCollections, testDebug } from '../mongooseFixtures';
 import { parseUri } from '../../src/driver/connection';
-import { FindCursor, DataAPIResponseError } from '@datastax/astra-db-ts';
+import { FindCursor, DataAPIResponseError, DataAPIVector, DataAPIBlob } from '@datastax/astra-db-ts';
 import { Long, UUID } from 'bson';
 import type { AstraMongoose } from '../../src';
 
@@ -111,6 +111,10 @@ describe('COLLECTIONS: mongoose Model API level tests with collections', async (
                         state: String
                     }
                 },
+                nestedMap: {
+                    type: Map,
+                    of: { type: Map, of: String }
+                },
                 uniqueId: Schema.Types.UUID,
                 category: BigInt,
                 documentArray: [{ name: String }],
@@ -151,6 +155,7 @@ describe('COLLECTIONS: mongoose Model API level tests with collections', async (
                         state: 'state 1'
                     }
                 },
+                nestedMap: new Map([['key1', new Map([['subkey1', 'value1'], ['subkey2', 'value2']])]]),
                 uniqueId: new UUID(uniqueIdVal),
                 category: BigInt(100),
                 documentArray: [{ name: 'test document array' }],
@@ -173,6 +178,10 @@ describe('COLLECTIONS: mongoose Model API level tests with collections', async (
             assert.strictEqual(saveResponse.nestedSchema!.address!.street, 'street 1');
             assert.strictEqual(saveResponse.nestedSchema!.address!.city, 'city 1');
             assert.strictEqual(saveResponse.nestedSchema!.address!.state, 'state 1');
+            // @ts-expect-error Mongoose types don't handle nested maps well
+            assert.strictEqual(saveResponse.nestedMap!.get('key1')!.get('subkey1'), 'value1');
+            // @ts-expect-error Mongoose types don't handle nested maps well
+            assert.strictEqual(saveResponse.nestedMap!.get('key1')!.get('subkey2'), 'value2');
             assert.strictEqual(saveResponse.uniqueId!.toString(), uniqueIdVal.toString());
             assert.strictEqual(saveResponse.category!.toString(), '100');
             assert.strictEqual(saveResponse.documentArray[0].name, 'test document array');
@@ -196,6 +205,10 @@ describe('COLLECTIONS: mongoose Model API level tests with collections', async (
             assert.strictEqual(findOneResponse.nestedSchema!.address!.street, 'street 1');
             assert.strictEqual(findOneResponse.nestedSchema!.address!.city, 'city 1');
             assert.strictEqual(findOneResponse.nestedSchema!.address!.state, 'state 1');
+            // @ts-expect-error Mongoose types don't handle nested maps well
+            assert.strictEqual(findOneResponse.nestedMap!.get('key1')!.get('subkey1'), 'value1');
+            // @ts-expect-error Mongoose types don't handle nested maps well
+            assert.strictEqual(findOneResponse.nestedMap!.get('key1')!.get('subkey2'), 'value2');
             assert.strictEqual(findOneResponse.uniqueId!.toString(), uniqueIdVal.toString());
             assert.strictEqual(findOneResponse.category!.toString(), '100');
             assert.strictEqual(findOneResponse.documentArray[0].name, 'test document array');
@@ -765,11 +778,6 @@ describe('COLLECTIONS: mongoose Model API level tests with collections', async (
                 /Invalid URI: multiple application tokens/
             );
 
-            await assert.rejects(
-                mongooseInstance.createConnection('https://apps.astra.datastax.com/api/json/v1/test?authHeaderName=test1&authHeaderName=test2', testClient!.options).asPromise(),
-                /Invalid URI: multiple application auth header names/
-            );
-
             if (!testClient?.isAstra) {
                 // Omit username and password from options
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -1116,6 +1124,20 @@ describe('COLLECTIONS: mongoose Model API level tests with collections', async (
 
         beforeEach(async function () {
             await Vector.deleteMany({});
+        });
+
+        it('throws on negative dimension', async function () {
+            assert.throws(
+                () => {
+                    mongooseInstance.model('ShouldNotExist', new Schema(
+                        {
+                            $vector: { type: [Number], default: () => void 0, dimension: -1 },
+                            someOtherPath: 'String'
+                        }
+                    ));
+                },
+                /`dimension` option for vectorize paths must be a positive integer, got: -1/
+            );
         });
 
         it('supports creating document with $vectorize', async function () {

--- a/tests/driver/collections.api.test.ts
+++ b/tests/driver/collections.api.test.ts
@@ -178,9 +178,7 @@ describe('COLLECTIONS: mongoose Model API level tests with collections', async (
             assert.strictEqual(saveResponse.nestedSchema!.address!.street, 'street 1');
             assert.strictEqual(saveResponse.nestedSchema!.address!.city, 'city 1');
             assert.strictEqual(saveResponse.nestedSchema!.address!.state, 'state 1');
-            // @ts-expect-error Mongoose types don't handle nested maps well
             assert.strictEqual(saveResponse.nestedMap!.get('key1')!.get('subkey1'), 'value1');
-            // @ts-expect-error Mongoose types don't handle nested maps well
             assert.strictEqual(saveResponse.nestedMap!.get('key1')!.get('subkey2'), 'value2');
             assert.strictEqual(saveResponse.uniqueId!.toString(), uniqueIdVal.toString());
             assert.strictEqual(saveResponse.category!.toString(), '90071992547409912');
@@ -205,9 +203,7 @@ describe('COLLECTIONS: mongoose Model API level tests with collections', async (
             assert.strictEqual(findOneResponse.nestedSchema!.address!.street, 'street 1');
             assert.strictEqual(findOneResponse.nestedSchema!.address!.city, 'city 1');
             assert.strictEqual(findOneResponse.nestedSchema!.address!.state, 'state 1');
-            // @ts-expect-error Mongoose types don't handle nested maps well
             assert.strictEqual(findOneResponse.nestedMap!.get('key1')!.get('subkey1'), 'value1');
-            // @ts-expect-error Mongoose types don't handle nested maps well
             assert.strictEqual(findOneResponse.nestedMap!.get('key1')!.get('subkey2'), 'value2');
             assert.strictEqual(findOneResponse.uniqueId!.toString(), uniqueIdVal.toString());
             assert.strictEqual(findOneResponse.category!.toString(), '90071992547409912');

--- a/tests/driver/collections.api.test.ts
+++ b/tests/driver/collections.api.test.ts
@@ -24,7 +24,7 @@ import {randomUUID} from 'crypto';
 import { OperationNotSupportedError } from '../../src/operationNotSupportedError';
 import { CartModelType, ProductModelType, productSchema, ProductRawDoc, createMongooseCollections, testDebug } from '../mongooseFixtures';
 import { parseUri } from '../../src/driver/connection';
-import { FindCursor, DataAPIResponseError, DataAPIVector, DataAPIBlob } from '@datastax/astra-db-ts';
+import { FindCursor, DataAPIResponseError } from '@datastax/astra-db-ts';
 import { Long, UUID } from 'bson';
 import type { AstraMongoose } from '../../src';
 

--- a/tests/driver/collections.api.test.ts
+++ b/tests/driver/collections.api.test.ts
@@ -146,7 +146,7 @@ describe('COLLECTIONS: mongoose Model API level tests with collections', async (
                 mixedData: {a: 1, b: 'test'},
                 employee: employeeIdVal,
                 friends: ['friend 1', 'friend 2'],
-                salary: mongoose.Types.Decimal128.fromString('100.25'),
+                salary: mongoose.Types.Decimal128.fromString('90071992547409910.12'), // Number.MAX_SAFE_INTEGER * 10 + 0.12 as string
                 favorites: new Map([['food', 'pizza'], ['drink', 'cola']]),
                 nestedSchema: {
                     address: {
@@ -157,7 +157,7 @@ describe('COLLECTIONS: mongoose Model API level tests with collections', async (
                 },
                 nestedMap: new Map([['key1', new Map([['subkey1', 'value1'], ['subkey2', 'value2']])]]),
                 uniqueId: new UUID(uniqueIdVal),
-                category: BigInt(100),
+                category: BigInt('90071992547409912'), // Number.MAX_SAFE_INTEGER * 10 + 2 as string
                 documentArray: [{ name: 'test document array' }],
                 buf: Buffer.from('hello', 'utf8'),
                 long: new Long(99n),
@@ -172,7 +172,7 @@ describe('COLLECTIONS: mongoose Model API level tests with collections', async (
             assert.strictEqual(saveResponse.employee!.toString(), employeeIdVal.toString());
             assert.strictEqual(saveResponse.friends[0], 'friend 1');
             assert.strictEqual(saveResponse.friends[1], 'friend 2');
-            assert.strictEqual(saveResponse.salary!.toString(), '100.25');
+            assert.strictEqual(saveResponse.salary!.toString(), '90071992547409910.12');
             assert.strictEqual(saveResponse.favorites!.get('food'), 'pizza');
             assert.strictEqual(saveResponse.favorites!.get('drink'), 'cola');
             assert.strictEqual(saveResponse.nestedSchema!.address!.street, 'street 1');
@@ -183,7 +183,7 @@ describe('COLLECTIONS: mongoose Model API level tests with collections', async (
             // @ts-expect-error Mongoose types don't handle nested maps well
             assert.strictEqual(saveResponse.nestedMap!.get('key1')!.get('subkey2'), 'value2');
             assert.strictEqual(saveResponse.uniqueId!.toString(), uniqueIdVal.toString());
-            assert.strictEqual(saveResponse.category!.toString(), '100');
+            assert.strictEqual(saveResponse.category!.toString(), '90071992547409912');
             assert.strictEqual(saveResponse.documentArray[0].name, 'test document array');
             assert.strictEqual(saveResponse.buf!.toString('utf8'), 'hello');
             assert.strictEqual(saveResponse.long!.toString(), '99');
@@ -199,7 +199,7 @@ describe('COLLECTIONS: mongoose Model API level tests with collections', async (
             assert.strictEqual(findOneResponse.employee!.toString(), employeeIdVal.toString());
             assert.strictEqual(findOneResponse.friends[0], 'friend 1');
             assert.strictEqual(findOneResponse.friends[1], 'friend 2');
-            assert.strictEqual(findOneResponse.salary!.toString(), '100.25');
+            assert.strictEqual(findOneResponse.salary!.toString(), '90071992547409910.12');
             assert.strictEqual(findOneResponse.favorites!.get('food'), 'pizza');
             assert.strictEqual(findOneResponse.favorites!.get('drink'), 'cola');
             assert.strictEqual(findOneResponse.nestedSchema!.address!.street, 'street 1');
@@ -210,7 +210,7 @@ describe('COLLECTIONS: mongoose Model API level tests with collections', async (
             // @ts-expect-error Mongoose types don't handle nested maps well
             assert.strictEqual(findOneResponse.nestedMap!.get('key1')!.get('subkey2'), 'value2');
             assert.strictEqual(findOneResponse.uniqueId!.toString(), uniqueIdVal.toString());
-            assert.strictEqual(findOneResponse.category!.toString(), '100');
+            assert.strictEqual(findOneResponse.category!.toString(), '90071992547409912');
             assert.strictEqual(findOneResponse.documentArray[0].name, 'test document array');
             assert.strictEqual(findOneResponse.buf!.toString('utf8'), 'hello');
             assert.strictEqual(findOneResponse.long!.toString(), '99');

--- a/tests/driver/tables.api.test.ts
+++ b/tests/driver/tables.api.test.ts
@@ -18,7 +18,7 @@ import {
 } from '../fixtures';
 import mongoose, { Schema, InferSchemaType, InsertManyResult, IndexDirection } from 'mongoose';
 import * as AstraMongooseDriver from '../../src/driver';
-import {OperationNotSupportedError} from '../../src/driver';
+import { OperationNotSupportedError } from '../../src/operationNotSupportedError';
 import { CartModelType, ProductModelType, productSchema, ProductRawDoc, createMongooseCollections } from '../mongooseFixtures';
 import { parseUri } from '../../src/driver/connection';
 import { DataAPIResponseError } from '@datastax/astra-db-ts';
@@ -628,11 +628,6 @@ describe('TABLES: Mongoose Model API level tests', async () => {
             await assert.rejects(
                 mongooseInstance.createConnection('https://apps.astra.datastax.com/api/json/v1/test?applicationToken=test1&applicationToken=test2', testClient!.options).asPromise(),
                 /Invalid URI: multiple application tokens/
-            );
-
-            await assert.rejects(
-                mongooseInstance.createConnection('https://apps.astra.datastax.com/api/json/v1/test?authHeaderName=test1&authHeaderName=test2', testClient!.options).asPromise(),
-                /Invalid URI: multiple application auth header names/
             );
 
             if (!testClient?.isAstra) {

--- a/tests/driver/tables.test.ts
+++ b/tests/driver/tables.test.ts
@@ -98,7 +98,6 @@ describe('TABLES: basic operations and data types', function() {
             primaryKey: '_id',
             columns: {
                 _id: { type: 'text' },
-                __v: { type: 'int' },
                 name: { type: 'text' },
                 age: { type: 'double' },
                 dob: { type: 'timestamp' },

--- a/tests/driver/tables.test.ts
+++ b/tests/driver/tables.test.ts
@@ -148,7 +148,7 @@ describe('TABLES: basic operations and data types', function() {
             mixedData: {a: 1, b: 'test'},
             employee: employeeIdVal,
             friends: ['friend 1', 'friend 2'],
-            salary: Types.Decimal128.fromString('100.25'),
+            salary: Types.Decimal128.fromString('90071992547409910.12'), // Number.MAX_SAFE_INTEGER * 10 + 0.12 as string
             favorites: new Map([['food', 'pizza'], ['drink', 'cola']]),
             nestedSchema: {
                 address: {
@@ -171,7 +171,7 @@ describe('TABLES: basic operations and data types', function() {
         assert.strictEqual(saveResponse.employee!.toString(), employeeIdVal.toString());
         assert.strictEqual(saveResponse.friends[0], 'friend 1');
         assert.strictEqual(saveResponse.friends[1], 'friend 2');
-        assert.strictEqual(saveResponse.salary!.toString(), '100.25');
+        assert.strictEqual(saveResponse.salary!.toString(), '90071992547409910.12');
         assert.strictEqual(saveResponse.favorites!.get('food'), 'pizza');
         assert.strictEqual(saveResponse.favorites!.get('drink'), 'cola');
         assert.strictEqual(saveResponse.uniqueId!.toString(), uniqueIdVal.toString());
@@ -203,7 +203,7 @@ describe('TABLES: basic operations and data types', function() {
         assert.strictEqual(findOneResponse.employee!.toString(), employeeIdVal.toString());
         assert.strictEqual(findOneResponse.friends[0], 'friend 1');
         assert.strictEqual(findOneResponse.friends[1], 'friend 2');
-        assert.strictEqual(findOneResponse.salary!.toString(), '100.25');
+        assert.strictEqual(findOneResponse.salary!.toString(), '90071992547409910.12');
         assert.strictEqual(findOneResponse.favorites!.get('food'), 'pizza');
         assert.strictEqual(findOneResponse.favorites!.get('drink'), 'cola');
         assert.strictEqual(findOneResponse.uniqueId!.toString(), uniqueIdVal.toString());

--- a/tests/driver/tables.test.ts
+++ b/tests/driver/tables.test.ts
@@ -148,7 +148,7 @@ describe('TABLES: basic operations and data types', function() {
             mixedData: {a: 1, b: 'test'},
             employee: employeeIdVal,
             friends: ['friend 1', 'friend 2'],
-            salary: Types.Decimal128.fromString('90071992547409910.12'), // Number.MAX_SAFE_INTEGER * 10 + 0.12 as string
+            salary: Types.Decimal128.fromString('100.25'),
             favorites: new Map([['food', 'pizza'], ['drink', 'cola']]),
             nestedSchema: {
                 address: {
@@ -171,7 +171,7 @@ describe('TABLES: basic operations and data types', function() {
         assert.strictEqual(saveResponse.employee!.toString(), employeeIdVal.toString());
         assert.strictEqual(saveResponse.friends[0], 'friend 1');
         assert.strictEqual(saveResponse.friends[1], 'friend 2');
-        assert.strictEqual(saveResponse.salary!.toString(), '90071992547409910.12');
+        assert.strictEqual(saveResponse.salary!.toString(), '100.25');
         assert.strictEqual(saveResponse.favorites!.get('food'), 'pizza');
         assert.strictEqual(saveResponse.favorites!.get('drink'), 'cola');
         assert.strictEqual(saveResponse.uniqueId!.toString(), uniqueIdVal.toString());
@@ -203,7 +203,7 @@ describe('TABLES: basic operations and data types', function() {
         assert.strictEqual(findOneResponse.employee!.toString(), employeeIdVal.toString());
         assert.strictEqual(findOneResponse.friends[0], 'friend 1');
         assert.strictEqual(findOneResponse.friends[1], 'friend 2');
-        assert.strictEqual(findOneResponse.salary!.toString(), '90071992547409910.12');
+        assert.strictEqual(findOneResponse.salary!.toString(), '100.25');
         assert.strictEqual(findOneResponse.favorites!.get('food'), 'pizza');
         assert.strictEqual(findOneResponse.favorites!.get('drink'), 'cola');
         assert.strictEqual(findOneResponse.uniqueId!.toString(), uniqueIdVal.toString());

--- a/tests/driver/tables.vector.test.ts
+++ b/tests/driver/tables.vector.test.ts
@@ -262,6 +262,21 @@ describe('TABLES: vectorize', function () {
         );
     });
 
+    it('throws an error if vectorize dimension is negative', async function () {
+        assert.throws(
+            () => {
+                new Vectorize('vector', {
+                    dimension: -1,
+                    service: {
+                        provider: 'nvidia',
+                        modelName: 'NV-Embed-QA'
+                    }
+                });
+            },
+            /`dimension` option for vectorize paths must be a positive integer, got: -1/
+        );
+    });
+
     it('handles required vectorize', async function () {
         const vectorSchema = new Schema<IVector>({ name: 'String' }, { autoCreate: false });
         vectorSchema.path('vector', new Vectorize('vector', {

--- a/tests/parseUri.test.ts
+++ b/tests/parseUri.test.ts
@@ -1,0 +1,82 @@
+// Copyright DataStax, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import assert from 'assert';
+import { parseUri } from '../src/driver/connection';
+
+describe('parseUri', () => {
+    it('parses a standard URI', () => {
+        const uri = 'https://xyz-us-east-2.apps.astra.datastax.com/api/json/v1/ecommerce_dev?applicationToken=AstraCS:ABC123';
+        const result = parseUri(uri);
+        assert.strictEqual(result.baseUrl, 'https://xyz-us-east-2.apps.astra.datastax.com');
+        assert.strictEqual(result.baseApiPath, 'api/json/v1');
+        assert.strictEqual(result.keyspaceName, 'ecommerce_dev');
+        assert.strictEqual(result.applicationToken, 'AstraCS:ABC123');
+    });
+
+    it('parses a URI with multiple path segments', () => {
+        const uri = 'https://xyz-us-east-2.apps.astra.datastax.com/api/json/v1/ecommerce_dev?applicationToken=AstraCS:ABC123';
+        const result = parseUri(uri);
+        assert.strictEqual(result.baseUrl, 'https://xyz-us-east-2.apps.astra.datastax.com');
+        assert.strictEqual(result.baseApiPath, 'api/json/v1');
+        assert.strictEqual(result.keyspaceName, 'ecommerce_dev');
+        assert.strictEqual(result.applicationToken, 'AstraCS:ABC123');
+    });
+
+    it('parses a URI with only keyspace in path', () => {
+        const uri = 'https://xyz-us-east-2.apps.astra.datastax.com/ecommerce_dev?applicationToken=AstraCS:ABC123';
+        const result = parseUri(uri);
+        assert.strictEqual(result.baseUrl, 'https://xyz-us-east-2.apps.astra.datastax.com');
+        assert.strictEqual(result.baseApiPath, '/');
+        assert.strictEqual(result.keyspaceName, 'ecommerce_dev');
+        assert.strictEqual(result.applicationToken, 'AstraCS:ABC123');
+    });
+
+    it('throws if multiple applicationToken params are present', () => {
+        const uri = 'https://xyz-us-east-2.apps.astra.datastax.com/api/json/v1/ecommerce_dev?applicationToken=abc123&applicationToken=def456';
+        assert.throws(() => parseUri(uri), /multiple application tokens/);
+    });
+
+    it('throws if keyspace is missing', () => {
+        const uri = 'https://xyz-us-east-2.apps.astra.datastax.com/?applicationToken=AstraCS:ABC123';
+        assert.throws(() => parseUri(uri), /keyspace is required/);
+    });
+
+    it('handles trailing slash after keyspace', () => {
+        const uri = 'https://xyz-us-east-2.apps.astra.datastax.com/api/json/v1/ecommerce_dev/?applicationToken=AstraCS:ABC123';
+        const result = parseUri(uri);
+        assert.strictEqual(result.baseUrl, 'https://xyz-us-east-2.apps.astra.datastax.com');
+        assert.strictEqual(result.baseApiPath, 'api/json/v1');
+        assert.strictEqual(result.keyspaceName, 'ecommerce_dev');
+        assert.strictEqual(result.applicationToken, 'AstraCS:ABC123');
+    });
+
+    it('handles trailing slash after baseApiPath', () => {
+        const uri = 'https://xyz-us-east-2.apps.astra.datastax.com/api/json/v1/ecommerce_dev/?applicationToken=AstraCS:ABC123';
+        const result = parseUri(uri);
+        assert.strictEqual(result.baseUrl, 'https://xyz-us-east-2.apps.astra.datastax.com');
+        assert.strictEqual(result.baseApiPath, 'api/json/v1');
+        assert.strictEqual(result.keyspaceName, 'ecommerce_dev');
+        assert.strictEqual(result.applicationToken, 'AstraCS:ABC123');
+    });
+
+    it('parses URI with no query params', () => {
+        const uri = 'https://xyz-us-east-2.apps.astra.datastax.com/api/json/v1/ecommerce_dev';
+        const result = parseUri(uri);
+        assert.strictEqual(result.baseUrl, 'https://xyz-us-east-2.apps.astra.datastax.com');
+        assert.strictEqual(result.baseApiPath, 'api/json/v1');
+        assert.strictEqual(result.keyspaceName, 'ecommerce_dev');
+        assert.strictEqual(result.applicationToken, undefined);
+    });
+});

--- a/tests/tableDefinitionFromSchema.test.ts
+++ b/tests/tableDefinitionFromSchema.test.ts
@@ -52,6 +52,24 @@ describe('tableDefinitionFromSchema', () => {
         });
     });
 
+    it('handles custom version key', () => {
+        const testSchema = new Schema(
+            { tags: [String] },
+            { versionKey: 'myVersionKey' }
+        );
+
+        const result = tableDefinitionFromSchema(testSchema);
+
+        assert.deepStrictEqual(result, {
+            primaryKey: '_id',
+            columns: {
+                '_id': { type: 'text' },
+                'myVersionKey': { type: 'int' },
+                'tags': { type: 'list', valueType: 'text' }
+            }
+        });
+    })
+
     it('generates table definition from schema with array of primitives', () => {
         const testSchema = new Schema({
             tags: [String]

--- a/tests/tableDefinitionFromSchema.test.ts
+++ b/tests/tableDefinitionFromSchema.test.ts
@@ -52,24 +52,6 @@ describe('tableDefinitionFromSchema', () => {
         });
     });
 
-    it('handles custom version key', () => {
-        const testSchema = new Schema(
-            { tags: [String] },
-            { versionKey: 'myVersionKey' }
-        );
-
-        const result = tableDefinitionFromSchema(testSchema);
-
-        assert.deepStrictEqual(result, {
-            primaryKey: '_id',
-            columns: {
-                '_id': { type: 'text' },
-                'myVersionKey': { type: 'int' },
-                'tags': { type: 'list', valueType: 'text' }
-            }
-        });
-    })
-
     it('generates table definition from schema with array of primitives', () => {
         const testSchema = new Schema({
             tags: [String]
@@ -339,6 +321,24 @@ describe('tableDefinitionFromSchema', () => {
             tableDefinitionFromSchema(testSchema);
         }, {
             message: 'Cannot convert schema to Data API table definition: vector column at "arr" must be an array of numbers'
+        });
+    });
+
+    it('handles custom version key', () => {
+        const testSchema = new Schema(
+            { tags: [String] },
+            { versionKey: 'myVersionKey' }
+        );
+
+        const result = tableDefinitionFromSchema(testSchema);
+
+        assert.deepStrictEqual(result, {
+            primaryKey: '_id',
+            columns: {
+                '_id': { type: 'text' },
+                'myVersionKey': { type: 'int' },
+                'tags': { type: 'list', valueType: 'text' }
+            }
         });
     });
 });


### PR DESCRIPTION
Several bug fixes:

1. Serialize nested maps in collections
2. Throw error on non-positive `dimensions`
3. Remove `authHeaderName` connection string parameter - astra-mongoose doesn't use it anywhere
4. Use `OperationNotSupportedError` for `dropDatabase()`
5. Clone `service` option when cloning vectorize
6. Serialize and deserialize documents in findAndRerank
7. In collections, store Decimal128 as string for consistency with bigint and precision issues
8. Respect `versionKey` option in tableDefinitionFromSchema

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
9. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)