### PR TITLE
Remove requirement to use `skipLibCheck`

### DIFF
--- a/APIReference.md
+++ b/APIReference.md
@@ -632,7 +632,7 @@ for tables and CollectionsDb class for collections.</p>
 **Kind**: global class  
 
 * [BaseDb](#BaseDb)
-    * [new BaseDb()](#new_BaseDb_new)
+    * [.isTable](#BaseDb+isTable)
     * [.createTable(name, definition)](#BaseDb+createTable)
     * [.dropCollection(name)](#BaseDb+dropCollection)
     * [.dropTable(name)](#BaseDb+dropTable)
@@ -645,13 +645,14 @@ for tables and CollectionsDb class for collections.</p>
     * [.syncTypes(types)](#BaseDb+syncTypes) ⇒
     * [.command(command)](#BaseDb+command)
 
-<a name="new_BaseDb_new"></a>
+<a name="BaseDb+isTable"></a>
 
-### new BaseDb()
+### baseDb.isTable
 <p>Whether we're using &quot;tables mode&quot; or &quot;collections mode&quot;. If tables mode, then <code>collection()</code> returns
 a Table instance, <strong>not</strong> a Collection instance. Also, if tables mode, <code>createCollection()</code> throws an
 error for Mongoose <code>syncIndexes()</code> compatibility reasons.</p>
 
+**Kind**: instance property of [<code>BaseDb</code>](#BaseDb)  
 <a name="BaseDb+createTable"></a>
 
 ### baseDb.createTable(name, definition)
@@ -1033,7 +1034,7 @@ the one exception being strings.</p>
 **Extends**: [<code>BaseDb</code>](#BaseDb)  
 
 * [BaseDb](#BaseDb) ⇐ [<code>BaseDb</code>](#BaseDb)
-    * [new BaseDb()](#new_BaseDb_new)
+    * [.isTable](#BaseDb+isTable)
     * [.createTable(name, definition)](#BaseDb+createTable)
     * [.dropCollection(name)](#BaseDb+dropCollection)
     * [.dropTable(name)](#BaseDb+dropTable)
@@ -1046,13 +1047,14 @@ the one exception being strings.</p>
     * [.syncTypes(types)](#BaseDb+syncTypes) ⇒
     * [.command(command)](#BaseDb+command)
 
-<a name="new_BaseDb_new"></a>
+<a name="BaseDb+isTable"></a>
 
-### new BaseDb()
+### baseDb.isTable
 <p>Whether we're using &quot;tables mode&quot; or &quot;collections mode&quot;. If tables mode, then <code>collection()</code> returns
 a Table instance, <strong>not</strong> a Collection instance. Also, if tables mode, <code>createCollection()</code> throws an
 error for Mongoose <code>syncIndexes()</code> compatibility reasons.</p>
 
+**Kind**: instance property of [<code>BaseDb</code>](#BaseDb)  
 <a name="BaseDb+createTable"></a>
 
 ### baseDb.createTable(name, definition)

--- a/bin/warm-up-tests.ts
+++ b/bin/warm-up-tests.ts
@@ -57,7 +57,7 @@ async function main() {
             }
         }
 
-        const collection = connection.db!.collection(collectionName, {});
+        const collection = connection.astraDb!.collection(collectionName, {});
         await retryNotEnoughReplicas(async () => {
             await collection.insertOne({ ping: true, ts: new Date() });
             await collection.deleteMany({});

--- a/jsdoc2md.json
+++ b/jsdoc2md.json
@@ -8,6 +8,6 @@
     "extensions": ["ts", "tsx"],
     "ignore": ["**/*.(test|spec).ts"],
     "babelrc": false,
-    "presets": [["@babel/preset-env", { "targets": { "node": true } }], "@babel/preset-typescript"]
+    "presets": [["@babel/preset-env", { "targets": { "node": true } }], ["@babel/preset-typescript", { "allowDeclareFields": true }]]
   }
 }

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -16,6 +16,7 @@ import { AstraMongooseError } from '../astraMongooseError';
 import { BaseCollection as MongooseCollection } from 'mongoose';
 import type { BaseConnection as MongooseConnection } from 'mongoose';
 import type { Connection } from './connection';
+import type { BaseDb } from './db';
 import {
     Collection as AstraCollection,
     CollectionCountDocumentsOptions,
@@ -144,7 +145,10 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
             ? { serdes: this._options.schemaUserProvidedOptions.serdes } as unknown as Record<string, never>
             : {};
         // Cache because @datastax/astra-db-ts doesn't
-        const collection = this.connection.astraDb!.collection<DocType>(this.name, collectionOptions);
+        // Widen to `BaseDb` because calling a generic overloaded method on the `CollectionsDb | TablesDb`
+        // union loses the type parameter.
+        const db: BaseDb = this.connection.db!;
+        const collection = db.collection<DocType>(this.name, collectionOptions);
         this._collection = collection;
 
         // Bubble up collection-level events from astra-db-ts to the main connection
@@ -156,11 +160,11 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
         return collection;
     }
 
-    // Get whether the underlying Astra store is a table or a collection. `connection.astraDb` may be undefined if
+    // Get whether the underlying Astra store is a table or a collection. `connection.db` may be `undefined` if
     // the connection has never been opened (`mongoose.connect()` or `openUri()` never called), so in that
     // case we default to `isTable: false`.
     get isTable() {
-        return this.connection.astraDb?.isTable;
+        return this.connection.db?.isTable;
     }
 
     /**
@@ -614,7 +618,7 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
     async runCommand(command: Record<string, unknown>, options?: Omit<RunCommandOptions, 'table' | 'collection' | 'keyspace'>) {
         // eslint-disable-next-line prefer-rest-params
         _logFunctionCall(this, this.connection.debug, this.name, 'runCommand', arguments);
-        return await this.connection.astraDb!.astraDb.command(
+        return await this.connection.db!.astraDb.command(
             command,
             this.isTable ? { table: this.name, ...options } : { collection: this.name, ...options }
         );
@@ -730,7 +734,7 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
         if (this.collection instanceof AstraCollection) {
             throw new OperationNotSupportedError('Cannot use dropIndex() with collections');
         }
-        await this.connection.astraDb!.astraDb.dropTableIndex(name, options);
+        await this.connection.db!.astraDb.dropTableIndex(name, options);
         return {};
     }
 

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -63,7 +63,7 @@ import { OperationNotSupportedError } from '../operationNotSupportedError';
 import { SchemaOptions } from 'mongoose';
 import { Writable } from 'stream';
 import deserializeDoc from '../deserializeDoc';
-import { IndexSpecification, Sort as MongoDBSort, WithId, InferIdType } from 'mongodb';
+import { FindCursor, IndexSpecification, ListIndexesCursor, Sort as MongoDBSort, WithId, InferIdType } from 'mongodb';
 import { inspect } from 'util';
 import { serialize } from '../serialize';
 import { setDefaultIdForUpdate, setDefaultIdForReplace } from '../setDefaultIdForUpsert';
@@ -77,7 +77,7 @@ type FindOptions = (Omit<CollectionFindOptions, 'sort'> | Omit<TableFindOptions,
   & { sort?: MongooseSortOption, maxTimeMS?: number, timeout?: boolean };
 type FindOneOptions = (Omit<CollectionFindOneOptions, 'sort'> | Omit<TableFindOneOptions, 'sort' | 'timeout' | 'maxTimeMS'>)
   & { sort?: MongooseSortOption, maxTimeMS?: number, timeout?: boolean };
-type FindOneAndUpdateOptions = Omit<CollectionFindOneAndUpdateOptions, 'sort'>
+type FindOneAndUpdateOptions = Omit<CollectionFindOneAndUpdateOptions, 'sort' | 'maxTimeMS'>
     & { sort?: MongooseSortOption, includeResultMetadata?: boolean };
 type FindOneAndDeleteOptions = Omit<CollectionFindOneAndDeleteOptions, 'sort' | 'maxTimeMS'>
     & { sort?: MongooseSortOption, includeResultMetadata?: boolean, maxTimeMS?: number };
@@ -89,15 +89,6 @@ type InsertOneOptions = (Omit<CollectionInsertOneOptions, 'maxTimeMS'> | Omit<Ta
 type ReplaceOneOptions = Omit<CollectionReplaceOneOptions, 'sort' | 'maxTimeMS'> & { sort?: MongooseSortOption, maxTimeMS?: number };
 type UpdateOneOptions = (Omit<CollectionUpdateOneOptions, 'sort' | 'maxTimeMS'> | Omit<TableUpdateOneOptions, 'sort' | 'maxTimeMS'>)
     & { sort?: MongooseSortOption, maxTimeMS?: number };
-
-interface AstraMongooseIndexDescription {
-    name: string,
-    definition: {
-      column: string | ({ [key: string]: '$keys' | '$values' }),
-      options?: TableIndexOptions | TableVectorIndexOptions | TableTextIndexOptions;
-    },
-    key: Record<string, 1 | -1 | '$keys' | '$values'>
-}
 
 interface AstraIndexDescription {
   name: string;
@@ -128,8 +119,7 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
     _collection?: AstraCollection<DocType> | AstraTable<DocType>;
     _closed: boolean;
     connection: Connection;
-    // @ts-expect-error options is technically a function on Mongoose collections
-    options?: (TableOptions | CollectionOptions) & MongooseCollectionOptions;
+    _options?: (TableOptions | CollectionOptions) & MongooseCollectionOptions;
     name: string;
 
     constructor(name: string, conn: Connection, options?: (TableOptions | CollectionOptions) & MongooseCollectionOptions) {
@@ -138,7 +128,7 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
         super(name, conn as unknown as MongooseConnection, options);
         this.connection = conn;
         this._closed = false;
-        this.options = options;
+        this._options = options;
         this.name = name;
     }
 
@@ -148,10 +138,10 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
             return this._collection;
         }
 
-        const collectionOptions = this.options?.schemaUserProvidedOptions?.serdes
+        const collectionOptions = this._options?.schemaUserProvidedOptions?.serdes
             // Type coercion because `collection<>` method below doesn't know whether we're creating a
             // Astra Table or Astra Collection until runtime
-            ? { serdes: this.options.schemaUserProvidedOptions.serdes } as unknown as Record<string, never>
+            ? { serdes: this._options.schemaUserProvidedOptions.serdes } as unknown as Record<string, never>
             : {};
         // Cache because @datastax/astra-db-ts doesn't
         const collection = this.connection.db!.collection<DocType>(this.name, collectionOptions);
@@ -195,7 +185,6 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
      * @param callback
      */
 
-    // @ts-expect-error Astra cursor is not fully compatible with MongoDB cursor
     find(filter?: Filter, options?: FindOptions) {
         // eslint-disable-next-line prefer-rest-params
         _logFunctionCall(this, this.connection.debug, this.name, 'find', arguments);
@@ -206,7 +195,9 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
             : { ...remainingOptions, sort: undefined };
         filter = serialize(filter ?? {}, this.isTable);
 
-        return this.collection.find(filter, requestOptions).map(doc => deserializeDoc<DocType>(doc) as DocType);
+        return this.collection
+            .find(filter, requestOptions)
+            .map(doc => deserializeDoc<DocType>(doc) as DocType) as unknown as FindCursor<WithId<DocType>>;
     }
 
     /**
@@ -268,12 +259,12 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
      * @param options
      */
 
-    // @ts-expect-error CollectionUpdateFilter not compatible with MongoDB UpdateFilter due to $inc inconsistencies and other issues
     async findOneAndUpdate(
         filter: Filter,
-        update: CollectionUpdateFilter<DocType> | Record<string, unknown>[],
-        options: FindOneAndUpdateOptions
-    ) {
+        update: CollectionUpdateFilter<DocType> | TableUpdateFilter<DocType> | Record<string, unknown>[],
+        options?: FindOneAndUpdateOptions
+    ): Promise<any> {
+        options = options ?? {};
         if (Array.isArray(update)) {
             throw new AstraMongooseError('Astra-mongoose does not support update pipelines', { update });
         }
@@ -289,10 +280,10 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
 
         filter = serialize(filter);
         setDefaultIdForUpdate<DocType>(filter, update, requestOptions);
-        update = serialize(update);
+        update = serialize(update as Record<string, unknown>);
 
         return await this.collection.findOneAndUpdate(filter, update, requestOptions).then((value: Record<string, unknown> | null) => {
-            if (options?.includeResultMetadata) {
+            if (options.includeResultMetadata) {
                 return { value: deserializeDoc<DocType>(value) };
             }
             return deserializeDoc<DocType>(value);
@@ -486,7 +477,7 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
         if (!this.isTable) {
             setDefaultIdForUpdate(filter, update as CollectionUpdateFilter<DocType>, requestOptions);
         }
-        update = serialize(update, this.isTable);
+        update = serialize(update as Record<string, unknown>, this.isTable);
         return await this.collection.updateOne(filter as TableFilter<DocType>, update, requestOptions).then(res => {
             // Mongoose currently has a bug where null response from updateOne() throws an error that we can't
             // catch here for unknown reasons. See Automattic/mongoose#15126. Tables API returns null here.
@@ -503,8 +494,11 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
      * @param options
      */
 
-    // @ts-expect-error CollectionUpdateFilter not compatible with MongoDB UpdateFilter due to $inc inconsistencies and other issues
-    async updateMany(filter: Filter, update: CollectionUpdateFilter<DocType> | Record<string, unknown>[], options: CollectionUpdateManyOptions) {
+    async updateMany(
+        filter: Filter,
+        update: CollectionUpdateFilter<DocType> | TableUpdateFilter<DocType> | Record<string, unknown>[],
+        options?: Omit<CollectionUpdateManyOptions, 'maxTimeMS'>
+    ): Promise<any> {
         if (Array.isArray(update)) {
             throw new AstraMongooseError('Astra-mongoose does not support update pipelines', { update });
         }
@@ -514,10 +508,13 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
         if (this.collection instanceof AstraTable) {
             throw new OperationNotSupportedError('Cannot use updateMany() with tables');
         }
+        options = options ?? {};
         filter = serialize(filter, this.isTable);
         setDefaultIdForUpdate(filter, update, options);
-        update = serialize(update, this.isTable);
-        return await this.collection.updateMany(filter, update, options).then(res => ({ ...res, acknowledged: true }));
+        update = serialize(update as Record<string, unknown>, this.isTable);
+        return await this.collection
+            .updateMany(filter, update, options)
+            .then(res => ({ ...res, acknowledged: true }));
     }
 
     /**
@@ -650,8 +647,7 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
      * Only works in tables mode, throws an error in collections mode.
      */
 
-    // @ts-expect-error Returns a pseudo-cursor, which isn't fully compatible with MongoDB cursors.
-    listIndexes(): { toArray: () => Promise<AstraMongooseIndexDescription[]> } {
+    listIndexes(): ListIndexesCursor {
         // eslint-disable-next-line prefer-rest-params
         _logFunctionCall(this, this.connection.debug, this.name, 'listIndexes', arguments);
         if (this.collection instanceof AstraCollection) {
@@ -669,7 +665,7 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
                     // Mongoose uses the `key` property of an index for index diffing in `cleanIndexes()` and `syncIndexes()`.
                     return indexes.map((index) => ({ ...index, key: typeof index.definition.column === 'string' ? { [index.definition.column]: 1 } : index.definition.column }));
                 })
-        };
+        } as unknown as ListIndexesCursor;
     }
 
     /**

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -16,7 +16,6 @@ import { AstraMongooseError } from '../astraMongooseError';
 import { BaseCollection as MongooseCollection } from 'mongoose';
 import type { BaseConnection as MongooseConnection } from 'mongoose';
 import type { Connection } from './connection';
-import type { BaseDb } from './db';
 import {
     Collection as AstraCollection,
     CollectionCountDocumentsOptions,
@@ -145,10 +144,7 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
             ? { serdes: this._options.schemaUserProvidedOptions.serdes } as unknown as Record<string, never>
             : {};
         // Cache because @datastax/astra-db-ts doesn't
-        // Widen to `BaseDb` because calling a generic overloaded method on the `CollectionsDb | TablesDb`
-        // union loses the type parameter.
-        const db: BaseDb = this.connection.db!;
-        const collection = db.collection<DocType>(this.name, collectionOptions);
+        const collection = this.connection.astraDb!.collection<DocType>(this.name, collectionOptions);
         this._collection = collection;
 
         // Bubble up collection-level events from astra-db-ts to the main connection
@@ -160,11 +156,11 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
         return collection;
     }
 
-    // Get whether the underlying Astra store is a table or a collection. `connection.db` may be `undefined` if
+    // Get whether the underlying Astra store is a table or a collection. `connection.astraDb` may be undefined if
     // the connection has never been opened (`mongoose.connect()` or `openUri()` never called), so in that
     // case we default to `isTable: false`.
     get isTable() {
-        return this.connection.db?.isTable;
+        return this.connection.astraDb?.isTable;
     }
 
     /**
@@ -618,7 +614,7 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
     async runCommand(command: Record<string, unknown>, options?: Omit<RunCommandOptions, 'table' | 'collection' | 'keyspace'>) {
         // eslint-disable-next-line prefer-rest-params
         _logFunctionCall(this, this.connection.debug, this.name, 'runCommand', arguments);
-        return await this.connection.db!.astraDb.command(
+        return await this.connection.astraDb!.astraDb.command(
             command,
             this.isTable ? { table: this.name, ...options } : { collection: this.name, ...options }
         );
@@ -734,7 +730,7 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
         if (this.collection instanceof AstraCollection) {
             throw new OperationNotSupportedError('Cannot use dropIndex() with collections');
         }
-        await this.connection.db!.astraDb.dropTableIndex(name, options);
+        await this.connection.astraDb!.astraDb.dropTableIndex(name, options);
         return {};
     }
 

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -144,7 +144,7 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
             ? { serdes: this._options.schemaUserProvidedOptions.serdes } as unknown as Record<string, never>
             : {};
         // Cache because @datastax/astra-db-ts doesn't
-        const collection = this.connection.db!.collection<DocType>(this.name, collectionOptions);
+        const collection = this.connection.astraDb!.collection<DocType>(this.name, collectionOptions);
         this._collection = collection;
 
         // Bubble up collection-level events from astra-db-ts to the main connection
@@ -156,11 +156,11 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
         return collection;
     }
 
-    // Get whether the underlying Astra store is a table or a collection. `connection.db` may be `null` if
+    // Get whether the underlying Astra store is a table or a collection. `connection.astraDb` may be undefined if
     // the connection has never been opened (`mongoose.connect()` or `openUri()` never called), so in that
     // case we default to `isTable: false`.
     get isTable() {
-        return this.connection.db?.isTable;
+        return this.connection.astraDb?.isTable;
     }
 
     /**
@@ -614,7 +614,7 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
     async runCommand(command: Record<string, unknown>, options?: Omit<RunCommandOptions, 'table' | 'collection' | 'keyspace'>) {
         // eslint-disable-next-line prefer-rest-params
         _logFunctionCall(this, this.connection.debug, this.name, 'runCommand', arguments);
-        return await this.connection.db!.astraDb.command(
+        return await this.connection.astraDb!.astraDb.command(
             command,
             this.isTable ? { table: this.name, ...options } : { collection: this.name, ...options }
         );
@@ -730,7 +730,7 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
         if (this.collection instanceof AstraCollection) {
             throw new OperationNotSupportedError('Cannot use dropIndex() with collections');
         }
-        await this.connection.db!.astraDb.dropTableIndex(name, options);
+        await this.connection.astraDb!.astraDb.dropTableIndex(name, options);
         return {};
     }
 

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -264,28 +264,10 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
      */
 
     async findOneAndUpdate(
-      filter: Filter,
-      update: CollectionUpdateFilter<DocType> | TableUpdateFilter<DocType> | Record<string, unknown>[],
-      options: (FindOneAndUpdateOptions & { includeResultMetadata: true })
-    ): Promise<{ value: WithId<DocType> | null, ok: 1 }>;
-
-    async findOneAndUpdate(
-      filter: Filter,
-      update: CollectionUpdateFilter<DocType> | TableUpdateFilter<DocType> | Record<string, unknown>[],
-      options: (FindOneAndUpdateOptions & { includeResultMetadata: false })
-    ): Promise<WithId<DocType> | null>;
-
-    async findOneAndUpdate(
-      filter: Filter,
-      update: CollectionUpdateFilter<DocType> | TableUpdateFilter<DocType> | Record<string, unknown>[],
-      options?: FindOneAndUpdateOptions
-    ): Promise<WithId<DocType> | null>;
-
-    async findOneAndUpdate(
         filter: Filter,
         update: CollectionUpdateFilter<DocType> | TableUpdateFilter<DocType> | Record<string, unknown>[],
         options?: FindOneAndUpdateOptions
-    ) {
+    ): Promise<any> {
         options = options ?? {};
         if (Array.isArray(update)) {
             throw new AstraMongooseError('Astra-mongoose does not support update pipelines', { update });
@@ -306,9 +288,9 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
 
         return await this.collection.findOneAndUpdate(filter, update, requestOptions).then((value: Record<string, unknown> | null) => {
             if (options.includeResultMetadata) {
-                return { value: deserializeDoc<WithId<DocType>>(value), ok: 1 };
+                return { value: deserializeDoc<DocType>(value) };
             }
-            return deserializeDoc<WithId<DocType>>(value);
+            return deserializeDoc<DocType>(value);
         });
     }
 

--- a/src/driver/collection.ts
+++ b/src/driver/collection.ts
@@ -264,10 +264,28 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
      */
 
     async findOneAndUpdate(
+      filter: Filter,
+      update: CollectionUpdateFilter<DocType> | TableUpdateFilter<DocType> | Record<string, unknown>[],
+      options: (FindOneAndUpdateOptions & { includeResultMetadata: true })
+    ): Promise<{ value: WithId<DocType> | null, ok: 1 }>;
+
+    async findOneAndUpdate(
+      filter: Filter,
+      update: CollectionUpdateFilter<DocType> | TableUpdateFilter<DocType> | Record<string, unknown>[],
+      options: (FindOneAndUpdateOptions & { includeResultMetadata: false })
+    ): Promise<WithId<DocType> | null>;
+
+    async findOneAndUpdate(
+      filter: Filter,
+      update: CollectionUpdateFilter<DocType> | TableUpdateFilter<DocType> | Record<string, unknown>[],
+      options?: FindOneAndUpdateOptions
+    ): Promise<WithId<DocType> | null>;
+
+    async findOneAndUpdate(
         filter: Filter,
         update: CollectionUpdateFilter<DocType> | TableUpdateFilter<DocType> | Record<string, unknown>[],
         options?: FindOneAndUpdateOptions
-    ): Promise<any> {
+    ) {
         options = options ?? {};
         if (Array.isArray(update)) {
             throw new AstraMongooseError('Astra-mongoose does not support update pipelines', { update });
@@ -288,9 +306,9 @@ export class Collection<DocType extends Record<string, unknown> = Record<string,
 
         return await this.collection.findOneAndUpdate(filter, update, requestOptions).then((value: Record<string, unknown> | null) => {
             if (options.includeResultMetadata) {
-                return { value: deserializeDoc<DocType>(value) };
+                return { value: deserializeDoc<WithId<DocType>>(value), ok: 1 };
             }
-            return deserializeDoc<DocType>(value);
+            return deserializeDoc<WithId<DocType>>(value);
         });
     }
 

--- a/src/driver/connection.ts
+++ b/src/driver/connection.ts
@@ -103,7 +103,6 @@ export class Connection extends MongooseConnection {
     baseUrl: string | null = null;
     baseApiPath: string | null = null;
     models: Record<string, Model<unknown>> = {};
-    // @ts-expect-error astra-mongoose collection currently doesn't fully extend from Mongoose collection in a TypeScript-compatible way.
     collections: Record<string, Collection> = {};
     _debug?: boolean | { color?: boolean, shell?: boolean } | Writable | ((name: string, fn: string, ...args: unknown[]) => void) | null | undefined;
     _connectionString: string | null = null;
@@ -170,7 +169,6 @@ export class Connection extends MongooseConnection {
      * @param options
      */
 
-    // @ts-expect-error astra-mongoose collection currently doesn't fully extend from Mongoose collection in a TypeScript-compatible way.
     collection<DocType extends Record<string, unknown> = Record<string, unknown>>(name: string, options?: MongooseCollectionOptions): Collection<DocType> {
         if (!(name in this.collections)) {
             // @ts-expect-error astra-mongoose collection currently doesn't fully extend from Mongoose collection in a TypeScript-compatible way.

--- a/src/driver/connection.ts
+++ b/src/driver/connection.ts
@@ -97,7 +97,8 @@ export class Connection extends MongooseConnection {
     initialConnection: Promise<this> | null = null;
     client: DataAPIClient | null = null;
     admin: AstraDbAdmin | DataAPIDbAdmin | null = null;
-    db: CollectionsDb | TablesDb | undefined;
+    declare db: undefined;
+    astraDb: CollectionsDb | TablesDb | undefined;
     keyspaceName: string | null = null;
     config: Partial<ConnectOptionsInternal> = {};
     baseUrl: string | null = null;
@@ -146,7 +147,7 @@ export class Connection extends MongooseConnection {
             // @ts-expect-error _waitForConnect not part of public API
             await this._waitForConnect();
             // Cannot happen, but this helps TypeScript infer the correct return type
-            const db = this.db;
+            const db = this.astraDb;
             const admin = this.admin;
             assert.ok(db);
             assert.ok(admin);
@@ -156,7 +157,7 @@ export class Connection extends MongooseConnection {
         }
 
         // Cannot happen, but this helps TypeScript infer the correct return type
-        const db = this.db;
+        const db = this.astraDb;
         const admin = this.admin;
         assert.ok(db);
         assert.ok(admin);
@@ -187,7 +188,7 @@ export class Connection extends MongooseConnection {
     useDb(name: string, options?: UseDbOptions): Connection {
         options = options ?? {};
         if (options.useCache && this.relatedDbs[name]) {
-            const cachedDb = this.relatedDbs[name].db;
+            const cachedDb = this.relatedDbs[name].astraDb;
             if (options?.isTable != null && cachedDb != null && options.isTable !== cachedDb.isTable) {
                 throw new AstraMongooseError(`Cannot use cached connection for ${name} with isTable=${options.isTable} (cached connection is isTable=${cachedDb.isTable})`);
             }
@@ -219,7 +220,7 @@ export class Connection extends MongooseConnection {
 
         const wireup = () => {
             const client = this.client;
-            const parentDb = this.db;
+            const parentDb = this.astraDb;
             const admin = this.admin;
             const baseUrl = this.baseUrl;
             assert.ok(client);
@@ -246,7 +247,7 @@ export class Connection extends MongooseConnection {
         });
         this.initialConnection?.catch(err => rejectInitialConnection?.(err));
 
-        if (this.db) {
+        if (this.astraDb) {
             wireup();
         } else {
             // @ts-expect-error _queue is an internal Mongoose property.
@@ -275,7 +276,7 @@ export class Connection extends MongooseConnection {
         options?: MongoCreateCollectionOptions
     ): Promise<MongoDBCollection<DocType>> {
         const { db } = await this._waitForClient();
-        return await db.createCollection(name, options as unknown as CreateCollectionOptions<DocType>) as unknown as MongoDBCollection<DocType>;
+        return await db.createCollection<DocType>(name, options as unknown as CreateCollectionOptions<DocType>) as unknown as MongoDBCollection<DocType>;
     }
 
     /**
@@ -602,7 +603,7 @@ export class Connection extends MongooseConnection {
             collection._collection = undefined;
         }
 
-        this.db = db;
+        this.astraDb = db;
         this.admin = admin;
 
         // Bubble up db-level events from astra-db-ts to the main connection.
@@ -619,8 +620,8 @@ export class Connection extends MongooseConnection {
     }
 
     _clearDbEventListeners() {
-        if (this.db && this._dbEventListeners) {
-            const dbEmitter = this.db.astraDb;
+        if (this.astraDb && this._dbEventListeners) {
+            const dbEmitter = this.astraDb.astraDb;
             dbEmitter.off('commandStarted', this._dbEventListeners.commandStarted);
             dbEmitter.off('commandFailed', this._dbEventListeners.commandFailed);
             dbEmitter.off('commandSucceeded', this._dbEventListeners.commandSucceeded);
@@ -640,8 +641,8 @@ export class Connection extends MongooseConnection {
       */
     async doClose() {
         // Remove db-level event listeners if present
-        if (this.db && this._dbEventListeners) {
-            const dbEmitter = this.db.astraDb;
+        if (this.astraDb && this._dbEventListeners) {
+            const dbEmitter = this.astraDb.astraDb;
             dbEmitter.off('commandStarted', this._dbEventListeners.commandStarted);
             dbEmitter.off('commandFailed', this._dbEventListeners.commandFailed);
             dbEmitter.off('commandSucceeded', this._dbEventListeners.commandSucceeded);

--- a/src/driver/connection.ts
+++ b/src/driver/connection.ts
@@ -47,6 +47,7 @@ import {
 } from '@datastax/astra-db-ts';
 import { CollectionsDb, TablesDb } from './db';
 import { BaseConnection as MongooseConnection } from 'mongoose';
+import type { CreateCollectionOptions as MongoCreateCollectionOptions, Collection as MongoDBCollection } from 'mongodb';
 import { OperationNotSupportedError } from '../operationNotSupportedError';
 import { STATES } from 'mongoose';
 import type { ConnectOptions, Mongoose, Model } from 'mongoose';
@@ -96,10 +97,10 @@ export class Connection extends MongooseConnection {
     initialConnection: Promise<this> | null = null;
     client: DataAPIClient | null = null;
     admin: AstraDbAdmin | DataAPIDbAdmin | null = null;
-    // @ts-expect-error astra-mongoose Db classes don't fully extend from Mongoose Db in a TypeScript-compatible way.
-    db: CollectionsDb | TablesDb | null = null;
+    declare db: undefined;
+    astraDb: CollectionsDb | TablesDb | undefined;
     keyspaceName: string | null = null;
-    config?: Partial<ConnectOptionsInternal>;
+    config: Partial<ConnectOptionsInternal> = {};
     baseUrl: string | null = null;
     baseApiPath: string | null = null;
     models: Record<string, Model<unknown>> = {};
@@ -146,7 +147,7 @@ export class Connection extends MongooseConnection {
             // @ts-expect-error _waitForConnect not part of public API
             await this._waitForConnect();
             // Cannot happen, but this helps TypeScript infer the correct return type
-            const db = this.db;
+            const db = this.astraDb;
             const admin = this.admin;
             assert.ok(db);
             assert.ok(admin);
@@ -156,7 +157,7 @@ export class Connection extends MongooseConnection {
         }
 
         // Cannot happen, but this helps TypeScript infer the correct return type
-        const db = this.db;
+        const db = this.astraDb;
         const admin = this.admin;
         assert.ok(db);
         assert.ok(admin);
@@ -184,11 +185,10 @@ export class Connection extends MongooseConnection {
       * @param name The keyspace name
       * @param options
       */
-    // @ts-expect-error astra-mongoose connection currently doesn't fully extend from Mongoose connection in a TypeScript-compatible way because of collections
     useDb(name: string, options?: UseDbOptions): Connection {
         options = options ?? {};
         if (options.useCache && this.relatedDbs[name]) {
-            const cachedDb = this.relatedDbs[name].db;
+            const cachedDb = this.relatedDbs[name].astraDb;
             if (options?.isTable != null && cachedDb != null && options.isTable !== cachedDb.isTable) {
                 throw new AstraMongooseError(`Cannot use cached connection for ${name} with isTable=${options.isTable} (cached connection is isTable=${cachedDb.isTable})`);
             }
@@ -220,7 +220,7 @@ export class Connection extends MongooseConnection {
 
         const wireup = () => {
             const client = this.client;
-            const parentDb = this.db;
+            const parentDb = this.astraDb;
             const admin = this.admin;
             const baseUrl = this.baseUrl;
             assert.ok(client);
@@ -247,7 +247,7 @@ export class Connection extends MongooseConnection {
         });
         this.initialConnection?.catch(err => rejectInitialConnection?.(err));
 
-        if (this.db) {
+        if (this.astraDb) {
             wireup();
         } else {
             // @ts-expect-error _queue is an internal Mongoose property.
@@ -271,13 +271,12 @@ export class Connection extends MongooseConnection {
      * @param options
      */
 
-    // @ts-expect-error astra-mongoose collection currently doesn't fully extend from Mongoose collection in a TypeScript-compatible way.
     async createCollection<DocType extends Record<string, unknown> = Record<string, unknown>>(
         name: string,
-        options?: CreateCollectionOptions<DocType>
-    ) {
+        options?: MongoCreateCollectionOptions
+    ): Promise<MongoDBCollection<DocType>> {
         const { db } = await this._waitForClient();
-        return await db.createCollection<DocType>(name, options);
+        return await db.createCollection<DocType>(name, options as unknown as CreateCollectionOptions<DocType>) as unknown as MongoDBCollection<DocType>;
     }
 
     /**
@@ -459,7 +458,6 @@ export class Connection extends MongooseConnection {
      * @param options
      */
 
-    // @ts-expect-error astra-mongoose connection currently doesn't fully extend from Mongoose connection in a TypeScript-compatible way because of collections
     async openUri(uri: string, options?: ConnectOptionsInternal) {
         let _fireAndForget: boolean | undefined = false;
         if (options && '_fireAndForget' in options) {
@@ -605,7 +603,7 @@ export class Connection extends MongooseConnection {
             collection._collection = undefined;
         }
 
-        this.db = db;
+        this.astraDb = db;
         this.admin = admin;
 
         // Bubble up db-level events from astra-db-ts to the main connection.
@@ -622,8 +620,8 @@ export class Connection extends MongooseConnection {
     }
 
     _clearDbEventListeners() {
-        if (this.db && this._dbEventListeners) {
-            const dbEmitter = this.db.astraDb;
+        if (this.astraDb && this._dbEventListeners) {
+            const dbEmitter = this.astraDb.astraDb;
             dbEmitter.off('commandStarted', this._dbEventListeners.commandStarted);
             dbEmitter.off('commandFailed', this._dbEventListeners.commandFailed);
             dbEmitter.off('commandSucceeded', this._dbEventListeners.commandSucceeded);
@@ -643,8 +641,8 @@ export class Connection extends MongooseConnection {
       */
     async doClose() {
         // Remove db-level event listeners if present
-        if (this.db && this._dbEventListeners) {
-            const dbEmitter = this.db.astraDb;
+        if (this.astraDb && this._dbEventListeners) {
+            const dbEmitter = this.astraDb.astraDb;
             dbEmitter.off('commandStarted', this._dbEventListeners.commandStarted);
             dbEmitter.off('commandFailed', this._dbEventListeners.commandFailed);
             dbEmitter.off('commandSucceeded', this._dbEventListeners.commandSucceeded);

--- a/src/driver/connection.ts
+++ b/src/driver/connection.ts
@@ -97,8 +97,7 @@ export class Connection extends MongooseConnection {
     initialConnection: Promise<this> | null = null;
     client: DataAPIClient | null = null;
     admin: AstraDbAdmin | DataAPIDbAdmin | null = null;
-    declare db: undefined;
-    astraDb: CollectionsDb | TablesDb | undefined;
+    db: CollectionsDb | TablesDb | undefined;
     keyspaceName: string | null = null;
     config: Partial<ConnectOptionsInternal> = {};
     baseUrl: string | null = null;
@@ -147,7 +146,7 @@ export class Connection extends MongooseConnection {
             // @ts-expect-error _waitForConnect not part of public API
             await this._waitForConnect();
             // Cannot happen, but this helps TypeScript infer the correct return type
-            const db = this.astraDb;
+            const db = this.db;
             const admin = this.admin;
             assert.ok(db);
             assert.ok(admin);
@@ -157,7 +156,7 @@ export class Connection extends MongooseConnection {
         }
 
         // Cannot happen, but this helps TypeScript infer the correct return type
-        const db = this.astraDb;
+        const db = this.db;
         const admin = this.admin;
         assert.ok(db);
         assert.ok(admin);
@@ -188,7 +187,7 @@ export class Connection extends MongooseConnection {
     useDb(name: string, options?: UseDbOptions): Connection {
         options = options ?? {};
         if (options.useCache && this.relatedDbs[name]) {
-            const cachedDb = this.relatedDbs[name].astraDb;
+            const cachedDb = this.relatedDbs[name].db;
             if (options?.isTable != null && cachedDb != null && options.isTable !== cachedDb.isTable) {
                 throw new AstraMongooseError(`Cannot use cached connection for ${name} with isTable=${options.isTable} (cached connection is isTable=${cachedDb.isTable})`);
             }
@@ -220,7 +219,7 @@ export class Connection extends MongooseConnection {
 
         const wireup = () => {
             const client = this.client;
-            const parentDb = this.astraDb;
+            const parentDb = this.db;
             const admin = this.admin;
             const baseUrl = this.baseUrl;
             assert.ok(client);
@@ -247,7 +246,7 @@ export class Connection extends MongooseConnection {
         });
         this.initialConnection?.catch(err => rejectInitialConnection?.(err));
 
-        if (this.astraDb) {
+        if (this.db) {
             wireup();
         } else {
             // @ts-expect-error _queue is an internal Mongoose property.
@@ -276,7 +275,7 @@ export class Connection extends MongooseConnection {
         options?: MongoCreateCollectionOptions
     ): Promise<MongoDBCollection<DocType>> {
         const { db } = await this._waitForClient();
-        return await db.createCollection<DocType>(name, options as unknown as CreateCollectionOptions<DocType>) as unknown as MongoDBCollection<DocType>;
+        return await db.createCollection(name, options as unknown as CreateCollectionOptions<DocType>) as unknown as MongoDBCollection<DocType>;
     }
 
     /**
@@ -603,7 +602,7 @@ export class Connection extends MongooseConnection {
             collection._collection = undefined;
         }
 
-        this.astraDb = db;
+        this.db = db;
         this.admin = admin;
 
         // Bubble up db-level events from astra-db-ts to the main connection.
@@ -620,8 +619,8 @@ export class Connection extends MongooseConnection {
     }
 
     _clearDbEventListeners() {
-        if (this.astraDb && this._dbEventListeners) {
-            const dbEmitter = this.astraDb.astraDb;
+        if (this.db && this._dbEventListeners) {
+            const dbEmitter = this.db.astraDb;
             dbEmitter.off('commandStarted', this._dbEventListeners.commandStarted);
             dbEmitter.off('commandFailed', this._dbEventListeners.commandFailed);
             dbEmitter.off('commandSucceeded', this._dbEventListeners.commandSucceeded);
@@ -641,8 +640,8 @@ export class Connection extends MongooseConnection {
       */
     async doClose() {
         // Remove db-level event listeners if present
-        if (this.astraDb && this._dbEventListeners) {
-            const dbEmitter = this.astraDb.astraDb;
+        if (this.db && this._dbEventListeners) {
+            const dbEmitter = this.db.astraDb;
             dbEmitter.off('commandStarted', this._dbEventListeners.commandStarted);
             dbEmitter.off('commandFailed', this._dbEventListeners.commandFailed);
             dbEmitter.off('commandSucceeded', this._dbEventListeners.commandSucceeded);

--- a/src/driver/db.ts
+++ b/src/driver/db.ts
@@ -14,6 +14,7 @@
 
 import {
     AlterTypeOptions,
+    Collection,
     Collection as AstraCollection,
     CollectionDescriptor,
     CollectionOptions,
@@ -37,15 +38,13 @@ import {
 } from '@datastax/astra-db-ts';
 import { AstraMongooseError } from '../astraMongooseError';
 import assert from 'assert';
-import { Db as MongoDb, MongoClient } from 'mongodb';
-import { OperationNotSupportedError } from '../operationNotSupportedError';
 
 /**
  * Defines the base database class for interacting with Astra DB. Responsible for creating collections and tables.
  * This class abstracts the operations for both collections mode and tables mode. There is a separate TablesDb class
  * for tables and CollectionsDb class for collections.
  */
-export abstract class BaseDb extends MongoDb {
+export abstract class BaseDb {
     astraDb: AstraDb;
     /**
      * Whether we're using "tables mode" or "collections mode". If tables mode, then `collection()` returns
@@ -56,13 +55,6 @@ export abstract class BaseDb extends MongoDb {
     name: string;
 
     constructor(astraDb: AstraDb, keyspaceName: string, isTable?: boolean) {
-        super({} as MongoClient, keyspaceName);
-        Object.defineProperty(this, 'client', {
-            configurable: true,
-            get: () => {
-                throw new OperationNotSupportedError('MongoDB client access is not supported by Astra DB');
-            }
-        });
         this.astraDb = astraDb;
         astraDb.useKeyspace(keyspaceName);
         this.isTable = !!isTable;
@@ -73,9 +65,7 @@ export abstract class BaseDb extends MongoDb {
      * Get a collection by name.
      * @param name The name of the collection.
      */
-    abstract collection<DocType extends Record<string, unknown> = Record<string, unknown>>(name: string, options?: Record<string, unknown>): AstraCollection<DocType> | AstraTable<DocType>;
-    // Loose overload for compatibility with MongoDB's `Db.collection()` signature
-    abstract collection(name: string, options?: unknown): any;
+    abstract collection<DocType extends Record<string, unknown> = Record<string, unknown>>(name: string, options: Record<string, unknown>): AstraCollection<DocType> | AstraTable<DocType>;
 
     /**
      * Create a new collection with the specified name and options.
@@ -85,9 +75,7 @@ export abstract class BaseDb extends MongoDb {
     abstract createCollection<DocType extends Record<string, unknown> = Record<string, unknown>>(
         name: string,
         options?: CreateCollectionOptions<DocType>
-    ): Promise<AstraCollection<DocType>>;
-    // Loose overload for compatibility with MongoDB's `Db.createCollection()` signature
-    abstract createCollection(name: string, options?: unknown): Promise<any>;
+    ): Promise<Collection<DocType>>;
 
     /**
      * Create a new table with the specified name and definition
@@ -107,10 +95,6 @@ export abstract class BaseDb extends MongoDb {
      * Drop a collection by name.
      * @param name The name of the collection to be dropped.
      */
-    async dropCollection(name: string, options?: DropCollectionOptions): Promise<void>;
-    // Loose overload for compatibility with MongoDB's `Db.dropCollection()` signature
-    async dropCollection(name: string, options?: unknown): Promise<any>;
-
     async dropCollection(name: string, options?: DropCollectionOptions) {
         return await this.astraDb.dropCollection(name, options);
     }
@@ -133,8 +117,6 @@ export abstract class BaseDb extends MongoDb {
 
     async listCollections(options: ListCollectionsOptions & { nameOnly: true }): Promise<string[]>;
     async listCollections(options?: ListCollectionsOptions & { nameOnly?: false }): Promise<CollectionDescriptor[]>;
-    // Loose overload for compatibility with MongoDB's `Db.listCollections()` signature, which returns a cursor
-    listCollections(options?: unknown): any;
 
     async listCollections(options?: ListCollectionsOptions) {
         if (options?.nameOnly) {
@@ -281,24 +263,6 @@ export abstract class BaseDb extends MongoDb {
     async command(command: Record<string, unknown>): Promise<RawDataAPIResponse> {
         return await this.astraDb.command(command);
     }
-
-    get secondaryOk(): boolean {
-        throw new OperationNotSupportedError('MongoDB secondary reads are not supported by Astra DB');
-    }
-
-    aggregate(..._args: any[]): never { throw new OperationNotSupportedError('MongoDB aggregation is not supported by Astra DB'); }
-    admin(..._args: any[]): never { throw new OperationNotSupportedError('MongoDB admin access is not supported by Astra DB'); }
-    stats(..._args: any[]): never { throw new OperationNotSupportedError('MongoDB database statistics are not supported by Astra DB'); }
-    renameCollection(..._args: any[]): never { throw new OperationNotSupportedError('MongoDB collection renaming is not supported by Astra DB'); }
-    dropDatabase(..._args: any[]): never { throw new OperationNotSupportedError('MongoDB database dropping is not supported by Astra DB'); }
-    collections(..._args: any[]): never { throw new OperationNotSupportedError('MongoDB collection enumeration is not supported by Astra DB'); }
-    createIndex(..._args: any[]): never { throw new OperationNotSupportedError('MongoDB database indexes are not supported by Astra DB'); }
-    removeUser(..._args: any[]): never { throw new OperationNotSupportedError('MongoDB users are not supported by Astra DB'); }
-    setProfilingLevel(..._args: any[]): never { throw new OperationNotSupportedError('MongoDB profiling is not supported by Astra DB'); }
-    profilingLevel(..._args: any[]): never { throw new OperationNotSupportedError('MongoDB profiling is not supported by Astra DB'); }
-    indexInformation(..._args: any[]): never { throw new OperationNotSupportedError('MongoDB index information is not supported by Astra DB'); }
-    watch(..._args: any[]): never { throw new OperationNotSupportedError('MongoDB change streams are not supported by Astra DB'); }
-    runCursorCommand(..._args: any[]): never { throw new OperationNotSupportedError('MongoDB cursor commands are not supported by Astra DB'); }
 }
 
 /**
@@ -319,21 +283,13 @@ export class CollectionsDb extends BaseDb {
      * Get a collection by name.
      * @param name The name of the collection.
      */
-    collection<DocType extends Record<string, unknown> = Record<string, unknown>>(name: string, options?: CollectionOptions): AstraCollection<DocType>;
-    // Loose overload for compatibility with MongoDB's `Db.collection()` signature
-    collection(name: string, options?: unknown): any;
-
-    collection<DocType extends Record<string, unknown> = Record<string, unknown>>(name: string, options?: CollectionOptions): AstraCollection<DocType> {
-        return this.astraDb.collection<DocType>(name, options ?? {});
+    collection<DocType extends Record<string, unknown> = Record<string, unknown>>(name: string, options: CollectionOptions) {
+        return this.astraDb.collection<DocType>(name, options);
     }
 
     /**
      * Send a CreateCollection command to Data API.
      */
-    createCollection<DocType extends Record<string, unknown> = Record<string, unknown>>(name: string, options?: CreateCollectionOptions<DocType>): Promise<AstraCollection<DocType>>;
-    // Loose overload for compatibility with MongoDB's `Db.createCollection()` signature
-    createCollection(name: string, options?: unknown): Promise<any>;
-
     async createCollection<DocType extends Record<string, unknown> = Record<string, unknown>>(name: string, options?: CreateCollectionOptions<DocType>) {
         return await this.astraDb.createCollection<DocType>(name, options);
     }
@@ -358,22 +314,17 @@ export class TablesDb extends BaseDb {
      * this method for getting a Mongoose Collection instance, which may map to a table in Astra DB when using tables mode.
      * @param name The name of the table.
      */
-    collection<DocType extends Record<string, unknown> = Record<string, unknown>>(name: string, options?: TableOptions): AstraTable<DocType>;
-    // Loose overload for compatibility with MongoDB's `Db.collection()` signature
-    collection(name: string, options?: unknown): any;
-
-    collection<DocType extends Record<string, unknown> = Record<string, unknown>>(name: string, options?: TableOptions): AstraTable<DocType> {
-        return this.astraDb.table<DocType>(name, options ?? {});
+    collection<DocType extends Record<string, unknown> = Record<string, unknown>>(name: string, options: TableOptions) {
+        return this.astraDb.table<DocType>(name, options);
     }
 
     /**
      * Throws an error, astra-mongoose does not support creating collections in tables mode.
      */
-    createCollection<DocType extends Record<string, unknown> = Record<string, unknown>>(name: string, options?: CreateCollectionOptions<DocType>): Promise<AstraCollection<DocType>>;
-    // Loose overload for compatibility with MongoDB's `Db.createCollection()` signature
-    createCollection(name: string, options?: unknown): Promise<any>;
-
-    async createCollection(name: string, options?: unknown): Promise<never> {
+    async createCollection<DocType extends Record<string, unknown> = Record<string, unknown>>(
+        name: string,
+        options?: CreateCollectionOptions<DocType>
+    ): Promise<Collection<DocType>> {
         throw new AstraMongooseError('Cannot createCollection in tables mode; use createTable instead', { name, options });
     }
 }

--- a/src/driver/db.ts
+++ b/src/driver/db.ts
@@ -14,7 +14,6 @@
 
 import {
     AlterTypeOptions,
-    Collection,
     Collection as AstraCollection,
     CollectionDescriptor,
     CollectionOptions,
@@ -38,13 +37,15 @@ import {
 } from '@datastax/astra-db-ts';
 import { AstraMongooseError } from '../astraMongooseError';
 import assert from 'assert';
+import { Db as MongoDb, MongoClient } from 'mongodb';
+import { OperationNotSupportedError } from '../operationNotSupportedError';
 
 /**
  * Defines the base database class for interacting with Astra DB. Responsible for creating collections and tables.
  * This class abstracts the operations for both collections mode and tables mode. There is a separate TablesDb class
  * for tables and CollectionsDb class for collections.
  */
-export abstract class BaseDb {
+export abstract class BaseDb extends MongoDb {
     astraDb: AstraDb;
     /**
      * Whether we're using "tables mode" or "collections mode". If tables mode, then `collection()` returns
@@ -55,6 +56,13 @@ export abstract class BaseDb {
     name: string;
 
     constructor(astraDb: AstraDb, keyspaceName: string, isTable?: boolean) {
+        super({} as MongoClient, keyspaceName);
+        Object.defineProperty(this, 'client', {
+            configurable: true,
+            get: () => {
+                throw new OperationNotSupportedError('MongoDB client access is not supported by Astra DB');
+            }
+        });
         this.astraDb = astraDb;
         astraDb.useKeyspace(keyspaceName);
         this.isTable = !!isTable;
@@ -65,7 +73,9 @@ export abstract class BaseDb {
      * Get a collection by name.
      * @param name The name of the collection.
      */
-    abstract collection<DocType extends Record<string, unknown> = Record<string, unknown>>(name: string, options: Record<string, unknown>): AstraCollection<DocType> | AstraTable<DocType>;
+    abstract collection<DocType extends Record<string, unknown> = Record<string, unknown>>(name: string, options?: Record<string, unknown>): AstraCollection<DocType> | AstraTable<DocType>;
+    // Loose overload for compatibility with MongoDB's `Db.collection()` signature
+    abstract collection(name: string, options?: unknown): any;
 
     /**
      * Create a new collection with the specified name and options.
@@ -75,7 +85,9 @@ export abstract class BaseDb {
     abstract createCollection<DocType extends Record<string, unknown> = Record<string, unknown>>(
         name: string,
         options?: CreateCollectionOptions<DocType>
-    ): Promise<Collection<DocType>>;
+    ): Promise<AstraCollection<DocType>>;
+    // Loose overload for compatibility with MongoDB's `Db.createCollection()` signature
+    abstract createCollection(name: string, options?: unknown): Promise<any>;
 
     /**
      * Create a new table with the specified name and definition
@@ -95,6 +107,10 @@ export abstract class BaseDb {
      * Drop a collection by name.
      * @param name The name of the collection to be dropped.
      */
+    async dropCollection(name: string, options?: DropCollectionOptions): Promise<void>;
+    // Loose overload for compatibility with MongoDB's `Db.dropCollection()` signature
+    async dropCollection(name: string, options?: unknown): Promise<any>;
+
     async dropCollection(name: string, options?: DropCollectionOptions) {
         return await this.astraDb.dropCollection(name, options);
     }
@@ -117,6 +133,8 @@ export abstract class BaseDb {
 
     async listCollections(options: ListCollectionsOptions & { nameOnly: true }): Promise<string[]>;
     async listCollections(options?: ListCollectionsOptions & { nameOnly?: false }): Promise<CollectionDescriptor[]>;
+    // Loose overload for compatibility with MongoDB's `Db.listCollections()` signature, which returns a cursor
+    listCollections(options?: unknown): any;
 
     async listCollections(options?: ListCollectionsOptions) {
         if (options?.nameOnly) {
@@ -263,6 +281,24 @@ export abstract class BaseDb {
     async command(command: Record<string, unknown>): Promise<RawDataAPIResponse> {
         return await this.astraDb.command(command);
     }
+
+    get secondaryOk(): boolean {
+        throw new OperationNotSupportedError('MongoDB secondary reads are not supported by Astra DB');
+    }
+
+    aggregate(..._args: any[]): never { throw new OperationNotSupportedError('MongoDB aggregation is not supported by Astra DB'); }
+    admin(..._args: any[]): never { throw new OperationNotSupportedError('MongoDB admin access is not supported by Astra DB'); }
+    stats(..._args: any[]): never { throw new OperationNotSupportedError('MongoDB database statistics are not supported by Astra DB'); }
+    renameCollection(..._args: any[]): never { throw new OperationNotSupportedError('MongoDB collection renaming is not supported by Astra DB'); }
+    dropDatabase(..._args: any[]): never { throw new OperationNotSupportedError('MongoDB database dropping is not supported by Astra DB'); }
+    collections(..._args: any[]): never { throw new OperationNotSupportedError('MongoDB collection enumeration is not supported by Astra DB'); }
+    createIndex(..._args: any[]): never { throw new OperationNotSupportedError('MongoDB database indexes are not supported by Astra DB'); }
+    removeUser(..._args: any[]): never { throw new OperationNotSupportedError('MongoDB users are not supported by Astra DB'); }
+    setProfilingLevel(..._args: any[]): never { throw new OperationNotSupportedError('MongoDB profiling is not supported by Astra DB'); }
+    profilingLevel(..._args: any[]): never { throw new OperationNotSupportedError('MongoDB profiling is not supported by Astra DB'); }
+    indexInformation(..._args: any[]): never { throw new OperationNotSupportedError('MongoDB index information is not supported by Astra DB'); }
+    watch(..._args: any[]): never { throw new OperationNotSupportedError('MongoDB change streams are not supported by Astra DB'); }
+    runCursorCommand(..._args: any[]): never { throw new OperationNotSupportedError('MongoDB cursor commands are not supported by Astra DB'); }
 }
 
 /**
@@ -283,13 +319,21 @@ export class CollectionsDb extends BaseDb {
      * Get a collection by name.
      * @param name The name of the collection.
      */
-    collection<DocType extends Record<string, unknown> = Record<string, unknown>>(name: string, options: CollectionOptions) {
-        return this.astraDb.collection<DocType>(name, options);
+    collection<DocType extends Record<string, unknown> = Record<string, unknown>>(name: string, options?: CollectionOptions): AstraCollection<DocType>;
+    // Loose overload for compatibility with MongoDB's `Db.collection()` signature
+    collection(name: string, options?: unknown): any;
+
+    collection<DocType extends Record<string, unknown> = Record<string, unknown>>(name: string, options?: CollectionOptions): AstraCollection<DocType> {
+        return this.astraDb.collection<DocType>(name, options ?? {});
     }
 
     /**
      * Send a CreateCollection command to Data API.
      */
+    createCollection<DocType extends Record<string, unknown> = Record<string, unknown>>(name: string, options?: CreateCollectionOptions<DocType>): Promise<AstraCollection<DocType>>;
+    // Loose overload for compatibility with MongoDB's `Db.createCollection()` signature
+    createCollection(name: string, options?: unknown): Promise<any>;
+
     async createCollection<DocType extends Record<string, unknown> = Record<string, unknown>>(name: string, options?: CreateCollectionOptions<DocType>) {
         return await this.astraDb.createCollection<DocType>(name, options);
     }
@@ -314,17 +358,22 @@ export class TablesDb extends BaseDb {
      * this method for getting a Mongoose Collection instance, which may map to a table in Astra DB when using tables mode.
      * @param name The name of the table.
      */
-    collection<DocType extends Record<string, unknown> = Record<string, unknown>>(name: string, options: TableOptions) {
-        return this.astraDb.table<DocType>(name, options);
+    collection<DocType extends Record<string, unknown> = Record<string, unknown>>(name: string, options?: TableOptions): AstraTable<DocType>;
+    // Loose overload for compatibility with MongoDB's `Db.collection()` signature
+    collection(name: string, options?: unknown): any;
+
+    collection<DocType extends Record<string, unknown> = Record<string, unknown>>(name: string, options?: TableOptions): AstraTable<DocType> {
+        return this.astraDb.table<DocType>(name, options ?? {});
     }
 
     /**
      * Throws an error, astra-mongoose does not support creating collections in tables mode.
      */
-    async createCollection<DocType extends Record<string, unknown> = Record<string, unknown>>(
-        name: string,
-        options?: CreateCollectionOptions<DocType>
-    ): Promise<Collection<DocType>> {
+    createCollection<DocType extends Record<string, unknown> = Record<string, unknown>>(name: string, options?: CreateCollectionOptions<DocType>): Promise<AstraCollection<DocType>>;
+    // Loose overload for compatibility with MongoDB's `Db.createCollection()` signature
+    createCollection(name: string, options?: unknown): Promise<any>;
+
+    async createCollection(name: string, options?: unknown): Promise<never> {
         throw new AstraMongooseError('Cannot createCollection in tables mode; use createTable instead', { name, options });
     }
 }

--- a/tests/driver/collections.api.test.ts
+++ b/tests/driver/collections.api.test.ts
@@ -240,7 +240,7 @@ describe('COLLECTIONS: mongoose Model API level tests with collections', async (
             let collections = await Product.db.listCollections().then(collections => collections.map(coll => coll.name));
             assert.ok(collections.includes(Product.collection.collectionName));
 
-            await Product.db.db!.dropCollection(Product.collection.collectionName);
+            await (Product.db as unknown as AstraMongooseDriver.Connection).astraDb!.dropCollection(Product.collection.collectionName);
             collections = await Product.db.listCollections().then(collections => collections.map(coll => coll.name));
             assert.ok(!collections.includes(Product.collection.collectionName));
 
@@ -315,7 +315,7 @@ describe('COLLECTIONS: mongoose Model API level tests with collections', async (
         it('API ops tests Model.db', async () => {
             const conn = Product.db as unknown as AstraMongooseDriver.Connection;
             assert.strictEqual(conn.keyspaceName, parseUri(testClient!.uri).keyspaceName);
-            assert.strictEqual(conn.db!.name, parseUri(testClient!.uri).keyspaceName);
+            assert.strictEqual(conn.astraDb!.name, parseUri(testClient!.uri).keyspaceName);
         });
         it('API ops tests Model.deleteMany()', async function() {
             const product1 = new Product({name: 'Product 1', price: 10, isCertified: true, category: 'cat 1'});
@@ -874,7 +874,7 @@ describe('COLLECTIONS: mongoose Model API level tests with collections', async (
             const { keyspaceName } = parseUri(testClient!.uri);
             const childConnection = connection.useDb(keyspaceName, { isTable: true });
 
-            assert.strictEqual(childConnection.db!.isTable, true);
+            assert.strictEqual(childConnection.astraDb!.isTable, true);
             await assert.rejects(
                 childConnection.createCollection('use_db_is_table_child'),
                 /Cannot createCollection in tables mode/
@@ -888,7 +888,7 @@ describe('COLLECTIONS: mongoose Model API level tests with collections', async (
             const { keyspaceName } = parseUri(testClient!.uri);
             const childConnection = connection.useDb(keyspaceName, { useCache: true, isTable: true });
 
-            assert.strictEqual(childConnection.db!.isTable, true);
+            assert.strictEqual(childConnection.astraDb!.isTable, true);
             assert.strictEqual(connection.useDb(keyspaceName, { useCache: true, isTable: true }), childConnection);
             assert.throws(
                 () => connection.useDb(keyspaceName, { useCache: true, isTable: false }),
@@ -909,7 +909,7 @@ describe('COLLECTIONS: mongoose Model API level tests with collections', async (
             await childConnection.asPromise();
 
             assert.strictEqual(childConnection.client, connection.client);
-            assert.notStrictEqual(childConnection.db, connection.db);
+            assert.notStrictEqual(childConnection.astraDb, connection.astraDb);
             assert.strictEqual(childConnection.keyspaceName, keyspaceName);
             assert.ok((await promise.then(res => res.map(obj => obj.name))).includes(Product.collection.collectionName));
 
@@ -923,7 +923,7 @@ describe('COLLECTIONS: mongoose Model API level tests with collections', async (
             await connection.openUri(testClient!.uri, testClient!.options);
             await childConnection.asPromise();
 
-            assert.strictEqual(childConnection.db!.isTable, true);
+            assert.strictEqual(childConnection.astraDb!.isTable, true);
             await assert.rejects(
                 childConnection.createCollection('use_db_is_table_child'),
                 /Cannot createCollection in tables mode/

--- a/tests/driver/collections.api.test.ts
+++ b/tests/driver/collections.api.test.ts
@@ -240,7 +240,7 @@ describe('COLLECTIONS: mongoose Model API level tests with collections', async (
             let collections = await Product.db.listCollections().then(collections => collections.map(coll => coll.name));
             assert.ok(collections.includes(Product.collection.collectionName));
 
-            await (Product.db as unknown as AstraMongooseDriver.Connection).astraDb!.dropCollection(Product.collection.collectionName);
+            await Product.db.db!.dropCollection(Product.collection.collectionName);
             collections = await Product.db.listCollections().then(collections => collections.map(coll => coll.name));
             assert.ok(!collections.includes(Product.collection.collectionName));
 
@@ -315,7 +315,7 @@ describe('COLLECTIONS: mongoose Model API level tests with collections', async (
         it('API ops tests Model.db', async () => {
             const conn = Product.db as unknown as AstraMongooseDriver.Connection;
             assert.strictEqual(conn.keyspaceName, parseUri(testClient!.uri).keyspaceName);
-            assert.strictEqual(conn.astraDb!.name, parseUri(testClient!.uri).keyspaceName);
+            assert.strictEqual(conn.db!.name, parseUri(testClient!.uri).keyspaceName);
         });
         it('API ops tests Model.deleteMany()', async function() {
             const product1 = new Product({name: 'Product 1', price: 10, isCertified: true, category: 'cat 1'});
@@ -874,7 +874,7 @@ describe('COLLECTIONS: mongoose Model API level tests with collections', async (
             const { keyspaceName } = parseUri(testClient!.uri);
             const childConnection = connection.useDb(keyspaceName, { isTable: true });
 
-            assert.strictEqual(childConnection.astraDb!.isTable, true);
+            assert.strictEqual(childConnection.db!.isTable, true);
             await assert.rejects(
                 childConnection.createCollection('use_db_is_table_child'),
                 /Cannot createCollection in tables mode/
@@ -888,7 +888,7 @@ describe('COLLECTIONS: mongoose Model API level tests with collections', async (
             const { keyspaceName } = parseUri(testClient!.uri);
             const childConnection = connection.useDb(keyspaceName, { useCache: true, isTable: true });
 
-            assert.strictEqual(childConnection.astraDb!.isTable, true);
+            assert.strictEqual(childConnection.db!.isTable, true);
             assert.strictEqual(connection.useDb(keyspaceName, { useCache: true, isTable: true }), childConnection);
             assert.throws(
                 () => connection.useDb(keyspaceName, { useCache: true, isTable: false }),
@@ -909,7 +909,7 @@ describe('COLLECTIONS: mongoose Model API level tests with collections', async (
             await childConnection.asPromise();
 
             assert.strictEqual(childConnection.client, connection.client);
-            assert.notStrictEqual(childConnection.astraDb, connection.astraDb);
+            assert.notStrictEqual(childConnection.db, connection.db);
             assert.strictEqual(childConnection.keyspaceName, keyspaceName);
             assert.ok((await promise.then(res => res.map(obj => obj.name))).includes(Product.collection.collectionName));
 
@@ -923,7 +923,7 @@ describe('COLLECTIONS: mongoose Model API level tests with collections', async (
             await connection.openUri(testClient!.uri, testClient!.options);
             await childConnection.asPromise();
 
-            assert.strictEqual(childConnection.astraDb!.isTable, true);
+            assert.strictEqual(childConnection.db!.isTable, true);
             await assert.rejects(
                 childConnection.createCollection('use_db_is_table_child'),
                 /Cannot createCollection in tables mode/

--- a/tests/driver/collections.driver.test.ts
+++ b/tests/driver/collections.driver.test.ts
@@ -226,7 +226,7 @@ describe('COLLECTIONS: driver based tests', async () => {
             }
 
             const _id = new mongoose.Types.ObjectId();
-            const collection = mongooseInstance.connection.astraDb!.collection(
+            const collection = mongooseInstance.connection.db!.collection(
                 Product.collection.collectionName,
                 { serdes: { enableBigNumbers: () => 'number_or_string' } }
             );

--- a/tests/driver/collections.driver.test.ts
+++ b/tests/driver/collections.driver.test.ts
@@ -226,7 +226,7 @@ describe('COLLECTIONS: driver based tests', async () => {
             }
 
             const _id = new mongoose.Types.ObjectId();
-            const collection = mongooseInstance.connection.db!.collection(
+            const collection = mongooseInstance.connection.astraDb!.collection(
                 Product.collection.collectionName,
                 { serdes: { enableBigNumbers: () => 'number_or_string' } }
             );

--- a/tests/driver/tables.api.test.ts
+++ b/tests/driver/tables.api.test.ts
@@ -206,7 +206,7 @@ describe('TABLES: Mongoose Model API level tests', async () => {
         it('API ops tests Model.db', async () => {
             const conn = Product.db as unknown as AstraMongooseDriver.Connection;
             assert.strictEqual(conn.keyspaceName, parseUri(testClient!.uri).keyspaceName);
-            assert.strictEqual(conn.db!.name, parseUri(testClient!.uri).keyspaceName);
+            assert.strictEqual(conn.astraDb!.name, parseUri(testClient!.uri).keyspaceName);
         });
         it('API ops tests Model.deleteOne()', async () => {
             const product1 = new Product({name: 'Product 1', price: 10, isCertified: true, category: 'cat 1'});
@@ -678,8 +678,8 @@ describe('TABLES: Mongoose Model API level tests', async () => {
             const { keyspaceName } = parseUri(testClient!.uri);
             const childConnection = connection.useDb(keyspaceName, { isTable: false });
 
-            assert.strictEqual(connection.db!.isTable, true);
-            assert.strictEqual(childConnection.db!.isTable, false);
+            assert.strictEqual(connection.astraDb!.isTable, true);
+            assert.strictEqual(childConnection.astraDb!.isTable, false);
 
             await connection.close();
         });
@@ -695,7 +695,7 @@ describe('TABLES: Mongoose Model API level tests', async () => {
             await childConnection.asPromise();
 
             assert.strictEqual(childConnection.client, connection.client);
-            assert.notStrictEqual(childConnection.db, connection.db);
+            assert.notStrictEqual(childConnection.astraDb, connection.astraDb);
             assert.strictEqual(childConnection.keyspaceName, keyspaceName);
             assert.ok((await promise.then(res => res.map(obj => obj.name))).includes(Product.collection.collectionName));
 
@@ -709,8 +709,8 @@ describe('TABLES: Mongoose Model API level tests', async () => {
             await connection.openUri(testClient!.uri, { ...testClient!.options, isTable: true });
             await childConnection.asPromise();
 
-            assert.strictEqual(connection.db!.isTable, true);
-            assert.strictEqual(childConnection.db!.isTable, false);
+            assert.strictEqual(connection.astraDb!.isTable, true);
+            assert.strictEqual(childConnection.astraDb!.isTable, false);
 
             await connection.close();
         });

--- a/tests/driver/tables.api.test.ts
+++ b/tests/driver/tables.api.test.ts
@@ -206,7 +206,7 @@ describe('TABLES: Mongoose Model API level tests', async () => {
         it('API ops tests Model.db', async () => {
             const conn = Product.db as unknown as AstraMongooseDriver.Connection;
             assert.strictEqual(conn.keyspaceName, parseUri(testClient!.uri).keyspaceName);
-            assert.strictEqual(conn.astraDb!.name, parseUri(testClient!.uri).keyspaceName);
+            assert.strictEqual(conn.db!.name, parseUri(testClient!.uri).keyspaceName);
         });
         it('API ops tests Model.deleteOne()', async () => {
             const product1 = new Product({name: 'Product 1', price: 10, isCertified: true, category: 'cat 1'});
@@ -678,8 +678,8 @@ describe('TABLES: Mongoose Model API level tests', async () => {
             const { keyspaceName } = parseUri(testClient!.uri);
             const childConnection = connection.useDb(keyspaceName, { isTable: false });
 
-            assert.strictEqual(connection.astraDb!.isTable, true);
-            assert.strictEqual(childConnection.astraDb!.isTable, false);
+            assert.strictEqual(connection.db!.isTable, true);
+            assert.strictEqual(childConnection.db!.isTable, false);
 
             await connection.close();
         });
@@ -695,7 +695,7 @@ describe('TABLES: Mongoose Model API level tests', async () => {
             await childConnection.asPromise();
 
             assert.strictEqual(childConnection.client, connection.client);
-            assert.notStrictEqual(childConnection.astraDb, connection.astraDb);
+            assert.notStrictEqual(childConnection.db, connection.db);
             assert.strictEqual(childConnection.keyspaceName, keyspaceName);
             assert.ok((await promise.then(res => res.map(obj => obj.name))).includes(Product.collection.collectionName));
 
@@ -709,8 +709,8 @@ describe('TABLES: Mongoose Model API level tests', async () => {
             await connection.openUri(testClient!.uri, { ...testClient!.options, isTable: true });
             await childConnection.asPromise();
 
-            assert.strictEqual(connection.astraDb!.isTable, true);
-            assert.strictEqual(childConnection.astraDb!.isTable, false);
+            assert.strictEqual(connection.db!.isTable, true);
+            assert.strictEqual(childConnection.db!.isTable, false);
 
             await connection.close();
         });

--- a/tests/e2e/tsconfig.json
+++ b/tests/e2e/tsconfig.json
@@ -1,13 +1,12 @@
 {
   "compilerOptions": {
     "target": "es2020",
-    "module": "node16",
-    "moduleResolution": "node16",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "strict": true,
     "noEmit": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true,
     "types": ["node"]
   },
   "include": ["smoke.ts"]

--- a/tests/mongooseFixtures.ts
+++ b/tests/mongooseFixtures.ts
@@ -165,7 +165,7 @@ export async function createMongooseCollections(isTable: boolean) {
         }
 
         if (testDebug) {
-            mongooseInstance.connection.db!.astraDb.on('commandStarted', ev => {
+            mongooseInstance.connection.astraDb!.astraDb.on('commandStarted', ev => {
                 console.log(ev.target.url, JSON.stringify(ev.command, null, '    '));
             });
         }

--- a/tests/mongooseFixtures.ts
+++ b/tests/mongooseFixtures.ts
@@ -165,7 +165,7 @@ export async function createMongooseCollections(isTable: boolean) {
         }
 
         if (testDebug) {
-            mongooseInstance.connection.astraDb!.astraDb.on('commandStarted', ev => {
+            mongooseInstance.connection.db!.astraDb.on('commandStarted', ev => {
                 console.log(ev.target.url, JSON.stringify(ev.command, null, '    '));
             });
         }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Currently astra-mongoose requires client projects set `skipLibCheck: true` to compile. That is a significant issue because `skipLibCheck` is all or nothing - in order to use astra-mongoose, client projects need to skip type checking for all node modules.

The major changes are:

1. Connections now use `astraDb` instead of `db` for storing the Astra DB wrapper. Mongoose assumes that `db` is a MongoDB compatible database wrapper; that means in order to avoid skipLibCheck we either need to have `db` be MongoDB compatible, or use a different property. I think having `astraDb` be separate makes more sense because we want to expose an Astra-specific wrapper. Although `db` -> `astraDb` is a backwards breaking change, I think it better aligns with the intended usage of this lib - `astraDb` is meant to be a more Astra-specific wrapper. If we try to make `baseDb` compatible, we need to implement a wide variety of methods like `stats()` etc. that throw an error (see [here](https://github.com/stargate/stargate-mongoose/pull/321/changes/08b33f3d6deb5958a3f559c641368a0f91d9ee14#diff-217b72e0172298767d2451a06975d005dda084100ccecc80fc46e462dab7ef1d) for reference implementation). The idea is that users can use Mongoose directly using this plugin, but also have `astraDb` as an escape hatch for accessing `astra-db-ts` directly, which lines up with how Mongoose is meant to be used.
2. `options` -> `_options` on collections. This is more correct because `options()` is a function on Mongoose collections.
3. Added `TableUpdateFilter<DocType>` to `updateMany()`, `findOneAndUpdate()` update type union. While not strictly correct currently because `updateMany()` and `findOneAndUpdate()` do not support tables, this satisfies the compiler.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)