### PR TITLE
add syncTable() to support modifying existing tables to match schema

### DIFF
--- a/APIReference.md
+++ b/APIReference.md
@@ -84,6 +84,8 @@ an Astra perspective, this class can be a wrapper around a Collection <strong>or
     * [.updateOne(filter, update, options)](#Collection+updateOne)
     * [.updateMany(filter, update, options)](#Collection+updateMany)
     * [.estimatedDocumentCount()](#Collection+estimatedDocumentCount)
+    * [.syncTable(definition, options)](#Collection+syncTable) ⇒
+    * [.alterTable(operation)](#Collection+alterTable)
     * [.runCommand(command)](#Collection+runCommand)
     * [.bulkWrite(ops, options)](#Collection+bulkWrite)
     * [.aggregate(pipeline, options)](#Collection+aggregate)
@@ -259,6 +261,33 @@ Converted to a <code>findOneAndReplace()</code> under the hood.</p>
 <p>Get the estimated number of documents in a collection based on collection metadata</p>
 
 **Kind**: instance method of [<code>Collection</code>](#Collection)  
+<a name="Collection+syncTable"></a>
+
+### collection.syncTable(definition, options) ⇒
+<p>Sync the underlying table schema with the specified definition: creates a new
+table if one doesn't exist, or alters the existing table to match the definition
+by adding or dropping columns as necessary.</p>
+<p>Note that modifying an existing column is NOT supported and will throw an error.</p>
+
+**Kind**: instance method of [<code>Collection</code>](#Collection)  
+**Returns**: <p>void</p>  
+
+| Param | Description |
+| --- | --- |
+| definition | <p>new table definition (strict only)</p> |
+| options | <p>passed to createTable if the table doesn't exist</p> |
+
+<a name="Collection+alterTable"></a>
+
+### collection.alterTable(operation)
+<p>Alter the underlying table with the specified name and operation - can add or drop columns</p>
+
+**Kind**: instance method of [<code>Collection</code>](#Collection)  
+
+| Param | Description |
+| --- | --- |
+| operation | <p>add/drop</p> |
+
 <a name="Collection+runCommand"></a>
 
 ### collection.runCommand(command)

--- a/src/convertSchemaToColumns.ts
+++ b/src/convertSchemaToColumns.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { CreateTableColumnDefinitions } from '@datastax/astra-db-ts';
+import { StrictCreateTableColumnDefinition } from '@datastax/astra-db-ts';
 import { Schema, SchemaType } from 'mongoose';
 import { AstraMongooseError } from './astraMongooseError';
 import getUDTNameFromSchemaType from './udt/getUDTNameFromSchemaType';
@@ -22,9 +22,12 @@ type AllowedDataAPITypes = 'text' | 'double' | 'timestamp' | 'boolean' | 'decima
 /**
  * Given a Mongoose schema, create an equivalent Data API table definition for use with `createTable()`
  */
-export default function convertSchemaToColumns(schema: Schema, udtName?: string): CreateTableColumnDefinitions {
+export default function convertSchemaToColumns(
+    schema: Schema,
+    udtName?: string
+): Record<string, StrictCreateTableColumnDefinition> {
     const versionKey = schema.options.versionKey;
-    const columns: CreateTableColumnDefinitions = {};
+    const columns: Record<string, StrictCreateTableColumnDefinition> = {};
     if (schema.options._id !== false) {
         columns._id = { type: 'text' };
     }

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -446,7 +446,7 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
             return JSON.stringify(existingTable.definition.columns[column]) !== JSON.stringify(definition.columns[column]);
         });
         if (columnsToModify.length > 0) {
-            throw new AstraMongooseError('syncTables cannot modify existing columns, found modified columns: ' + columnsToModify.join(', '));
+            throw new AstraMongooseError('syncTable cannot modify existing columns, found modified columns: ' + columnsToModify.join(', '));
         }
 
         const add = Object.fromEntries(

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -453,9 +453,11 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
             columnsToAdd.map(name => [name, definition.columns[name]])
         );
 
-        await this.alterTable({
-            add: { columns: add }
-        });
+        if (columnsToAdd.length > 0) {
+            await this.alterTable({
+                add: { columns: add }
+            });
+        }
         if (columnsToDrop.length > 0) {
             await this.alterTable({
                 drop: { columns: columnsToDrop }

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -443,7 +443,7 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
 
         const overlappingColumnNames = existingColumnNames.filter(column => newColumnNames.includes(column));
         const columnsToModify = overlappingColumnNames.filter(column => {
-            return JSON.stringify(existingTable.definition.columns[column]) !== JSON.stringify(definition.columns[column])
+            return JSON.stringify(existingTable.definition.columns[column]) !== JSON.stringify(definition.columns[column]);
         });
         if (columnsToModify.length > 0) {
             throw new AstraMongooseError('syncTables cannot modify existing columns, found modified columns: ' + columnsToModify.join(', '));

--- a/src/driver/db.ts
+++ b/src/driver/db.ts
@@ -34,8 +34,7 @@ import {
     Table as AstraTable,
     TableDescriptor,
     TableOptions,
-    TypeDescriptor,
-    StrictCreateTableColumnDefinition
+    TypeDescriptor
 } from '@datastax/astra-db-ts';
 import { AstraMongooseError } from '../astraMongooseError';
 import assert from 'assert';

--- a/src/driver/db.ts
+++ b/src/driver/db.ts
@@ -34,7 +34,8 @@ import {
     Table as AstraTable,
     TableDescriptor,
     TableOptions,
-    TypeDescriptor
+    TypeDescriptor,
+    StrictCreateTableColumnDefinition
 } from '@datastax/astra-db-ts';
 import { AstraMongooseError } from '../astraMongooseError';
 import assert from 'assert';

--- a/src/tableDefinitionFromSchema.ts
+++ b/src/tableDefinitionFromSchema.ts
@@ -12,14 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { CreateTableDefinition } from '@datastax/astra-db-ts';
+import { CreateTableDefinition, StrictCreateTableColumnDefinition } from '@datastax/astra-db-ts';
 import { Schema } from 'mongoose';
 import convertSchemaToColumns from './convertSchemaToColumns';
 
 /**
  * Given a Mongoose schema, create an equivalent Data API table definition for use with `createTable()`
  */
-export default function tableDefinitionFromSchema(schema: Schema): CreateTableDefinition {
+export default function tableDefinitionFromSchema(
+    schema: Schema
+): CreateTableDefinition & { columns: Record<string, StrictCreateTableColumnDefinition> } {
     return {
         primaryKey: '_id',
         columns: convertSchemaToColumns(schema)

--- a/tests/driver/tables.test.ts
+++ b/tests/driver/tables.test.ts
@@ -271,7 +271,7 @@ describe('TABLES: basic operations and data types', function() {
 
         await assert.rejects(
             collection.syncTable(tableDefinition),
-            /syncTables cannot modify existing columns, found modified columns: email/
+            /syncTable cannot modify existing columns, found modified columns: email/
         );
     });
 

--- a/tests/driver/tables.test.ts
+++ b/tests/driver/tables.test.ts
@@ -232,6 +232,49 @@ describe('TABLES: basic operations and data types', function() {
         assert.strictEqual(findOneResponse.get('timeOfDay'), '13:00:00.000000000');
     });
 
+    it('syncTable', async () => {
+        const userSchema = new Schema({
+            name: String,
+            age: Number
+        }, { versionKey: false });
+        await mongooseInstance.connection.dropTable(TEST_TABLE_NAME);
+        let tableDefinition = tableDefinitionFromSchema(userSchema);
+
+        const collection = mongooseInstance.connection.collection(TEST_TABLE_NAME);
+        await collection.syncTable(tableDefinition);
+
+        let tables = await mongooseInstance.connection.listTables();
+        let table = tables.find(t => t.name === TEST_TABLE_NAME);
+        assert.ok(table);
+        assert.strictEqual(table.name, TEST_TABLE_NAME);
+        assert.deepStrictEqual(Object.keys(table.definition.columns).sort(), ['_id', 'age', 'name']);
+
+        const updatedUserSchema = new Schema({
+            name: String,
+            email: String
+        }, { versionKey: false });
+        tableDefinition = tableDefinitionFromSchema(updatedUserSchema);
+
+        await collection.syncTable(tableDefinition);
+
+        tables = await mongooseInstance.connection.listTables();
+        table = tables.find(t => t.name === TEST_TABLE_NAME);
+        assert.ok(table);
+        assert.strictEqual(table.name, TEST_TABLE_NAME);
+        assert.deepStrictEqual(Object.keys(table.definition.columns).sort(), ['_id', 'email', 'name']);
+
+        const updateExistingSchema = new Schema({
+            name: String,
+            email: Number
+        }, { versionKey: false });
+        tableDefinition = tableDefinitionFromSchema(updateExistingSchema);
+
+        await assert.rejects(
+            collection.syncTable(tableDefinition),
+            /syncTables cannot modify existing columns, found modified columns: email/
+        );
+    });
+
     describe('UDTs', () => {
         beforeEach(async () => {
             await mongooseInstance.connection.dropTable(TEST_TABLE_NAME);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Adds `alterTable()` and `syncTable()` to collections to enable modifying existing tables by adding/dropping columns

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)