### PR TITLE
upgrade to latest data API, fix deprecation warnings and test compatibility with latest Mongoose

### DIFF
--- a/api-compatibility.versions
+++ b/api-compatibility.versions
@@ -1,2 +1,2 @@
-dse_version=6.9.16
-data_api_version=v1.0.34
+dse_version=6.9.21
+data_api_version=v1.0.46

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -454,7 +454,7 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
         setDefaultIdForReplace(filter, replacement, requestOptions);
         replacement = serialize(replacement);
         return await this.collection.replaceOne(filter, replacement, requestOptions)
-          .then(res => ({ ...res, acknowledged: true, upsertedId: null }));
+            .then(res => ({ ...res, acknowledged: true, upsertedId: null }));
     }
 
     /**

--- a/src/driver/connection.ts
+++ b/src/driver/connection.ts
@@ -348,8 +348,8 @@ export class Connection extends MongooseConnection {
         const { admin } = await this._waitForClient();
         // `ok: 1` to be compatible with Mongoose's TypeScript types.
         return {
-          databases: await admin!.listKeyspaces(options).then(keyspaces => keyspaces.map(name => ({ name }))),
-          ok: 1
+            databases: await admin!.listKeyspaces(options).then(keyspaces => keyspaces.map(name => ({ name }))),
+            ok: 1
         };
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,10 @@ export { OperationNotSupportedError } from './operationNotSupportedError';
 export type AstraMongoose = Omit<Mongoose, 'connection'> & { connection: AstraMongooseDriver.Connection };
 
 declare module 'mongodb' {
+    interface FilterOperators<TValue> {
+        $match?: TValue extends string ? string : never;
+    }
+
     interface CreateCollectionOptions {
         vector?: CollectionVectorOptions;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/tests/driver/collections.api.test.ts
+++ b/tests/driver/collections.api.test.ts
@@ -751,7 +751,6 @@ describe('COLLECTIONS: mongoose Model API level tests with collections', async (
                 () => Product.watch().next(),
                 { message: 'watch() Not Implemented' }
             );
-            );
         });
         it('API ops tests Model.where()', async () => {
             const product1 = new Product({name: 'Product 1', price: 10, isCertified: true, category: 'cat 2'});

--- a/tests/driver/collections.api.test.ts
+++ b/tests/driver/collections.api.test.ts
@@ -227,7 +227,12 @@ describe('COLLECTIONS: mongoose Model API level tests with collections', async (
             await product1.save();
             const error: Error | null = await Product.$where('this.name === "Product 1"').exec().then(() => null, error => error);
             assert.ok(error instanceof DataAPIResponseError);
-            assert.strictEqual(error.errorDescriptors[0].message, 'Invalid filter expression: filter clause path (\'$where\') cannot start with `$`');
+            assert.ok(
+                error.errorDescriptors[0].message.startsWith(
+                    'Unsupported filter clause: filter expression path (\'$where\') cannot start with \'$\'.'
+                ),
+                error.errorDescriptors[0].message
+            );
         });
         it('API ops tests db.dropCollection() and Model.createCollection()', async function() {
             this.timeout(120_000);
@@ -742,11 +747,8 @@ describe('COLLECTIONS: mongoose Model API level tests with collections', async (
         it('API ops tests Model.watch()', async () => {
             const product1 = new Product({name: 'Product 1', price: 10, isCertified: true, category: 'cat 2'});
             await product1.save();
-            assert.throws(
-                () => Product.watch().on('change', (change) => {
-                    assert.strictEqual(change.operationType, 'delete');
-                    assert.strictEqual(change.documentKey._id.toString(), product1._id.toString());
-                }),
+            await assert.rejects(
+                Product.watch().next(),
                 { message: 'watch() Not Implemented' }
             );
         });

--- a/tests/driver/collections.api.test.ts
+++ b/tests/driver/collections.api.test.ts
@@ -748,8 +748,9 @@ describe('COLLECTIONS: mongoose Model API level tests with collections', async (
             const product1 = new Product({name: 'Product 1', price: 10, isCertified: true, category: 'cat 2'});
             await product1.save();
             await assert.rejects(
-                Product.watch().next(),
+                () => Product.watch().next(),
                 { message: 'watch() Not Implemented' }
+            );
             );
         });
         it('API ops tests Model.where()', async () => {

--- a/tests/driver/collections.driver.test.ts
+++ b/tests/driver/collections.driver.test.ts
@@ -201,8 +201,8 @@ describe('COLLECTIONS: driver based tests', async () => {
             const Person = mongooseInstance!.model('Person');
             await Person.init();
             await Person.deleteMany({});
-            assert.throws(
-                () => Person.watch([{$match: {name: 'John'}}]),
+            await assert.rejects(
+                Person.watch([{ $match: { name: 'John' } }]).next(),
                 /watch\(\) Not Implemented/
             );
         });

--- a/tests/driver/tables.api.test.ts
+++ b/tests/driver/tables.api.test.ts
@@ -557,11 +557,8 @@ describe('TABLES: Mongoose Model API level tests', async () => {
         it('API ops tests Model.watch()', async () => {
             const product1 = new Product({name: 'Product 1', price: 10, isCertified: true, category: 'cat 2'});
             await product1.save();
-            assert.throws(
-                () => Product.watch().on('change', (change) => {
-                    assert.strictEqual(change.operationType, 'delete');
-                    assert.strictEqual(change.documentKey._id.toString(), product1._id.toString());
-                }),
+            await assert.rejects(
+                Product.watch().next(),
                 { message: 'watch() Not Implemented' }
             );
         });

--- a/tests/driver/tables.api.test.ts
+++ b/tests/driver/tables.api.test.ts
@@ -561,7 +561,6 @@ describe('TABLES: Mongoose Model API level tests', async () => {
                 () => Product.watch().next(),
                 { message: 'watch() Not Implemented' }
             );
-            );
         });
         it('API ops tests Model.where()', async () => {
             const product1 = new Product({name: 'Product 1', price: 10, isCertified: true, category: 'cat 2'});

--- a/tests/driver/tables.api.test.ts
+++ b/tests/driver/tables.api.test.ts
@@ -558,8 +558,9 @@ describe('TABLES: Mongoose Model API level tests', async () => {
             const product1 = new Product({name: 'Product 1', price: 10, isCertified: true, category: 'cat 2'});
             await product1.save();
             await assert.rejects(
-                Product.watch().next(),
+                () => Product.watch().next(),
                 { message: 'watch() Not Implemented' }
+            );
             );
         });
         it('API ops tests Model.where()', async () => {

--- a/tests/driver/tables.driver.test.ts
+++ b/tests/driver/tables.driver.test.ts
@@ -201,8 +201,8 @@ describe('TABLES: driver based tests', async () => {
             const Person = mongooseInstance!.model('Person');
             await Person.init();
             await Person.deleteMany({});
-            assert.throws(
-                () => Person.watch([{$match: {name: 'John'}}]),
+            await assert.rejects(
+                Person.watch([{ $match: { name: 'John' } }]).next(),
                 /watch\(\) Not Implemented/
             );
         });

--- a/tests/driver/tables.test.ts
+++ b/tests/driver/tables.test.ts
@@ -629,10 +629,10 @@ describe('TABLES: basic operations and data types', function() {
             }]);
 
             // 2. Define schema that uses a set of AddressType as "addresses"
-            const addressSchema = new Schema(
+            const addressSchema = Schema.create(
                 {
-                    city: { type: String },
-                    state: { type: String }
+                    city: { type: String, required: true },
+                    state: { type: String, required: true }
                 },
                 { udtName: 'AddressType', versionKey: false, _id: false }
             );

--- a/tests/driver/tables.test.ts
+++ b/tests/driver/tables.test.ts
@@ -275,7 +275,7 @@ describe('TABLES: basic operations and data types', function() {
         findOneResponse.tags!.add('typescript');
         findOneResponse.tags!.delete('nodejs');
         findOneResponse.luckyNumbers!.add(99);
-        assert.deepStrictEqual(findOneResponse.getChanges(), {
+        assert.deepStrictEqual(findOneResponse.$getChanges(), {
             $set: { tags: ['cassandra', 'mongodb', 'typescript'] },
             $push: { luckyNumbers: { $each: [99] } }
         });
@@ -283,7 +283,7 @@ describe('TABLES: basic operations and data types', function() {
 
         // Test that atomics were reset after save
         findOneResponse.tags!.add('java');
-        assert.deepStrictEqual(findOneResponse.getChanges(), {
+        assert.deepStrictEqual(findOneResponse.$getChanges(), {
             $push: { tags: { $each: ['java'] } }
         });
 
@@ -464,7 +464,7 @@ describe('TABLES: basic operations and data types', function() {
 
             doc.luckyNumbers!.delete(2);
             assert.deepEqual(
-                doc.getChanges(),
+                doc.$getChanges(),
                 { $pullAll: { luckyNumbers: [2] } }
             );
             doc.luckyNumbers!.delete(1);
@@ -472,7 +472,7 @@ describe('TABLES: basic operations and data types', function() {
             // @ts-expect-error Mongoose will cast '1' to a number
             doc.luckyNumbers!.delete('1');
             assert.deepEqual(
-                doc.getChanges(),
+                doc.$getChanges(),
                 { $pullAll: { luckyNumbers: [2, 1] } }
             );
             await doc.save();
@@ -525,13 +525,13 @@ describe('TABLES: basic operations and data types', function() {
             });
             doc.luckyNumbers!.delete(42);
             doc.luckyNumbers!.add(99);
-            assert.deepStrictEqual(doc.getChanges(), {
+            assert.deepStrictEqual(doc.$getChanges(), {
                 $set: {
                     luckyNumbers: [7, 77, 99]
                 }
             });
             doc.luckyNumbers!.delete(99);
-            assert.deepStrictEqual(doc.getChanges(), {
+            assert.deepStrictEqual(doc.$getChanges(), {
                 $set: {
                     luckyNumbers: [7, 77]
                 }
@@ -705,7 +705,7 @@ describe('TABLES: basic operations and data types', function() {
             // 6. Change tracking
             foundUser.addresses.add({ city: 'San Francisco', state: 'CA' });
             assert.deepStrictEqual(
-                foundUser.getChanges(),
+                foundUser.$getChanges(),
                 {
                     $push: {
                         addresses: {
@@ -730,7 +730,7 @@ describe('TABLES: basic operations and data types', function() {
             }, {});
             updatedUser = await User.findOne({ name: 'Bob' }).orFail();
             assert.strictEqual(updatedUser.addresses!.size, 4);
-            assert.deepStrictEqual(updatedUser.getChanges(), {});
+            assert.deepStrictEqual(updatedUser.$getChanges(), {});
             // Assert that the Los Angeles entry's key order is city, state
             const lastAddress = [...updatedUser.addresses!].find(
                 addr => addr.city === 'Los Angeles' && addr.state === 'CA'
@@ -741,17 +741,17 @@ describe('TABLES: basic operations and data types', function() {
 
             // Different key order should still be equal
             updatedUser.addresses!.add({ state: 'CA', city: 'Los Angeles' });
-            assert.deepStrictEqual(updatedUser.getChanges(), {});
+            assert.deepStrictEqual(updatedUser.$getChanges(), {});
 
             updatedUser.addresses!.add({ city: 'Portland', state: 'OR' });
-            assert.deepStrictEqual(updatedUser.getChanges(), {});
+            assert.deepStrictEqual(updatedUser.$getChanges(), {});
             await updatedUser.save();
             updatedUser = await User.findOne({ name: 'Bob' }).orFail();
             assert.strictEqual(updatedUser.addresses!.size, 4);
 
             updatedUser.addresses!.delete({ city: 'Portland', state: 'OR' });
             assert.deepStrictEqual(
-                updatedUser.getChanges(),
+                updatedUser.$getChanges(),
                 { $pullAll: { addresses: [{ city: 'Portland', state: 'OR' }] } }
             );
             await updatedUser.save();


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

1. Bump Data API to v1.0.46  and DSE to 6.9.21 based on https://github.com/stargate/data-api/blob/main/pom.xml
2. Mongoose `getChanges()` is deprecated in favor of `$getChanges()` - just a rename
3. Since v9.3.0, Mongoose does not throw errors immediately if the underlying change stream `watch()` throws an error - this is an edge case for Mongoose. However, using the change stream will still error, so I updated the tests to assert that using the change stream errors out.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)