### PR TITLE
add vector search benchmarks

### DIFF
--- a/benchmarks/queryVector.mjs
+++ b/benchmarks/queryVector.mjs
@@ -1,0 +1,59 @@
+import astraMongoose from '../dist/index.js';
+import fs from 'node:fs/promises';
+import mongoose from 'mongoose';
+
+const { driver, tableDefinitionFromSchema } = astraMongoose;
+
+mongoose.set('autoCreate', false);
+mongoose.set('autoIndex', false);
+mongoose.setDriver(driver);
+
+const isTable = !!process.env.IS_TABLE;
+
+await mongoose.connect(process.env.ASTRA_URI, { isAstra: true, isTable });
+
+const vectorField = isTable ? 'vector' : '$vector';
+
+const contentSchema = new mongoose.Schema({
+  text: {
+    type: String,
+    required: true
+  },
+  [vectorField]: {
+    type: [Number],
+    validate: v => v == null || v.length === 512,
+    default: undefined,
+    dimension: 512,
+    index: { name: 'content_vector', vector: true }
+  }
+}, { versionKey: false });
+const ContentModel = mongoose.model('Content', contentSchema, 'content');
+
+const content = await ContentModel.findOne().select({ '*': 1 }).orFail();
+const $meta = [...content[vectorField]];
+$meta[0] = 0.001;
+
+const start = process.hrtime.bigint();
+
+const totalQueries = 2000;
+const parallelism = 10;
+
+for (let i = 0; i < totalQueries; i += parallelism) {
+  const batchSize = Math.min(parallelism, totalQueries - i);
+  await Promise.all(
+    Array.from({ length: batchSize }, () =>
+      ContentModel.find().limit(10).select({ [vectorField]: 0 }).sort({ [vectorField]: { $meta } })
+    )
+  );
+}
+
+const end = process.hrtime.bigint();
+const seconds = Number(end - start) / 1e9;
+
+console.log(JSON.stringify({
+  queries: totalQueries,
+  parallelism,
+  seconds: +seconds.toFixed(6),
+  queriesPerSecond: +(totalQueries / seconds).toFixed(6),
+  secondsPerBatch: +(seconds / (totalQueries / parallelism)).toFixed(6)
+}));

--- a/benchmarks/queryVector.mjs
+++ b/benchmarks/queryVector.mjs
@@ -1,5 +1,4 @@
 import astraMongoose from '../dist/index.js';
-import fs from 'node:fs/promises';
 import mongoose from 'mongoose';
 
 const { driver, tableDefinitionFromSchema } = astraMongoose;

--- a/benchmarks/writeVector.mjs
+++ b/benchmarks/writeVector.mjs
@@ -59,8 +59,18 @@ if (isTable) {
   await ContentModel.syncIndexes();
 }
 
-const moviesRaw = await fs.readFile('./movies.json', 'utf8');
-const movies = JSON.parse(moviesRaw);
+const moviesPath = process.env.MOVIES_JSON_PATH || './movies.json';
+
+let movies;
+try {
+  const moviesRaw = await fs.readFile(moviesPath, 'utf8');
+  movies = JSON.parse(moviesRaw);
+} catch (err) {
+  console.error(`Failed to load movies dataset from "${moviesPath}".`);
+  console.error('Set the MOVIES_JSON_PATH environment variable to point to a valid movies.json file.');
+  console.error('Original error:', err?.message || err);
+  process.exit(1);
+}
 const batchSize = 20;
 const start = process.hrtime.bigint();
 

--- a/benchmarks/writeVector.mjs
+++ b/benchmarks/writeVector.mjs
@@ -47,9 +47,14 @@ if (isTable) {
     tableDefinitionFromSchema(contentSchema)
   );
 } else {
-  if (tables.find(table => table.name === 'content')) {
-    await mongoose.connection.dropTable('content')
-  } else if (!collections.find(collection => collection.name === 'content')) {
+  const hasTable = tables.find(table => table.name === 'content');
+  const hasCollection = collections.find(collection => collection.name === 'content');
+
+  if (hasTable) {
+    await mongoose.connection.dropTable('content');
+  }
+
+  if (!hasCollection) {
     await ContentModel.createCollection();
   }
 }

--- a/benchmarks/writeVector.mjs
+++ b/benchmarks/writeVector.mjs
@@ -1,0 +1,84 @@
+import astraMongoose from '../dist/index.js';
+import fs from 'node:fs/promises';
+import mongoose from 'mongoose';
+
+const { driver, tableDefinitionFromSchema } = astraMongoose;
+
+mongoose.set('autoCreate', false);
+mongoose.set('autoIndex', false);
+mongoose.setDriver(driver);
+
+const isTable = !!process.env.IS_TABLE;
+
+await mongoose.connect(process.env.ASTRA_URI, { isAstra: true, isTable });
+
+const vectorField = isTable ? 'vector' : '$vector';
+
+const contentSchema = new mongoose.Schema({
+  text: {
+    type: String,
+    required: true
+  },
+  [vectorField]: {
+    type: [Number],
+    validate: v => v == null || v.length === 512,
+    default: undefined,
+    dimension: 512,
+    index: { name: 'content_vector', vector: true }
+  }
+}, {
+  versionKey: false,
+  autoCreate: false,
+  collectionOptions: { vector: { dimension: 512, metric: 'cosine' } }
+});
+const ContentModel = mongoose.model('Content', contentSchema, 'content');
+
+const tables = await mongoose.connection.listTables();
+const collections = await mongoose.connection.listCollections();
+
+console.log('Tables', tables);
+console.log('Collections', collections);
+
+if (isTable) {
+  if (collections.find(collection => collection.name === 'content')) {
+    await mongoose.connection.dropCollection('content');
+  }
+  await mongoose.connection.collection('content').syncTable(
+    tableDefinitionFromSchema(contentSchema)
+  );
+} else {
+  if (tables.find(table => table.name === 'content')) {
+    await mongoose.connection.dropTable('content')
+  } else if (!collections.find(collection => collection.name === 'content')) {
+    await ContentModel.createCollection();
+  }
+}
+
+await ContentModel.deleteMany();
+if (isTable) {
+  await ContentModel.syncIndexes();
+}
+
+const moviesRaw = await fs.readFile('./movies.json', 'utf8');
+const movies = JSON.parse(moviesRaw);
+const batchSize = 20;
+const start = process.hrtime.bigint();
+
+for (let i = 0; i < movies.length; i += batchSize) {
+  const batch = movies.slice(i, i + batchSize).map(m => ({
+    text: [m?.title, m?.plot, m?.fullplot].filter(Boolean).join('\n\n').slice(0, 5000),
+    [vectorField]: m.vector
+  }));
+
+  await ContentModel.insertMany(batch, { ordered: false });
+}
+
+const end = process.hrtime.bigint();
+const seconds = Number(end - start) / 1e9;
+
+console.log(JSON.stringify({
+  inserted: movies.length,
+  seconds: +seconds.toFixed(6),
+  docsPerSecond: +(movies.length / seconds).toFixed(6),
+  secondsPerBatch: +(seconds / (movies.length / batchSize)).toFixed(6)
+}));


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Basic benchmarks for vector search:

1. writeVector: insert 21k vector documents in batches of 20 using insertMany with ordered: false
2. queryVector: execute 2000 ANN queries 10 at a time on the 21k vectors inserted

21k documents just have a `text` and `vector` property. Paradoxically, it seems like collections are actually _faster_ than tables in this case. A big reason why collections are faster though is because collections project out the vector field by default, it seems like nearly 90% of the overhead of tables vs collections is eliminated by projecting out the vector field on the read path.

# Tables

- Tables insert: `{"inserted":21347,"seconds":376.129264,"docsPerSecond":56.754425,"secondsPerBatch":0.352395}`
- Tables read: `{"queries":2000,"parallelism":10,"seconds":55.601865,"queriesPerSecond":35.970016,"secondsPerBatch":0.278009}`
- Tables read w/ vector projected out: `{"queries":2000,"parallelism":10,"seconds":32.994885,"queriesPerSecond":60.615457,"secondsPerBatch":0.164974}`

# Collections

- Collections insert: `{"inserted":21347,"seconds":222.619178,"docsPerSecond":95.890211,"secondsPerBatch":0.208572}`
- Collections read: `{"queries":2000,"parallelism":10,"seconds":28.87107,"queriesPerSecond":69.273497,"secondsPerBatch":0.144355}`

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)