### PR TITLE
fix publish script for dse-server changes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,6 @@ jobs:
       - name: Wait for services
         run: |
           while ! nc -z localhost 8181; do sleep 1; done
-          while ! nc -z localhost 8081; do sleep 1; done
       - name: Setting up the node version
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

New dse-server based `start_data_api.sh` no longer exposes port 8081, so publish.yml hangs forever. See https://github.com/stargate/stargate-mongoose/actions/runs/17810611508/job/50633254363 as an example.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)