### PR TITLE
add connection-level helpers for UDTs

### DIFF
--- a/APIReference.md
+++ b/APIReference.md
@@ -354,6 +354,11 @@ connection to Data API.</p>
     * [.createKeyspace(name)](#Connection+createKeyspace)
     * [.listCollections()](#Connection+listCollections)
     * [.listTables()](#Connection+listTables)
+    * [.listTypes()](#Connection+listTypes) ⇒
+    * [.createType(name, definition)](#Connection+createType) ⇒ <code>Promise.&lt;TypeDescriptor&gt;</code>
+    * [.dropType(name)](#Connection+dropType) ⇒
+    * [.alterType(name, update)](#Connection+alterType) ⇒
+    * [.syncTypes(types)](#Connection+syncTypes) ⇒
     * [.runCommand(command)](#Connection+runCommand)
     * [.listDatabases()](#Connection+listDatabases)
     * [.openUri(uri, options)](#Connection+openUri)
@@ -447,6 +452,69 @@ connection to Data API.</p>
 <p>List all tables in the database</p>
 
 **Kind**: instance method of [<code>Connection</code>](#Connection)  
+<a name="Connection+listTypes"></a>
+
+### connection.listTypes() ⇒
+<p>List all user-defined types (UDTs) in the database.</p>
+
+**Kind**: instance method of [<code>Connection</code>](#Connection)  
+**Returns**: <p>An array of type descriptors.</p>  
+<a name="Connection+createType"></a>
+
+### connection.createType(name, definition) ⇒ <code>Promise.&lt;TypeDescriptor&gt;</code>
+<p>Create a new user-defined type (UDT) with the specified name and fields definition.</p>
+
+**Kind**: instance method of [<code>Connection</code>](#Connection)  
+**Returns**: <code>Promise.&lt;TypeDescriptor&gt;</code> - <p>The created type descriptor.</p>  
+
+| Param | Description |
+| --- | --- |
+| name | <p>The name of the type to create.</p> |
+| definition | <p>The definition of the fields for the type.</p> |
+
+<a name="Connection+dropType"></a>
+
+### connection.dropType(name) ⇒
+<p>Drop (delete) a user-defined type (UDT) by name.</p>
+
+**Kind**: instance method of [<code>Connection</code>](#Connection)  
+**Returns**: <p>The result of the dropType command.</p>  
+
+| Param | Description |
+| --- | --- |
+| name | <p>The name of the type to drop.</p> |
+
+<a name="Connection+alterType"></a>
+
+### connection.alterType(name, update) ⇒
+<p>Alter a user-defined type (UDT) by renaming or adding fields.</p>
+
+**Kind**: instance method of [<code>Connection</code>](#Connection)  
+**Returns**: <p>The result of the alterType command.</p>  
+
+| Param | Description |
+| --- | --- |
+| name | <p>The name of the type to alter.</p> |
+| update | <p>The alterations to be made: renaming or adding fields.</p> |
+
+<a name="Connection+syncTypes"></a>
+
+### connection.syncTypes(types) ⇒
+<p>Synchronizes the set of user-defined types (UDTs) in the database. It makes existing types in the database
+match the list provided by <code>types</code>. New types that are missing are created, and types that exist in the database
+but are not in the input list are dropped. If a type is present in both, we add all the new type's fields to the existing type.</p>
+
+**Kind**: instance method of [<code>Connection</code>](#Connection)  
+**Returns**: <p>An object describing which types were created, updated, or dropped.</p>  
+**Throws**:
+
+- [<code>AstraMongooseError</code>](#AstraMongooseError) <p>If an error occurs during type synchronization, with partial progress information in the error.</p>
+
+
+| Param | Description |
+| --- | --- |
+| types | <p>An array of objects each specifying the name and CreateTypeDefinition for a UDT to synchronize.</p> |
+
 <a name="Connection+runCommand"></a>
 
 ### connection.runCommand(command)

--- a/src/driver/connection.ts
+++ b/src/driver/connection.ts
@@ -270,7 +270,7 @@ export class Connection extends MongooseConnection {
      * Create a new user-defined type (UDT) with the specified name and fields definition.
      * @param name The name of the type to create.
      * @param definition The definition of the fields for the type.
-     * @returns The result of the createType command.
+     * @returns {Promise<TypeDescriptor>} The created type descriptor.
      */
     async createType(name: string, definition: CreateTypeDefinition) {
         const { db } = await this._waitForClient();

--- a/tests/driver/tables.test.ts
+++ b/tests/driver/tables.test.ts
@@ -235,11 +235,9 @@ describe('TABLES: basic operations and data types', function() {
     describe('UDTs', () => {
         beforeEach(async () => {
             await mongooseInstance.connection.dropTable(TEST_TABLE_NAME);
-            const db = mongooseInstance.connection.db;
-            assert.ok(db);
-            const types = await db.listTypes({ nameOnly: true });
+            const types = await mongooseInstance.connection.listTypes({ nameOnly: true });
             for (const type of types) {
-                await db.dropType(type);
+                await mongooseInstance.connection.dropType(type);
             }
 
             mongooseInstance.deleteModel(/Test/);
@@ -247,43 +245,38 @@ describe('TABLES: basic operations and data types', function() {
 
         afterEach(async () => {
             await mongooseInstance.connection.dropTable(TEST_TABLE_NAME);
-            const db = mongooseInstance.connection.db;
-            assert.ok(db);
-            const types = await db.listTypes({ nameOnly: true });
+            const types = await mongooseInstance.connection.listTypes({ nameOnly: true });
             for (const type of types) {
-                await db.dropType(type);
+                await mongooseInstance.connection.dropType(type);
             }
         });
 
         it('supports creating and altering UDTs', async () => {
-            const db = mongooseInstance.connection.db;
-            assert.ok(db);
-
-            await db.createType('ProductType', {
+            await mongooseInstance.connection.createType('ProductType', {
                 fields: {
                     name: { type: 'text' },
                     price: { type: 'int' }
                 }
             });
 
-            const typeNames = await db.listTypes({ nameOnly: true });
+            const typeNames = await mongooseInstance.connection.listTypes({ nameOnly: true });
             assert.deepStrictEqual(typeNames, ['ProductType']);
 
-            const typeDefs = await db.listTypes({ nameOnly: false });
+            const typeDefs = await mongooseInstance.connection.listTypes({ nameOnly: false });
             assert.deepStrictEqual(typeDefs.map((def) => def.definition!.fields), [{
                 name: { type: 'text' },
                 price: { type: 'int' }
             }]);
 
             // Test altering the type to add a new "category" field
-            await db.alterType('ProductType', {
+            await mongooseInstance.connection.alterType('ProductType', {
                 operation: {
                     add: { fields: { category: { type: 'text' } } }
                 }
             });
 
             // Verify the field is present after alteration
-            const typeDefsAfterAlter = await db.listTypes({ nameOnly: false });
+            const typeDefsAfterAlter = await mongooseInstance.connection.listTypes({ nameOnly: false });
             assert.deepStrictEqual(typeDefsAfterAlter.map((def) => def.definition!.fields), [{
                 name: { type: 'text' },
                 price: { type: 'int' },
@@ -292,9 +285,6 @@ describe('TABLES: basic operations and data types', function() {
         });
 
         it('handles UDTs created from a schema definition', async () => {
-            const db = mongooseInstance.connection.db;
-            assert.ok(db);
-
             const productSchema = new Schema(
                 {
                     name: { type: String },
@@ -304,8 +294,8 @@ describe('TABLES: basic operations and data types', function() {
                 { udtName: 'Product', versionKey: false, _id: false }
             );
 
-            await db.createType('Product', { fields: convertSchemaToUDTColumns(productSchema) });
-            const typeDefs = await db.listTypes({ nameOnly: false });
+            await mongooseInstance.connection.createType('Product', { fields: convertSchemaToUDTColumns(productSchema) });
+            const typeDefs = await mongooseInstance.connection.listTypes({ nameOnly: false });
             assert.deepStrictEqual(typeDefs.map((def) => def.definition!.fields), [{
                 name: { type: 'text' },
                 price: { type: 'double' },
@@ -339,9 +329,6 @@ describe('TABLES: basic operations and data types', function() {
         });
 
         it('handles UDTs created from a schema definition with udtName', async () => {
-            const db = mongooseInstance.connection.db;
-            assert.ok(db);
-
             const productSchema = new Schema(
                 {
                     name: { type: String },
@@ -351,8 +338,8 @@ describe('TABLES: basic operations and data types', function() {
                 { versionKey: false, _id: false }
             );
 
-            await db.createType('Product', { fields: convertSchemaToUDTColumns(productSchema) });
-            const typeDefs = await db.listTypes({ nameOnly: false });
+            await mongooseInstance.connection.createType('Product', { fields: convertSchemaToUDTColumns(productSchema) });
+            const typeDefs = await mongooseInstance.connection.listTypes({ nameOnly: false });
             assert.deepStrictEqual(typeDefs.map((def) => def.definition!.fields), [{
                 name: { type: 'text' },
                 price: { type: 'double' },
@@ -386,9 +373,6 @@ describe('TABLES: basic operations and data types', function() {
         });
 
         it('handles set of UDTs created from a schema definition', async () => {
-            const db = mongooseInstance.connection.db;
-            assert.ok(db);
-
             const productSchema = new Schema(
                 {
                     name: { type: String },
@@ -398,8 +382,8 @@ describe('TABLES: basic operations and data types', function() {
                 { udtName: 'Product', versionKey: false, _id: false }
             );
 
-            await db.createType('Product', { fields: convertSchemaToUDTColumns(productSchema) });
-            const typeDefs = await db.listTypes();
+            await mongooseInstance.connection.createType('Product', { fields: convertSchemaToUDTColumns(productSchema) });
+            const typeDefs = await mongooseInstance.connection.listTypes();
             assert.deepStrictEqual(typeDefs.map((def) => def.definition!.fields), [{
                 name: { type: 'text' },
                 price: { type: 'double' },
@@ -438,9 +422,6 @@ describe('TABLES: basic operations and data types', function() {
         });
 
         it('handles map of UDTs created from a schema definition', async () => {
-            const db = mongooseInstance.connection.db;
-            assert.ok(db);
-
             const productSchema = new Schema(
                 {
                     name: { type: String },
@@ -450,8 +431,8 @@ describe('TABLES: basic operations and data types', function() {
                 { udtName: 'Product', versionKey: false, _id: false }
             );
 
-            await db.createType('Product', { fields: convertSchemaToUDTColumns(productSchema) });
-            const typeDefs = await db.listTypes();
+            await mongooseInstance.connection.createType('Product', { fields: convertSchemaToUDTColumns(productSchema) });
+            const typeDefs = await mongooseInstance.connection.listTypes();
             assert.deepStrictEqual(typeDefs.map((def) => def.definition!.fields), [{
                 name: { type: 'text' },
                 price: { type: 'double' },
@@ -491,9 +472,6 @@ describe('TABLES: basic operations and data types', function() {
 
         it('syncTypes handles creating, dropping, and updating UDTs based on udtDefinitionsFromSchema', async () => {
             // Test syncTypes and udtDefinitionsFromSchema
-            const db = mongooseInstance.connection.db;
-            assert.ok(db);
-
             // Step 1: Define two UDT schemas
             const pageSchema = new Schema(
                 {
@@ -522,44 +500,44 @@ describe('TABLES: basic operations and data types', function() {
             assert.ok(productUdtDefinitions['Product']);
 
             // First, ensure a clean slate
-            const typesAtStart = await db.listTypes({ nameOnly: true });
+            const typesAtStart = await mongooseInstance.connection.listTypes({ nameOnly: true });
             for (const type of typesAtStart) {
-                await db.dropType(type);
+                await mongooseInstance.connection.dropType(type);
             }
-            let currTypes = await db.listTypes({ nameOnly: true });
+            let currTypes = await mongooseInstance.connection.listTypes({ nameOnly: true });
             assert.deepStrictEqual(currTypes, []);
 
             // Step 3: create a UDT that will be dropped and a Page UDT with slightly different fields
-            await db.createType('Page', {
+            await mongooseInstance.connection.createType('Page', {
                 fields: {
                     title: { type: 'text' },
                     content: { type: 'text' }
                 }
             });
 
-            await db.createType('Taco', {
+            await mongooseInstance.connection.createType('Taco', {
                 fields: {
                     name: { type: 'text' },
                     price: { type: 'decimal' }
                 }
             });
 
-            currTypes = await db.listTypes({ nameOnly: true });
+            currTypes = await mongooseInstance.connection.listTypes({ nameOnly: true });
             assert.deepStrictEqual(currTypes, ['Page', 'Taco']);
 
             // Step 3: Use syncTypes to create the Brand and Product UDTs
             const typesToSync = Object.entries(productUdtDefinitions).map(([name, def]) => ({ name, definition: def }));
-            const syncResult1 = await db.syncTypes(typesToSync);
+            const syncResult1 = await mongooseInstance.connection.syncTypes(typesToSync);
             assert.deepStrictEqual(syncResult1.created.sort(), ['Product']);
             assert.deepStrictEqual(syncResult1.updated.sort(), ['Page']);
             assert.deepStrictEqual(syncResult1.dropped.sort(), ['Taco']);
 
             // Check that types now exist
-            const currTypes2 = await db.listTypes({ nameOnly: true });
+            const currTypes2 = await mongooseInstance.connection.listTypes({ nameOnly: true });
             assert.deepStrictEqual(currTypes2.sort(), ['Page', 'Product'].sort());
 
             // Verify Brand has new field
-            const typeDefs = await db.listTypes({ nameOnly: false });
+            const typeDefs = await mongooseInstance.connection.listTypes({ nameOnly: false });
             const brandDef = typeDefs.find(def => def.name === 'Page');
             assert.deepStrictEqual(brandDef?.definition?.fields, {
                 title: { type: 'text' },
@@ -571,7 +549,7 @@ describe('TABLES: basic operations and data types', function() {
             // Step 4: test syncTypes updating an existing field with an incompatible type
             (typesToSync[0].definition.fields['title'] as TableScalarColumnDefinition).type = 'float';
             await assert.rejects(
-                () => db.syncTypes(typesToSync),
+                () => mongooseInstance.connection.syncTypes(typesToSync),
                 /Error in syncTypes: Field 'title' in type 'Page' exists with different type. \(current: text, new: float\)/
             );
         });

--- a/tests/driver/tables.vector.test.ts
+++ b/tests/driver/tables.vector.test.ts
@@ -359,4 +359,8 @@ describe('TABLES: vectorize', function () {
             });
         }, /`provider` option for vectorize paths must be a string, got: undefined/);
     });
+
+    it('throws error on findAndRerank', async function () {
+        await assert.rejects(() => Vector.findAndRerank({}, {}), /Cannot use findAndRerank\(\) with tables/);
+    });
 });


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Allow users to use `mongoose.connection.createType()` instead of `mongoose.connection.db!.createType()`, which is more consistent with the rest of the API.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)