### PR TITLE
Upgrade to TypeScript 6, add clean-db script to clean collections, couple of minor fixes

### DIFF
--- a/bin/clean-db.ts
+++ b/bin/clean-db.ts
@@ -1,0 +1,55 @@
+// Copyright DataStax, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import mongoose from 'mongoose';
+import { driver } from '../src';
+import type { Connection } from '../src/driver';
+
+void main().catch(err => {
+    console.error(err);
+    process.exitCode = 1;
+});
+
+async function main() {
+    const uri = process.env.DATA_API_URI;
+    if (!uri) {
+        throw new Error('DATA_API_URI must be set');
+    }
+
+    mongoose.setDriver(driver);
+    await mongoose.connect(uri, {
+        isAstra: false,
+        username: process.env.STARGATE_USERNAME,
+        password: process.env.STARGATE_PASSWORD
+    });
+
+    try {
+        const connection = mongoose.connection as unknown as Connection;
+        const collections = await connection.listCollections({ nameOnly: true });
+        for (const collectionName of collections) {
+            console.log(`Dropping collection ${collectionName}`);
+            await connection.dropCollection(collectionName);
+        }
+
+        const tables = await connection.listTables({ nameOnly: true });
+        for (const tableName of tables) {
+            console.log(`Dropping table ${tableName}`);
+            await connection.dropTable(tableName);
+        }
+
+        console.log(`Dropped ${collections.length} collections and ${tables.length} tables`);
+    } finally {
+        await mongoose.disconnect();
+    }
+}

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "test": "env TEST_DOC_DB=dataapi node --env-file=.env ./node_modules/.bin/ts-mocha --forbid-only -p tsconfig.json tests/**/*.test.ts tests/*.test.ts",
     "test-astra": "env TEST_DOC_DB=astra node --env-file=.env ./node_modules/.bin/nyc --check-coverage --reporter=text --reporter=lcov ts-mocha --forbid-only -p tsconfig.json tests/**/*.test.ts tests/*.test.ts",
     "test-dataapi": "env TEST_DOC_DB=dataapi node --env-file=.env ./node_modules/.bin/nyc --check-coverage --reporter=text --reporter=lcov ts-mocha --forbid-only -p tsconfig.json tests/**/*.test.ts tests/*.test.ts",
+    "clean-db": "node --env-file=.env ./node_modules/.bin/ts-node --project tsconfig.json bin/clean-db.ts",
     "preinstall": "npm run update-version-file",
     "build": "npm run update-version-file && tsc --project tsconfig.build.json",
     "build:test": "tsc",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "nyc": "^17.1.0",
     "sinon": "^16.1.1",
     "ts-mocha": "^11.1.0",
-    "typescript": "5.x",
+    "typescript": "6.x",
     "typescript-eslint": "^8.35.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "nyc": "^17.1.0",
     "sinon": "^16.1.1",
     "ts-mocha": "^11.1.0",
-    "typescript": "6.x",
+    "typescript": "~6.0",
     "typescript-eslint": "^8.35.0"
   },
   "dependencies": {

--- a/src/driver/connection.ts
+++ b/src/driver/connection.ts
@@ -94,7 +94,7 @@ export class Connection extends MongooseConnection {
     // @ts-expect-error astra-mongoose Db classes don't fully extend from Mongoose Db in a TypeScript-compatible way.
     db: CollectionsDb | TablesDb | null = null;
     keyspaceName: string | null = null;
-    config?: ConnectOptionsInternal;
+    config?: Partial<ConnectOptionsInternal>;
     baseUrl: string | null = null;
     baseApiPath: string | null = null;
     models: Record<string, Model<unknown>> = {};
@@ -139,17 +139,21 @@ export class Connection extends MongooseConnection {
             // @ts-expect-error _waitForConnect not part of public API
             await this._waitForConnect();
             // Cannot happen, but this helps TypeScript infer the correct return type
-            assert.ok(this.db);
-            assert.ok(this.admin);
-            return { db: this.db, admin: this.admin };
+            const db = this.db;
+            const admin = this.admin;
+            assert.ok(db);
+            assert.ok(admin);
+            return { db, admin };
         } else if (this.readyState !== STATES.connected) {
             throw new AstraMongooseError('Connection is not connected', { readyState: this.readyState });
         }
 
         // Cannot happen, but this helps TypeScript infer the correct return type
-        assert.ok(this.db);
-        assert.ok(this.admin);
-        return { db: this.db, admin: this.admin };
+        const db = this.db;
+        const admin = this.admin;
+        assert.ok(db);
+        assert.ok(admin);
+        return { db, admin };
     }
 
     /**

--- a/tests/convertSchemaToColumns.test.ts
+++ b/tests/convertSchemaToColumns.test.ts
@@ -12,11 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Schema } from 'mongoose';
+import { Mongoose, Schema as MongooseSchema } from 'mongoose';
 import assert from 'assert';
 import convertSchemaToColumns from '../src/convertSchemaToColumns';
+import * as AstraMongooseDriver from '../src/driver';
 
 describe('convertSchemaToColumns', () => {
+    let Schema: typeof MongooseSchema;
+
+    beforeEach(() => {
+        const mongooseInstance = new Mongoose();
+        Object.assign(mongooseInstance.Schema.Types, AstraMongooseDriver.SchemaTypes);
+        Schema = mongooseInstance.Schema;
+    });
+
     it('generates table definition from schema with all primitive data types', () => {
         const testSchema = new Schema({
             name: String,
@@ -512,7 +521,7 @@ describe('convertSchemaToColumns', () => {
     it('throws if set value is not supported type', () => {
         const testSchema = new Schema({
             mySet: {
-                type: Set, of: { type: Set, of: { type: String, required: true }, required: true }
+                type: Set, of: { type: 'Mixed', required: true }
             }
         });
 

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,7 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src"
+  },
   "exclude": ["tests/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,15 @@
 {
   "compilerOptions": {
     "target": "es2020",
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "module": "Node16",
+    "moduleResolution": "Node16",
     "declaration": true,
     "sourceMap": true,
-    "baseUrl": "./",
     "outDir": "./dist",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
+    "types": ["node", "mocha"],
     "skipLibCheck": true
   },
   "include": ["tests/**/*", "src/**/*"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "Node16",
     "declaration": true,
     "sourceMap": true,
+    "rootDir": ".",
     "outDir": "./dist",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

1. Upgrade to TypeScript 6
2. Leftover collections always caused trouble for testing the photography sample app - `npm run seed` would run into the 5 collections limit and troubleshooting that is difficult. Added a script to clean up test collections
3. Couple of minor test fixes

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)