### PR TITLE
improve async stack traces by making explicit `await` on astra-db-ts calls

### DIFF
--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -161,7 +161,8 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
             throw new OperationNotSupportedError('Cannot use countDocuments() with tables');
         }
         filter = serialize(filter);
-        return this.collection.countDocuments(filter, 1000, options);
+        const result = await this.collection.countDocuments(filter, 1000, options);
+        return result;
     }
 
     /**
@@ -196,7 +197,8 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
 
         filter = serialize(filter, this.isTable);
 
-        return this.collection.findOne(filter, requestOptions).then(doc => deserializeDoc<DocType>(doc));
+        const result = await this.collection.findOne(filter, requestOptions).then(doc => deserializeDoc<DocType>(doc));
+        return result;
     }
 
     /**
@@ -206,7 +208,8 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
     async insertOne(doc: Record<string, unknown>, options?: CollectionInsertOneOptions | TableInsertOneOptions) {
         // eslint-disable-next-line prefer-rest-params
         _logFunctionCall(this.connection.debug, this.name, 'insertOne', arguments);
-        return this.collection.insertOne(serialize(doc, this.isTable) as DocType, options);
+        const result = await this.collection.insertOne(serialize(doc, this.isTable) as DocType, options);
+        return result;
     }
 
     /**
@@ -218,7 +221,8 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
         // eslint-disable-next-line prefer-rest-params
         _logFunctionCall(this.connection.debug, this.name, 'insertMany', arguments);
         documents = documents.map(doc => serialize(doc, this.isTable));
-        return this.collection.insertMany(documents as DocType[], options);
+        const result = await this.collection.insertMany(documents as DocType[], options);
+        return result;
     }
 
     /**
@@ -241,12 +245,13 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
         setDefaultIdForUpdate<DocType>(filter, update, requestOptions);
         update = serialize(update);
 
-        return this.collection.findOneAndUpdate(filter, update, requestOptions).then((value: Record<string, unknown> | null) => {
+        const result = await this.collection.findOneAndUpdate(filter, update, requestOptions).then((value: Record<string, unknown> | null) => {
             if (options?.includeResultMetadata) {
                 return { value: deserializeDoc<DocType>(value) };
             }
             return deserializeDoc<DocType>(value);
         });
+        return result;
     }
 
     /**
@@ -265,12 +270,13 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
             : { ...options, sort: undefined };
         filter = serialize(filter);
 
-        return this.collection.findOneAndDelete(filter, requestOptions).then((value: Record<string, unknown> | null) => {
+        const result = await this.collection.findOneAndDelete(filter, requestOptions).then((value: Record<string, unknown> | null) => {
             if (options?.includeResultMetadata) {
                 return { value: deserializeDoc<DocType>(value) };
             }
             return deserializeDoc<DocType>(value);
         });
+        return result;
     }
 
     /**
@@ -292,12 +298,13 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
         setDefaultIdForReplace(filter, newDoc, requestOptions);
         newDoc = serialize(newDoc);
 
-        return this.collection.findOneAndReplace(filter, newDoc, requestOptions).then((value: Record<string, unknown> | null) => {
+        const result = await this.collection.findOneAndReplace(filter, newDoc, requestOptions).then((value: Record<string, unknown> | null) => {
             if (options?.includeResultMetadata) {
                 return { value: deserializeDoc<DocType>(value) };
             }
             return deserializeDoc<DocType>(value);
         });
+        return result;
     }
 
     /**
@@ -308,7 +315,8 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
         // eslint-disable-next-line prefer-rest-params
         _logFunctionCall(this.connection.debug, this.name, 'deleteMany', arguments);
         filter = serialize(filter, this.isTable);
-        return this.collection.deleteMany(filter, options);
+        const result = await this.collection.deleteMany(filter, options);
+        return result;
     }
 
     /**
@@ -324,7 +332,8 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
             ? { ...options, sort: processSortOption(options.sort) }
             : { ...options, sort: undefined };
         filter = serialize(filter, this.isTable);
-        return this.collection.deleteOne(filter as TableFilter<DocType>, requestOptions);
+        const result = await this.collection.deleteOne(filter as TableFilter<DocType>, requestOptions);
+        return result;
     }
 
     /**
@@ -346,7 +355,8 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
         filter = serialize(filter);
         setDefaultIdForReplace(filter, replacement, requestOptions);
         replacement = serialize(replacement);
-        return this.collection.replaceOne(filter, replacement, requestOptions);
+        const result = await this.collection.replaceOne(filter, replacement, requestOptions);
+        return result;
     }
 
     /**
@@ -369,11 +379,12 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
             setDefaultIdForUpdate(filter, update as CollectionUpdateFilter<DocType>, requestOptions);
         }
         update = serialize(update, this.isTable);
-        return this.collection.updateOne(filter as TableFilter<DocType>, update, requestOptions).then(res => {
+        const result = await this.collection.updateOne(filter as TableFilter<DocType>, update, requestOptions).then(res => {
             // Mongoose currently has a bug where null response from updateOne() throws an error that we can't
             // catch here for unknown reasons. See Automattic/mongoose#15126. Tables API returns null here.
             return res ?? {};
         });
+        return result;
     }
 
     /**
@@ -391,7 +402,8 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
         filter = serialize(filter, this.isTable);
         setDefaultIdForUpdate(filter, update, options);
         update = serialize(update, this.isTable);
-        return this.collection.updateMany(filter, update, options);
+        const result = await this.collection.updateMany(filter, update, options);
+        return result;
     }
 
     /**
@@ -403,7 +415,8 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
         if (this.collection instanceof AstraTable) {
             throw new OperationNotSupportedError('Cannot use estimatedDocumentCount() with tables');
         }
-        return this.collection.estimatedDocumentCount(options);
+        const result = await this.collection.estimatedDocumentCount(options);
+        return result;
     }
 
     /**
@@ -413,10 +426,11 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
     async runCommand(command: Record<string, unknown>, options?: Omit<RunCommandOptions, 'table' | 'collection' | 'keyspace'>) {
         // eslint-disable-next-line prefer-rest-params
         _logFunctionCall(this.connection.debug, this.name, 'runCommand', arguments);
-        return this.connection.db!.astraDb.command(
+        const result = await this.connection.db!.astraDb.command(
             command,
             this.isTable ? { table: this.name, ...options } : { collection: this.name, ...options }
         );
+        return result;
     }
 
     /**

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -135,10 +135,10 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
         this._collection = collection;
 
         // Bubble up collection-level events from astra-db-ts to the main connection
-        collection.on('commandStarted', ev => this.connection.emit('commandStarted', ev));
-        collection.on('commandFailed', ev => this.connection.emit('commandFailed', ev));
-        collection.on('commandSucceeded', ev => this.connection.emit('commandSucceeded', ev));
-        collection.on('commandWarnings', ev => this.connection.emit('commandWarnings', ev));
+        collection.on('commandStarted', (ev) => this.connection.emit('commandStarted', ev));
+        collection.on('commandFailed', (ev) => this.connection.emit('commandFailed', ev));
+        collection.on('commandSucceeded', (ev) => this.connection.emit('commandSucceeded', ev));
+        collection.on('commandWarnings', (ev) => this.connection.emit('commandWarnings', ev));
 
         return collection;
     }
@@ -161,8 +161,7 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
             throw new OperationNotSupportedError('Cannot use countDocuments() with tables');
         }
         filter = serialize(filter);
-        const result = await this.collection.countDocuments(filter, 1000, options);
-        return result;
+        return await this.collection.countDocuments(filter, 1000, options);
     }
 
     /**
@@ -197,8 +196,7 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
 
         filter = serialize(filter, this.isTable);
 
-        const result = await this.collection.findOne(filter, requestOptions).then(doc => deserializeDoc<DocType>(doc));
-        return result;
+        return await this.collection.findOne(filter, requestOptions).then(doc => deserializeDoc<DocType>(doc));
     }
 
     /**
@@ -208,8 +206,7 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
     async insertOne(doc: Record<string, unknown>, options?: CollectionInsertOneOptions | TableInsertOneOptions) {
         // eslint-disable-next-line prefer-rest-params
         _logFunctionCall(this.connection.debug, this.name, 'insertOne', arguments);
-        const result = await this.collection.insertOne(serialize(doc, this.isTable) as DocType, options);
-        return result;
+        return await this.collection.insertOne(serialize(doc, this.isTable) as DocType, options);
     }
 
     /**
@@ -221,8 +218,7 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
         // eslint-disable-next-line prefer-rest-params
         _logFunctionCall(this.connection.debug, this.name, 'insertMany', arguments);
         documents = documents.map(doc => serialize(doc, this.isTable));
-        const result = await this.collection.insertMany(documents as DocType[], options);
-        return result;
+        return await this.collection.insertMany(documents as DocType[], options);
     }
 
     /**
@@ -245,13 +241,12 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
         setDefaultIdForUpdate<DocType>(filter, update, requestOptions);
         update = serialize(update);
 
-        const result = await this.collection.findOneAndUpdate(filter, update, requestOptions).then((value: Record<string, unknown> | null) => {
+        return await this.collection.findOneAndUpdate(filter, update, requestOptions).then((value: Record<string, unknown> | null) => {
             if (options?.includeResultMetadata) {
                 return { value: deserializeDoc<DocType>(value) };
             }
             return deserializeDoc<DocType>(value);
         });
-        return result;
     }
 
     /**
@@ -270,13 +265,12 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
             : { ...options, sort: undefined };
         filter = serialize(filter);
 
-        const result = await this.collection.findOneAndDelete(filter, requestOptions).then((value: Record<string, unknown> | null) => {
+        return await this.collection.findOneAndDelete(filter, requestOptions).then((value: Record<string, unknown> | null) => {
             if (options?.includeResultMetadata) {
                 return { value: deserializeDoc<DocType>(value) };
             }
             return deserializeDoc<DocType>(value);
         });
-        return result;
     }
 
     /**
@@ -298,13 +292,12 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
         setDefaultIdForReplace(filter, newDoc, requestOptions);
         newDoc = serialize(newDoc);
 
-        const result = await this.collection.findOneAndReplace(filter, newDoc, requestOptions).then((value: Record<string, unknown> | null) => {
+        return await this.collection.findOneAndReplace(filter, newDoc, requestOptions).then((value: Record<string, unknown> | null) => {
             if (options?.includeResultMetadata) {
                 return { value: deserializeDoc<DocType>(value) };
             }
             return deserializeDoc<DocType>(value);
         });
-        return result;
     }
 
     /**
@@ -315,8 +308,7 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
         // eslint-disable-next-line prefer-rest-params
         _logFunctionCall(this.connection.debug, this.name, 'deleteMany', arguments);
         filter = serialize(filter, this.isTable);
-        const result = await this.collection.deleteMany(filter, options);
-        return result;
+        return await this.collection.deleteMany(filter, options);
     }
 
     /**
@@ -332,8 +324,7 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
             ? { ...options, sort: processSortOption(options.sort) }
             : { ...options, sort: undefined };
         filter = serialize(filter, this.isTable);
-        const result = await this.collection.deleteOne(filter as TableFilter<DocType>, requestOptions);
-        return result;
+        return await this.collection.deleteOne(filter as TableFilter<DocType>, requestOptions);
     }
 
     /**
@@ -355,8 +346,7 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
         filter = serialize(filter);
         setDefaultIdForReplace(filter, replacement, requestOptions);
         replacement = serialize(replacement);
-        const result = await this.collection.replaceOne(filter, replacement, requestOptions);
-        return result;
+        return await this.collection.replaceOne(filter, replacement, requestOptions);
     }
 
     /**
@@ -379,12 +369,11 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
             setDefaultIdForUpdate(filter, update as CollectionUpdateFilter<DocType>, requestOptions);
         }
         update = serialize(update, this.isTable);
-        const result = await this.collection.updateOne(filter as TableFilter<DocType>, update, requestOptions).then(res => {
+        return await this.collection.updateOne(filter as TableFilter<DocType>, update, requestOptions).then(res => {
             // Mongoose currently has a bug where null response from updateOne() throws an error that we can't
             // catch here for unknown reasons. See Automattic/mongoose#15126. Tables API returns null here.
             return res ?? {};
         });
-        return result;
     }
 
     /**
@@ -402,8 +391,7 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
         filter = serialize(filter, this.isTable);
         setDefaultIdForUpdate(filter, update, options);
         update = serialize(update, this.isTable);
-        const result = await this.collection.updateMany(filter, update, options);
-        return result;
+        return await this.collection.updateMany(filter, update, options);
     }
 
     /**
@@ -415,8 +403,7 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
         if (this.collection instanceof AstraTable) {
             throw new OperationNotSupportedError('Cannot use estimatedDocumentCount() with tables');
         }
-        const result = await this.collection.estimatedDocumentCount(options);
-        return result;
+        return await this.collection.estimatedDocumentCount(options);
     }
 
     /**
@@ -426,11 +413,10 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
     async runCommand(command: Record<string, unknown>, options?: Omit<RunCommandOptions, 'table' | 'collection' | 'keyspace'>) {
         // eslint-disable-next-line prefer-rest-params
         _logFunctionCall(this.connection.debug, this.name, 'runCommand', arguments);
-        const result = await this.connection.db!.astraDb.command(
+        return await this.connection.db!.astraDb.command(
             command,
             this.isTable ? { table: this.name, ...options } : { collection: this.name, ...options }
         );
-        return result;
     }
 
     /**

--- a/src/driver/connection.ts
+++ b/src/driver/connection.ts
@@ -161,7 +161,8 @@ export class Connection extends MongooseConnection {
         options?: CreateCollectionOptions<DocType>
     ) {
         const { db } = await this._waitForClient();
-        return db.createCollection<DocType>(name, options);
+        const result = await db.createCollection<DocType>(name, options);
+        return result;
     }
 
     /**
@@ -182,7 +183,8 @@ export class Connection extends MongooseConnection {
         options?: Omit<CreateTableOptions, 'definition'>
     ) {
         const { db } = await this._waitForClient();
-        return db.createTable<DocType>(name, definition, options);
+        const result = await db.createTable<DocType>(name, definition, options);
+        return result;
     }
 
     /**
@@ -191,7 +193,8 @@ export class Connection extends MongooseConnection {
       */
     async dropCollection(name: string, options?: DropCollectionOptions) {
         const { db } = await this._waitForClient();
-        return db.dropCollection(name, options);
+        const result = await db.dropCollection(name, options);
+        return result;
     }
 
     /**
@@ -200,7 +203,8 @@ export class Connection extends MongooseConnection {
       */
     async dropTable(name: string, options?: DropTableOptions) {
         const { db } = await this._waitForClient();
-        return db.dropTable(name, options);
+        const result = await db.dropTable(name, options);
+        return result;
     }
 
     /**
@@ -210,7 +214,8 @@ export class Connection extends MongooseConnection {
       */
     async createKeyspace(name: string, options?: CreateAstraKeyspaceOptions & CreateDataAPIKeyspaceOptions) {
         const { admin } = await this._waitForClient();
-        return await admin.createKeyspace(name, options);
+        const result = await admin.createKeyspace(name, options);
+        return result;
     }
 
     /**
@@ -232,9 +237,11 @@ export class Connection extends MongooseConnection {
     async listCollections(options?: ListCollectionsOptions) {
         const { db } = await this._waitForClient();
         if (options?.nameOnly) {
-            return db.listCollections({ ...options, nameOnly: true });
+            const result = await db.listCollections({ ...options, nameOnly: true });
+            return result;
         }
-        return db.listCollections({ ...options, nameOnly: false });
+        const result = await db.listCollections({ ...options, nameOnly: false });
+        return result;
     }
 
     /**
@@ -247,9 +254,11 @@ export class Connection extends MongooseConnection {
     async listTables(options?: ListTablesOptions) {
         const { db } = await this._waitForClient();
         if (options?.nameOnly) {
-            return db.listTables({ ...options, nameOnly: true });
+            const result = await db.listTables({ ...options, nameOnly: true });
+            return result;
         }
-        return db.listTables({ ...options, nameOnly: false });
+        const result = await db.listTables({ ...options, nameOnly: false });
+        return result;
     }
 
     /**
@@ -261,9 +270,11 @@ export class Connection extends MongooseConnection {
     async listTypes(options?: ListTypesOptions) {
         const { db } = await this._waitForClient();
         if (options?.nameOnly) {
-            return db.listTypes({ ...options, nameOnly: true });
+            const result = await db.listTypes({ ...options, nameOnly: true });
+            return result;
         }
-        return db.listTypes({ ...options, nameOnly: false });
+        const result = await db.listTypes({ ...options, nameOnly: false });
+        return result;
     }
 
     /**
@@ -274,7 +285,8 @@ export class Connection extends MongooseConnection {
      */
     async createType(name: string, definition: CreateTypeDefinition) {
         const { db } = await this._waitForClient();
-        return db.createType(name, definition);
+        const result = await db.createType(name, definition);
+        return result;
     }
 
     /**
@@ -284,7 +296,8 @@ export class Connection extends MongooseConnection {
      */
     async dropType(name: string, options?: DropTypeOptions) {
         const { db } = await this._waitForClient();
-        return db.dropType(name, options);
+        const result = await db.dropType(name, options);
+        return result;
     }
 
     /**
@@ -295,7 +308,8 @@ export class Connection extends MongooseConnection {
      */
     async alterType<UDTSchema extends SomeRow = SomeRow>(name: string, update: AlterTypeOptions<UDTSchema>) {
         const { db } = await this._waitForClient();
-        return db.alterType(name, update);
+        const result = await db.alterType(name, update);
+        return result;
     }
 
     /**
@@ -309,7 +323,8 @@ export class Connection extends MongooseConnection {
      */
     async syncTypes(types: { name: string, definition: CreateTypeDefinition }[]) {
         const { db } = await this._waitForClient();
-        return db.syncTypes(types);
+        const result = await db.syncTypes(types);
+        return result;
     }
 
     /**
@@ -318,7 +333,8 @@ export class Connection extends MongooseConnection {
       */
     async runCommand(command: Record<string, unknown>): Promise<RawDataAPIResponse> {
         const { db } = await this._waitForClient();
-        return db.command(command);
+        const result = await db.command(command);
+        return result;
     }
 
     /**

--- a/src/driver/connection.ts
+++ b/src/driver/connection.ts
@@ -161,8 +161,7 @@ export class Connection extends MongooseConnection {
         options?: CreateCollectionOptions<DocType>
     ) {
         const { db } = await this._waitForClient();
-        const result = await db.createCollection<DocType>(name, options);
-        return result;
+        return await db.createCollection<DocType>(name, options);
     }
 
     /**
@@ -183,8 +182,7 @@ export class Connection extends MongooseConnection {
         options?: Omit<CreateTableOptions, 'definition'>
     ) {
         const { db } = await this._waitForClient();
-        const result = await db.createTable<DocType>(name, definition, options);
-        return result;
+        return await db.createTable<DocType>(name, definition, options);
     }
 
     /**
@@ -193,8 +191,7 @@ export class Connection extends MongooseConnection {
       */
     async dropCollection(name: string, options?: DropCollectionOptions) {
         const { db } = await this._waitForClient();
-        const result = await db.dropCollection(name, options);
-        return result;
+        return await db.dropCollection(name, options);
     }
 
     /**
@@ -203,8 +200,7 @@ export class Connection extends MongooseConnection {
       */
     async dropTable(name: string, options?: DropTableOptions) {
         const { db } = await this._waitForClient();
-        const result = await db.dropTable(name, options);
-        return result;
+        return await db.dropTable(name, options);
     }
 
     /**
@@ -214,8 +210,7 @@ export class Connection extends MongooseConnection {
       */
     async createKeyspace(name: string, options?: CreateAstraKeyspaceOptions & CreateDataAPIKeyspaceOptions) {
         const { admin } = await this._waitForClient();
-        const result = await admin.createKeyspace(name, options);
-        return result;
+        return await admin.createKeyspace(name, options);
     }
 
     /**
@@ -237,11 +232,9 @@ export class Connection extends MongooseConnection {
     async listCollections(options?: ListCollectionsOptions) {
         const { db } = await this._waitForClient();
         if (options?.nameOnly) {
-            const result = await db.listCollections({ ...options, nameOnly: true });
-            return result;
+            return await db.listCollections({ ...options, nameOnly: true });
         }
-        const result = await db.listCollections({ ...options, nameOnly: false });
-        return result;
+        return await db.listCollections({ ...options, nameOnly: false });
     }
 
     /**
@@ -254,11 +247,9 @@ export class Connection extends MongooseConnection {
     async listTables(options?: ListTablesOptions) {
         const { db } = await this._waitForClient();
         if (options?.nameOnly) {
-            const result = await db.listTables({ ...options, nameOnly: true });
-            return result;
+            return await db.listTables({ ...options, nameOnly: true });
         }
-        const result = await db.listTables({ ...options, nameOnly: false });
-        return result;
+        return await db.listTables({ ...options, nameOnly: false });
     }
 
     /**
@@ -270,11 +261,9 @@ export class Connection extends MongooseConnection {
     async listTypes(options?: ListTypesOptions) {
         const { db } = await this._waitForClient();
         if (options?.nameOnly) {
-            const result = await db.listTypes({ ...options, nameOnly: true });
-            return result;
+            return await db.listTypes({ ...options, nameOnly: true });
         }
-        const result = await db.listTypes({ ...options, nameOnly: false });
-        return result;
+        return await db.listTypes({ ...options, nameOnly: false });
     }
 
     /**
@@ -285,8 +274,7 @@ export class Connection extends MongooseConnection {
      */
     async createType(name: string, definition: CreateTypeDefinition) {
         const { db } = await this._waitForClient();
-        const result = await db.createType(name, definition);
-        return result;
+        return await db.createType(name, definition);
     }
 
     /**
@@ -296,8 +284,7 @@ export class Connection extends MongooseConnection {
      */
     async dropType(name: string, options?: DropTypeOptions) {
         const { db } = await this._waitForClient();
-        const result = await db.dropType(name, options);
-        return result;
+        return await db.dropType(name, options);
     }
 
     /**
@@ -308,8 +295,7 @@ export class Connection extends MongooseConnection {
      */
     async alterType<UDTSchema extends SomeRow = SomeRow>(name: string, update: AlterTypeOptions<UDTSchema>) {
         const { db } = await this._waitForClient();
-        const result = await db.alterType(name, update);
-        return result;
+        return await db.alterType(name, update);
     }
 
     /**
@@ -323,8 +309,7 @@ export class Connection extends MongooseConnection {
      */
     async syncTypes(types: { name: string, definition: CreateTypeDefinition }[]) {
         const { db } = await this._waitForClient();
-        const result = await db.syncTypes(types);
-        return result;
+        return await db.syncTypes(types);
     }
 
     /**
@@ -333,8 +318,7 @@ export class Connection extends MongooseConnection {
       */
     async runCommand(command: Record<string, unknown>): Promise<RawDataAPIResponse> {
         const { db } = await this._waitForClient();
-        const result = await db.command(command);
-        return result;
+        return await db.command(command);
     }
 
     /**

--- a/src/driver/db.ts
+++ b/src/driver/db.ts
@@ -88,7 +88,8 @@ export abstract class BaseDb {
         definition: CreateTableDefinition,
         options?: Omit<CreateTableOptions, 'definition'>
     ) {
-        return this.astraDb.createTable<DocType>(name, { ...options, definition });
+        const result = await this.astraDb.createTable<DocType>(name, { ...options, definition });
+        return result;
     }
 
     /**
@@ -96,7 +97,8 @@ export abstract class BaseDb {
      * @param name The name of the collection to be dropped.
      */
     async dropCollection(name: string, options?: DropCollectionOptions) {
-        return this.astraDb.dropCollection(name, options);
+        const result = await this.astraDb.dropCollection(name, options);
+        return result;
     }
 
     /**
@@ -104,10 +106,11 @@ export abstract class BaseDb {
      * @param name
      */
     async dropTable(name: string, options?: DropTableOptions) {
-        return this.astraDb.dropTable(name, {
+        const result = await this.astraDb.dropTable(name, {
             ifExists: true,
             ...options
         });
+        return result;
     }
 
     /**
@@ -120,9 +123,11 @@ export abstract class BaseDb {
 
     async listCollections(options?: ListCollectionsOptions) {
         if (options?.nameOnly) {
-            return this.astraDb.listCollections({ ...options, nameOnly: true });
+            const result = await this.astraDb.listCollections({ ...options, nameOnly: true });
+            return result;
         }
-        return this.astraDb.listCollections({ ...options, nameOnly: false });
+        const result = await this.astraDb.listCollections({ ...options, nameOnly: false });
+        return result;
     }
 
     /**
@@ -133,9 +138,11 @@ export abstract class BaseDb {
 
     async listTables(options?: ListTablesOptions) {
         if (options?.nameOnly) {
-            return this.astraDb.listTables({ ...options, nameOnly: true });
+            const result = await this.astraDb.listTables({ ...options, nameOnly: true });
+            return result;
         }
-        return this.astraDb.listTables({ ...options, nameOnly: false });
+        const result = await this.astraDb.listTables({ ...options, nameOnly: false });
+        return result;
     }
 
     /**
@@ -146,9 +153,11 @@ export abstract class BaseDb {
     async listTypes(options?: { nameOnly?: false }): Promise<TypeDescriptor[]>;
     async listTypes(options?: ListTypesOptions) {
         if (options?.nameOnly) {
-            return this.astraDb.listTypes({ ...options, nameOnly: true });
+            const result = await this.astraDb.listTypes({ ...options, nameOnly: true });
+            return result;
         }
-        return this.astraDb.listTypes({ ...options, nameOnly: false });
+        const result = await this.astraDb.listTypes({ ...options, nameOnly: false });
+        return result;
     }
 
     /**
@@ -158,7 +167,8 @@ export abstract class BaseDb {
      * @returns The result of the createType command.
      */
     async createType(name: string, definition: CreateTypeDefinition) {
-        return this.astraDb.createType(name, { definition });
+        const result = await this.astraDb.createType(name, { definition });
+        return result;
     }
 
     /**
@@ -167,7 +177,8 @@ export abstract class BaseDb {
      * @returns The result of the dropType command.
      */
     async dropType(name: string, options?: DropTypeOptions) {
-        return this.astraDb.dropType(name, options);
+        const result = await this.astraDb.dropType(name, options);
+        return result;
     }
 
     /**
@@ -177,7 +188,8 @@ export abstract class BaseDb {
      * @returns The result of the alterType command.
      */
     async alterType<UDTSchema extends SomeRow = SomeRow>(name: string, update: AlterTypeOptions<UDTSchema>) {
-        return this.astraDb.alterType(name, update);
+        const result = await this.astraDb.alterType(name, update);
+        return result;
     }
 
     /**
@@ -260,7 +272,8 @@ export abstract class BaseDb {
      * @param command The command to be executed.
      */
     async command(command: Record<string, unknown>): Promise<RawDataAPIResponse> {
-        return this.astraDb.command(command);
+        const result = await this.astraDb.command(command);
+        return result;
     }
 }
 
@@ -289,8 +302,9 @@ export class CollectionsDb extends BaseDb {
     /**
      * Send a CreateCollection command to Data API.
      */
-    createCollection<DocType extends Record<string, unknown> = Record<string, unknown>>(name: string, options?: CreateCollectionOptions<DocType>) {
-        return this.astraDb.createCollection<DocType>(name, options);
+    async createCollection<DocType extends Record<string, unknown> = Record<string, unknown>>(name: string, options?: CreateCollectionOptions<DocType>) {
+        const result = await this.astraDb.createCollection<DocType>(name, options);
+        return result;
     }
 }
 
@@ -320,7 +334,7 @@ export class TablesDb extends BaseDb {
     /**
      * Throws an error, astra-mongoose does not support creating collections in tables mode.
      */
-    createCollection<DocType extends Record<string, unknown> = Record<string, unknown>>(
+    async createCollection<DocType extends Record<string, unknown> = Record<string, unknown>>(
         name: string,
         options?: CreateCollectionOptions<DocType>
     ): Promise<Collection<DocType>> {

--- a/src/driver/db.ts
+++ b/src/driver/db.ts
@@ -88,8 +88,7 @@ export abstract class BaseDb {
         definition: CreateTableDefinition,
         options?: Omit<CreateTableOptions, 'definition'>
     ) {
-        const result = await this.astraDb.createTable<DocType>(name, { ...options, definition });
-        return result;
+        return await this.astraDb.createTable<DocType>(name, { ...options, definition });
     }
 
     /**
@@ -97,8 +96,7 @@ export abstract class BaseDb {
      * @param name The name of the collection to be dropped.
      */
     async dropCollection(name: string, options?: DropCollectionOptions) {
-        const result = await this.astraDb.dropCollection(name, options);
-        return result;
+        return await this.astraDb.dropCollection(name, options);
     }
 
     /**
@@ -106,11 +104,10 @@ export abstract class BaseDb {
      * @param name
      */
     async dropTable(name: string, options?: DropTableOptions) {
-        const result = await this.astraDb.dropTable(name, {
+        return await this.astraDb.dropTable(name, {
             ifExists: true,
             ...options
         });
-        return result;
     }
 
     /**
@@ -123,11 +120,9 @@ export abstract class BaseDb {
 
     async listCollections(options?: ListCollectionsOptions) {
         if (options?.nameOnly) {
-            const result = await this.astraDb.listCollections({ ...options, nameOnly: true });
-            return result;
+            return await this.astraDb.listCollections({ ...options, nameOnly: true });
         }
-        const result = await this.astraDb.listCollections({ ...options, nameOnly: false });
-        return result;
+        return await this.astraDb.listCollections({ ...options, nameOnly: false });
     }
 
     /**
@@ -138,11 +133,9 @@ export abstract class BaseDb {
 
     async listTables(options?: ListTablesOptions) {
         if (options?.nameOnly) {
-            const result = await this.astraDb.listTables({ ...options, nameOnly: true });
-            return result;
+            return await this.astraDb.listTables({ ...options, nameOnly: true });
         }
-        const result = await this.astraDb.listTables({ ...options, nameOnly: false });
-        return result;
+        return await this.astraDb.listTables({ ...options, nameOnly: false });
     }
 
     /**
@@ -153,11 +146,9 @@ export abstract class BaseDb {
     async listTypes(options?: { nameOnly?: false }): Promise<TypeDescriptor[]>;
     async listTypes(options?: ListTypesOptions) {
         if (options?.nameOnly) {
-            const result = await this.astraDb.listTypes({ ...options, nameOnly: true });
-            return result;
+            return await this.astraDb.listTypes({ ...options, nameOnly: true });
         }
-        const result = await this.astraDb.listTypes({ ...options, nameOnly: false });
-        return result;
+        return await this.astraDb.listTypes({ ...options, nameOnly: false });
     }
 
     /**
@@ -167,8 +158,7 @@ export abstract class BaseDb {
      * @returns The result of the createType command.
      */
     async createType(name: string, definition: CreateTypeDefinition) {
-        const result = await this.astraDb.createType(name, { definition });
-        return result;
+        return await this.astraDb.createType(name, { definition });
     }
 
     /**
@@ -177,8 +167,7 @@ export abstract class BaseDb {
      * @returns The result of the dropType command.
      */
     async dropType(name: string, options?: DropTypeOptions) {
-        const result = await this.astraDb.dropType(name, options);
-        return result;
+        return await this.astraDb.dropType(name, options);
     }
 
     /**
@@ -188,8 +177,7 @@ export abstract class BaseDb {
      * @returns The result of the alterType command.
      */
     async alterType<UDTSchema extends SomeRow = SomeRow>(name: string, update: AlterTypeOptions<UDTSchema>) {
-        const result = await this.astraDb.alterType(name, update);
-        return result;
+        return await this.astraDb.alterType(name, update);
     }
 
     /**
@@ -272,8 +260,7 @@ export abstract class BaseDb {
      * @param command The command to be executed.
      */
     async command(command: Record<string, unknown>): Promise<RawDataAPIResponse> {
-        const result = await this.astraDb.command(command);
-        return result;
+        return await this.astraDb.command(command);
     }
 }
 
@@ -303,8 +290,7 @@ export class CollectionsDb extends BaseDb {
      * Send a CreateCollection command to Data API.
      */
     async createCollection<DocType extends Record<string, unknown> = Record<string, unknown>>(name: string, options?: CreateCollectionOptions<DocType>) {
-        const result = await this.astraDb.createCollection<DocType>(name, options);
-        return result;
+        return await this.astraDb.createCollection<DocType>(name, options);
     }
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Because we use `return` instead of `await`, async stack traces skip astra-mongoose entirely. For example, below is an error message I got earlier: goes straight from Mongoose `Query.exec` to Astra `Table.updateOne` with no mention of astra-mongoose.

```
DataAPIResponseError: Server internal error: Filter type not supported, unable to resolve to a filtering strategy
    at DataAPIHttpClient.executeCommand (/node_modules/@datastax/astra-db-ts/dist/cjs/lib/api/clients/data-api-http-client.js:187:23)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async CommandImpls.updateOne (/node_modules/@datastax/astra-db-ts/dist/cjs/documents/commands/command-impls.js:70:22)
    at async Table.updateOne (/node_modules/@datastax/astra-db-ts/dist/cjs/documents/tables/table.js:66:9)
    at async model.Query.exec (/node_modules/mongoose/lib/query.js:4627:63)
    at async model.syncToAstra (/backend/db/pageContextSchema.js:156:18)

```

This is confusing DX. We can prevent this by explicitly using `await` on astra-db-ts calls - with the changes in this PR, stack trace will show astra-mongoose calls

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)