### PR TITLE
handle loose type definitions in syncTypes and apiSupport option in syncTable

### DIFF
--- a/APIReference.md
+++ b/APIReference.md
@@ -270,7 +270,7 @@ by adding or dropping columns as necessary.</p>
 <p>Note that modifying an existing column is NOT supported and will throw an error.</p>
 
 **Kind**: instance method of [<code>Collection</code>](#Collection)  
-**Returns**: <p>void</p>  
+**Returns**: <p>An object with details of the planned or applied changes, including columnsToAdd, columnsToDrop, and createdNewTable.</p>  
 
 | Param | Description |
 | --- | --- |

--- a/APIReference.md
+++ b/APIReference.md
@@ -84,7 +84,7 @@ an Astra perspective, this class can be a wrapper around a Collection <strong>or
     * [.updateOne(filter, update, options)](#Collection+updateOne)
     * [.updateMany(filter, update, options)](#Collection+updateMany)
     * [.estimatedDocumentCount()](#Collection+estimatedDocumentCount)
-    * [.syncTable(definition, options)](#Collection+syncTable) ⇒
+    * [.syncTable(definition, createTableOptions, dryRun)](#Collection+syncTable) ⇒
     * [.alterTable(operation)](#Collection+alterTable)
     * [.runCommand(command)](#Collection+runCommand)
     * [.bulkWrite(ops, options)](#Collection+bulkWrite)
@@ -263,7 +263,7 @@ Converted to a <code>findOneAndReplace()</code> under the hood.</p>
 **Kind**: instance method of [<code>Collection</code>](#Collection)  
 <a name="Collection+syncTable"></a>
 
-### collection.syncTable(definition, options) ⇒
+### collection.syncTable(definition, createTableOptions, dryRun) ⇒
 <p>Sync the underlying table schema with the specified definition: creates a new
 table if one doesn't exist, or alters the existing table to match the definition
 by adding or dropping columns as necessary.</p>
@@ -275,7 +275,8 @@ by adding or dropping columns as necessary.</p>
 | Param | Description |
 | --- | --- |
 | definition | <p>new table definition (strict only)</p> |
-| options | <p>passed to createTable if the table doesn't exist</p> |
+| createTableOptions | <p>passed to createTable if the table doesn't exist</p> |
+| dryRun | <p>if true, don't actually perform the operation, just return info on what would happen</p> |
 
 <a name="Collection+alterTable"></a>
 

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -432,7 +432,9 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
         const existingTable = existingTables.find(table => table.name === name);
         // Create new table with the specified definition if it doesn't exist
         if (!existingTable) {
-            await this.connection.createTable<DocType>(name, definition, createTableOptions);
+            if (!dryRun) {
+                await this.connection.createTable<DocType>(name, definition, createTableOptions);
+            }
             return { columnsToAdd: Object.keys(definition.columns), columnsToDrop: [], createdNewTable: true };
         }
 

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -443,7 +443,11 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
 
         const overlappingColumnNames = existingColumnNames.filter(column => newColumnNames.includes(column));
         const columnsToModify = overlappingColumnNames.filter(column => {
-            return JSON.stringify(existingTable.definition.columns[column]) !== JSON.stringify(definition.columns[column]);
+            const existingColumn = { ...existingTable.definition.columns[column] };
+            if (existingColumn.apiSupport != null) {
+                delete existingColumn.apiSupport;
+            }
+            return JSON.stringify(existingColumn) !== JSON.stringify(definition.columns[column]);
         });
         if (columnsToModify.length > 0) {
             throw new AstraMongooseError('syncTable cannot modify existing columns, found modified columns: ' + columnsToModify.join(', '));

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -420,7 +420,7 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
      * @param definition new table definition (strict only)
      * @param createTableOptions passed to createTable if the table doesn't exist
      * @param dryRun if true, don't actually perform the operation, just return info on what would happen
-     * @returns void
+     * @returns An object with details of the planned or applied changes, including columnsToAdd, columnsToDrop, and createdNewTable.
      */
     async syncTable<DocType extends Record<string, unknown> = Record<string, unknown>>(
         definition: Pick<CreateTableDefinition, 'primaryKey'> & { columns: Record<string, StrictCreateTableColumnDefinition> },

--- a/src/driver/db.ts
+++ b/src/driver/db.ts
@@ -229,12 +229,13 @@ export abstract class BaseDb {
                     const fieldsToAdd: CreateTypeDefinition = { fields: {} };
                     for (const [field, newField] of Object.entries(type.definition.fields)) {
                         if (existingFields?.[field] != null) {
-                            const existingFieldType = existingFields[field];
+                            const existingField = existingFields[field];
                             // Compare type as string since Astra DB types may be represented in string form
                             const newFieldType = typeof newField === 'string' ? newField : newField.type;
-                            if (existingFieldType.type !== newFieldType) {
+                            const existingFieldType = typeof existingField === 'string' ? existingField : existingField.type;
+                            if (existingFieldType !== newFieldType) {
                                 throw new AstraMongooseError(
-                                    `Field '${field}' in type '${type.name}' exists with different type. (current: ${existingFieldType.type}, new: ${newFieldType})`
+                                    `Field '${field}' in type '${type.name}' exists with different type. (current: ${existingFieldType}, new: ${newFieldType})`
                                 );
                             }
                         } else {
@@ -249,7 +250,7 @@ export abstract class BaseDb {
                 }
             }
         } catch (err) {
-            throw new AstraMongooseError(`Error in syncTypes: ${err instanceof Error ? err.message : err}`, { created, updated, dropped });
+            throw new AstraMongooseError(`Error in syncTypes: ${err}`, { created, updated, dropped });
         }
 
         return { created, updated, dropped };

--- a/tests/driver/tables.test.ts
+++ b/tests/driver/tables.test.ts
@@ -243,13 +243,13 @@ describe('TABLES: basic operations and data types', function() {
             }
         }, { versionKey: false });
 
-        await mongooseInstance.connection.createType('WebsiteType', {
-            fields: {
-                url: { type: 'text' }
-            }
-        });
-
         try {
+            await mongooseInstance.connection.createType('WebsiteType', {
+                fields: {
+                    url: { type: 'text' }
+                }
+            });
+
             await mongooseInstance.connection.dropTable(TEST_TABLE_NAME);
             let tableDefinition = tableDefinitionFromSchema(userSchema);
 

--- a/tests/driver/tables.test.ts
+++ b/tests/driver/tables.test.ts
@@ -236,44 +236,74 @@ describe('TABLES: basic operations and data types', function() {
     it('syncTable', async () => {
         const userSchema = new Schema({
             name: String,
-            age: Number
+            age: Number,
+            website: {
+                type: new Schema({ url: String }),
+                udtName: 'WebsiteType'
+            }
         }, { versionKey: false });
-        await mongooseInstance.connection.dropTable(TEST_TABLE_NAME);
-        let tableDefinition = tableDefinitionFromSchema(userSchema);
 
-        const collection = mongooseInstance.connection.collection(TEST_TABLE_NAME);
-        await collection.syncTable(tableDefinition);
+        await mongooseInstance.connection.createType('WebsiteType', {
+            fields: {
+                url: { type: 'text' }
+            }
+        });
 
-        let tables = await mongooseInstance.connection.listTables();
-        let table = tables.find(t => t.name === TEST_TABLE_NAME);
-        assert.ok(table);
-        assert.strictEqual(table.name, TEST_TABLE_NAME);
-        assert.deepStrictEqual(Object.keys(table.definition.columns).sort(), ['_id', 'age', 'name']);
+        try {
+            await mongooseInstance.connection.dropTable(TEST_TABLE_NAME);
+            let tableDefinition = tableDefinitionFromSchema(userSchema);
 
-        const updatedUserSchema = new Schema({
-            name: String,
-            email: String
-        }, { versionKey: false });
-        tableDefinition = tableDefinitionFromSchema(updatedUserSchema);
+            const collection = mongooseInstance.connection.collection(TEST_TABLE_NAME);
+            await collection.syncTable(tableDefinition);
 
-        await collection.syncTable(tableDefinition);
+            let tables = await mongooseInstance.connection.listTables();
+            let table = tables.find(t => t.name === TEST_TABLE_NAME);
+            assert.ok(table);
+            assert.strictEqual(table.name, TEST_TABLE_NAME);
+            assert.deepStrictEqual(
+                Object.keys(table.definition.columns).sort(),
+                ['_id', 'age', 'name', 'website']
+            );
 
-        tables = await mongooseInstance.connection.listTables();
-        table = tables.find(t => t.name === TEST_TABLE_NAME);
-        assert.ok(table);
-        assert.strictEqual(table.name, TEST_TABLE_NAME);
-        assert.deepStrictEqual(Object.keys(table.definition.columns).sort(), ['_id', 'email', 'name']);
+            const updatedUserSchema = new Schema({
+                name: String,
+                email: String,
+                website: {
+                    type: new Schema({ url: String }),
+                    udtName: 'WebsiteType'
+                }
+            }, { versionKey: false });
+            tableDefinition = tableDefinitionFromSchema(updatedUserSchema);
 
-        const updateExistingSchema = new Schema({
-            name: String,
-            email: Number
-        }, { versionKey: false });
-        tableDefinition = tableDefinitionFromSchema(updateExistingSchema);
+            await collection.syncTable(tableDefinition);
 
-        await assert.rejects(
-            collection.syncTable(tableDefinition),
-            /syncTable cannot modify existing columns, found modified columns: email/
-        );
+            tables = await mongooseInstance.connection.listTables();
+            table = tables.find(t => t.name === TEST_TABLE_NAME);
+            assert.ok(table);
+            assert.strictEqual(table.name, TEST_TABLE_NAME);
+            assert.deepStrictEqual(
+                Object.keys(table.definition.columns).sort(),
+                ['_id', 'email', 'name', 'website']
+            );
+
+            const updateExistingSchema = new Schema({
+                name: String,
+                email: Number,
+                website: {
+                    type: new Schema({ url: String }),
+                    udtName: 'WebsiteType'
+                }
+            }, { versionKey: false });
+            tableDefinition = tableDefinitionFromSchema(updateExistingSchema);
+
+            await assert.rejects(
+                collection.syncTable(tableDefinition),
+                /syncTable cannot modify existing columns, found modified columns: email/
+            );
+        } finally {
+            await mongooseInstance.connection.dropTable(TEST_TABLE_NAME);
+            await mongooseInstance.connection.dropType('WebsiteType');
+        }
     });
 
     describe('UDTs', () => {
@@ -566,11 +596,19 @@ describe('TABLES: basic operations and data types', function() {
                 }
             });
 
+            await mongooseInstance.connection.createType('UnusedType', {
+                // Added to test loose create type field definition (string not object with `type`)
+                fields: {
+                    test: 'text'
+                }
+            });
+
             currTypes = await mongooseInstance.connection.listTypes({ nameOnly: true });
-            assert.deepStrictEqual(currTypes, ['Page', 'Taco']);
+            assert.deepStrictEqual(currTypes, ['Page', 'Taco', 'UnusedType']);
 
             // Step 3: Use syncTypes to create the Brand and Product UDTs
             const typesToSync = Object.entries(productUdtDefinitions).map(([name, def]) => ({ name, definition: def }));
+            typesToSync.push({ name: 'UnusedType', definition: { fields: { test: 'text' } } });
             const syncResult1 = await mongooseInstance.connection.syncTypes(typesToSync);
             assert.deepStrictEqual(syncResult1.created.sort(), ['Product']);
             assert.deepStrictEqual(syncResult1.updated.sort(), ['Page']);
@@ -578,7 +616,7 @@ describe('TABLES: basic operations and data types', function() {
 
             // Check that types now exist
             const currTypes2 = await mongooseInstance.connection.listTypes({ nameOnly: true });
-            assert.deepStrictEqual(currTypes2.sort(), ['Page', 'Product'].sort());
+            assert.deepStrictEqual(currTypes2.sort(), ['Page', 'Product', 'UnusedType'].sort());
 
             // Verify Brand has new field
             const typeDefs = await mongooseInstance.connection.listTypes({ nameOnly: false });
@@ -594,7 +632,7 @@ describe('TABLES: basic operations and data types', function() {
             (typesToSync[0].definition.fields['title'] as TableScalarColumnDefinition).type = 'float';
             await assert.rejects(
                 () => mongooseInstance.connection.syncTypes(typesToSync),
-                /Error in syncTypes: Field 'title' in type 'Page' exists with different type. \(current: text, new: float\)/
+                /Error in syncTypes: AstraMongooseError: Field 'title' in type 'Page' exists with different type. \(current: text, new: float\)/
             );
         });
     });


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Fixes a couple of issues I spotted:

1. syncTable() should ignore `apiSupport` option, otherwise calling syncTable() on a table with any UDT columns fails.
2. `syncTypes()` should support types with loose definition (string instead of `{ type }` object)

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)