### PR TITLE
avoid importing bson to avoid potential compatibility issues

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Binary, Double, ObjectId } from 'bson';
 import mongoose from 'mongoose';
+
+const { Binary, Double, ObjectId } = mongoose.mongo.BSON;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function serialize(data: Record<string, any>, isTable?: boolean): Record<string, any> {

--- a/tests/driver/collections.api.test.ts
+++ b/tests/driver/collections.api.test.ts
@@ -24,8 +24,9 @@ import { OperationNotSupportedError } from '../../src/operationNotSupportedError
 import { CartModelType, ProductModelType, productSchema, ProductRawDoc, createMongooseCollections, testDebug } from '../mongooseFixtures';
 import { parseUri } from '../../src/driver/connection';
 import { FindCursor, DataAPIResponseError } from '@datastax/astra-db-ts';
-import { Long, UUID } from 'bson';
 import type { AstraMongoose } from '../../src';
+
+const { Long, UUID } = mongoose.mongo.BSON;
 
 describe('COLLECTIONS: mongoose Model API level tests with collections', async () => {
     let Product: ProductModelType;

--- a/tests/driver/tables.test.ts
+++ b/tests/driver/tables.test.ts
@@ -14,13 +14,14 @@
 
 import assert from 'assert';
 import { mongooseInstanceTables as mongooseInstance, createMongooseCollections, testDebug } from '../mongooseFixtures';
-import { Schema, Types } from 'mongoose';
+import mongoose, { Schema, Types } from 'mongoose';
 import { randomUUID } from 'crypto';
-import { UUID } from 'bson';
 import tableDefinitionFromSchema from '../../src/tableDefinitionFromSchema';
 import { DataAPIDuration, DataAPIInet, DataAPIDate, DataAPITime, TableScalarColumnDefinition } from '@datastax/astra-db-ts';
 import convertSchemaToUDTColumns from '../../src/udt/convertSchemaToUDTColumns';
 import udtDefinitionsFromSchema from '../../src/udt/udtDefinitionsFromSchema';
+
+const { UUID } = mongoose.mongo.BSON;
 
 const TEST_TABLE_NAME = 'table1';
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

astra-mongoose doesn't include bson as a dependency but imports `bson`. npm _usually_ puts bson in the top-level of node_modules because it is a dependency of mongoose via the mongodb node driver, but that is not strictly guaranteed. To avoid potential issues with importing bson, this PR instead uses Mongoose's exports to pull out Mongoose's dependency of the MongoDB node driver, and in turn the MongoDB node driver's dependency on bson.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)